### PR TITLE
Add MCP server integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ pnpm-debug.log*
 # Package manager metadata
 .npm/
 .pnpm-store/
+*.tgz
 
 
 # OS and editor files

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ zg "where query auto update happens"
 - **Managed ripgrep Route**: `zg --rg` supports common `rg` flags and works even before a repository is indexed.
 - **Explicit Model Choice**: The first index build requires a model such as `local/embeddinggemma-300m`, `local/qwen3-embedding-0.6b`, or `qwen/text-embedding-v4`.
 - **Schema Reuse**: Re-running `zg --index` on an existing index reuses the stored embedding schema unless you explicitly change it.
+- **MCP Server**: Run `zg serve --mcp` to expose indexed and no-index lexical search tools to MCP clients. Indexing and status remain CLI-only operations.
 - **Library API**: Use `createZvecGrep()` directly from Node.js tools, agents, or MCP servers.
 
 ## <a id="installation"></a>📦 Installation
@@ -66,6 +67,31 @@ Or run it without a global install:
 ```bash
 npx @zvec/zvec-grep --help
 ```
+
+Install the latest source checkout as a global `zg` command:
+
+```bash
+git clone https://github.com/zvec-ai/zvec-grep.git
+cd zvec-grep
+npm ci
+npm run build
+npm install -g .
+zg --version
+```
+
+Run the stdio MCP server:
+
+```bash
+zg serve --mcp
+```
+
+Install the Codex MCP integration:
+
+```bash
+zg install --target codex --yes
+```
+
+Codex MCP tool calls default to a 600-second timeout. Override it during installation with `--mcp-tool-timeout <seconds>`.
 
 ### ✅ Requirements
 
@@ -118,6 +144,8 @@ Switch to human-readable output:
 zg --human "root local index discovery" --limit 3
 ```
 
+Use from an MCP client with `zvec_grep_search` and `zvec_grep_rg`. MCP inputs use JSON-friendly fields such as `include: ["src/**"]`; use the CLI for `zg --status` and `zg --index`. The Codex installer writes managed zvec-grep blocks to `${CODEX_HOME:-$HOME/.codex}/config.toml` and `${CODEX_HOME:-$HOME/.codex}/AGENTS.md`.
+
 ## <a id="models"></a>🧠 Models
 
 Local models run through `node-llama-cpp` and keep code search private to your machine:
@@ -127,6 +155,8 @@ zg --index --embedding local/embeddinggemma-300m
 zg --index --embedding local/qwen3-embedding-0.6b
 ```
 
+On Apple Silicon, local builds use quiet llama.cpp CMake defaults to avoid harmless OpenMP and ARM native-detection warnings. Override any llama.cpp CMake option with `NODE_LLAMA_CPP_CMAKE_OPTION_<name>`, for example `NODE_LLAMA_CPP_CMAKE_OPTION_GGML_NATIVE=ON` to opt back into native CPU tuning.
+
 Remote Qwen embeddings are useful when you prefer a managed embedding service or want to avoid local model setup:
 
 ```bash
@@ -134,6 +164,25 @@ zg --index \
   --embedding qwen/text-embedding-v4 \
   --api-key "$DASHSCOPE_API_KEY"
 ```
+
+After a successful index, explicitly passed global model and provider options are saved to `~/.zvec-grep/config.json` with user-only permissions. This lets an already-running `zg` MCP server load a newly configured remote API key on its next model request without restarting Codex. Values read only from environment variables are not persisted.
+
+```json
+{
+  "version": 1,
+  "defaults": {
+    "embedding": "qwen/text-embedding-v4"
+  },
+  "providers": {
+    "qwen": {
+      "apiKey": "...",
+      "endpoint": "https://dashscope.aliyuncs.com/compatible-mode/v1/embeddings"
+    }
+  }
+}
+```
+
+Resolution order is explicit CLI or library options, then environment variables, then global config, then built-in defaults. Repository roots and include/exclude filters remain in each repository's `.zvec-grep` metadata rather than global config.
 
 For existing indexes, `zg --index` without `--embedding` reuses the stored schema. Use `--rebuild --embedding <model>` only when you intentionally want to rebuild with a different model:
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -50,6 +50,7 @@ zg "where query auto update happens"
 - **托管 ripgrep 通道**：`zg --rg` 支持常见 `rg` 参数，未建索引仓库也能使用。
 - **显式模型选择**：第一次建索引必须指定模型，例如 `local/embeddinggemma-300m`、`local/qwen3-embedding-0.6b` 或 `qwen/text-embedding-v4`。
 - **Schema 复用**：已有索引再次运行 `zg --index` 会复用保存的 embedding schema，除非你显式切换模型。
+- **MCP Server**：运行 `zg serve --mcp`，向 MCP 客户端暴露索引搜索和无索引文本搜索工具；建索引和状态查看仍由 CLI 提供。
 - **库 API**：Node.js 工具、agent 或 MCP server 可以直接使用 `createZvecGrep()`。
 
 ## <a id="installation"></a>📦 安装
@@ -66,6 +67,31 @@ zg --version
 ```bash
 npx @zvec/zvec-grep --help
 ```
+
+从最新源码构建，并将 `zg` 安装为全局命令：
+
+```bash
+git clone https://github.com/zvec-ai/zvec-grep.git
+cd zvec-grep
+npm ci
+npm run build
+npm install -g .
+zg --version
+```
+
+运行 stdio MCP server：
+
+```bash
+zg serve --mcp
+```
+
+安装 Codex MCP 集成：
+
+```bash
+zg install --target codex --yes
+```
+
+Codex MCP 工具调用默认超时为 600 秒，可在安装时通过 `--mcp-tool-timeout <秒数>` 覆盖。
 
 ### ✅ 运行要求
 
@@ -118,6 +144,8 @@ zg --rg -F "ZVEC_GREP_HOME" src
 zg --human "root local index discovery" --limit 3
 ```
 
+在 MCP 客户端中可使用 `zvec_grep_search` 和 `zvec_grep_rg`。MCP 输入使用 JSON 友好的字段，例如 `include: ["src/**"]`；状态查看和建索引请使用 CLI 的 `zg --status` 与 `zg --index`。Codex installer 会向 `${CODEX_HOME:-$HOME/.codex}/config.toml` 和 `${CODEX_HOME:-$HOME/.codex}/AGENTS.md` 写入由 zvec-grep 管理的配置块。
+
 ## <a id="models"></a>🧠 模型
 
 本地模型通过 `node-llama-cpp` 运行，适合把代码检索留在本机：
@@ -127,6 +155,8 @@ zg --index --embedding local/embeddinggemma-300m
 zg --index --embedding local/qwen3-embedding-0.6b
 ```
 
+在 Apple Silicon 上，本地构建默认使用更安静的 llama.cpp CMake 配置，避免无害的 OpenMP 和 ARM native 探测 warning。可以通过 `NODE_LLAMA_CPP_CMAKE_OPTION_<name>` 覆盖任意 llama.cpp CMake 选项，例如设置 `NODE_LLAMA_CPP_CMAKE_OPTION_GGML_NATIVE=ON` 重新启用 native CPU 优化。
+
 远程 Qwen embedding 适合希望使用托管 embedding 服务，或不想在本机配置模型的场景：
 
 ```bash
@@ -134,6 +164,25 @@ zg --index \
   --embedding qwen/text-embedding-v4 \
   --api-key "$DASHSCOPE_API_KEY"
 ```
+
+索引成功后，通过 CLI 显式传入的全局模型和 provider 参数会保存到 `~/.zvec-grep/config.json`，并使用仅当前用户可读写的权限。已经运行的 `zg` MCP server 会在下一次需要模型时读取新的远程 API key，不需要重启 Codex。只从环境变量读取、没有作为 CLI 参数显式传入的值不会被持久化。
+
+```json
+{
+  "version": 1,
+  "defaults": {
+    "embedding": "qwen/text-embedding-v4"
+  },
+  "providers": {
+    "qwen": {
+      "apiKey": "...",
+      "endpoint": "https://dashscope.aliyuncs.com/compatible-mode/v1/embeddings"
+    }
+  }
+}
+```
+
+配置优先级为：显式 CLI 或库参数、环境变量、全局配置、内置默认值。仓库 root 和 include/exclude 规则仍保存在各仓库自己的 `.zvec-grep` 元数据中，不进入全局配置。
 
 对于已有索引，`zg --index` 不传 `--embedding` 会复用索引里保存的 schema。只有在你明确想切换模型时，才使用 `--rebuild --embedding <model>`：
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
     },
     "node_modules/@hono/node-server": {
       "version": "1.19.14",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@hono/node-server/-/node-server-1.19.14.tgz",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
       "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
       "engines": {
@@ -84,7 +84,7 @@
     },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",
-      "resolved": "https://registry.anpm.alibaba-inc.com/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
       "dependencies": {
@@ -769,7 +769,7 @@
     },
     "node_modules/accepts": {
       "version": "2.0.0",
-      "resolved": "https://registry.anpm.alibaba-inc.com/accepts/-/accepts-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
       "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
       "license": "MIT",
       "dependencies": {
@@ -782,7 +782,7 @@
     },
     "node_modules/ajv": {
       "version": "8.20.0",
-      "resolved": "https://registry.anpm.alibaba-inc.com/ajv/-/ajv-8.20.0.tgz",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
       "dependencies": {
@@ -798,7 +798,7 @@
     },
     "node_modules/ajv-formats": {
       "version": "3.0.1",
-      "resolved": "https://registry.anpm.alibaba-inc.com/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
       "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
       "license": "MIT",
       "dependencies": {
@@ -873,7 +873,7 @@
     },
     "node_modules/body-parser": {
       "version": "2.3.0",
-      "resolved": "https://registry.anpm.alibaba-inc.com/body-parser/-/body-parser-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
       "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
@@ -897,7 +897,7 @@
     },
     "node_modules/body-parser/node_modules/content-type": {
       "version": "2.0.0",
-      "resolved": "https://registry.anpm.alibaba-inc.com/content-type/-/content-type-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
       "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
       "license": "MIT",
       "engines": {
@@ -919,7 +919,7 @@
     },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
-      "resolved": "https://registry.anpm.alibaba-inc.com/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
       "license": "MIT",
       "dependencies": {
@@ -932,7 +932,7 @@
     },
     "node_modules/call-bound": {
       "version": "1.0.4",
-      "resolved": "https://registry.anpm.alibaba-inc.com/call-bound/-/call-bound-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
       "license": "MIT",
       "dependencies": {
@@ -1140,7 +1140,7 @@
     },
     "node_modules/content-disposition": {
       "version": "1.1.0",
-      "resolved": "https://registry.anpm.alibaba-inc.com/content-disposition/-/content-disposition-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
       "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
       "license": "MIT",
       "engines": {
@@ -1153,7 +1153,7 @@
     },
     "node_modules/content-type": {
       "version": "1.0.5",
-      "resolved": "https://registry.anpm.alibaba-inc.com/content-type/-/content-type-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
       "license": "MIT",
       "engines": {
@@ -1162,7 +1162,7 @@
     },
     "node_modules/cookie": {
       "version": "0.7.2",
-      "resolved": "https://registry.anpm.alibaba-inc.com/cookie/-/cookie-0.7.2.tgz",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
       "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "license": "MIT",
       "engines": {
@@ -1171,7 +1171,7 @@
     },
     "node_modules/cookie-signature": {
       "version": "1.2.2",
-      "resolved": "https://registry.anpm.alibaba-inc.com/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
       "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
       "license": "MIT",
       "engines": {
@@ -1180,7 +1180,7 @@
     },
     "node_modules/cors": {
       "version": "2.8.6",
-      "resolved": "https://registry.anpm.alibaba-inc.com/cors/-/cors-2.8.6.tgz",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
       "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
       "license": "MIT",
       "dependencies": {
@@ -1259,7 +1259,7 @@
     },
     "node_modules/depd": {
       "version": "2.0.0",
-      "resolved": "https://registry.anpm.alibaba-inc.com/depd/-/depd-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "license": "MIT",
       "engines": {
@@ -1268,7 +1268,7 @@
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
-      "resolved": "https://registry.anpm.alibaba-inc.com/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
       "license": "MIT",
       "dependencies": {
@@ -1282,7 +1282,7 @@
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
-      "resolved": "https://registry.anpm.alibaba-inc.com/ee-first/-/ee-first-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
     },
@@ -1295,7 +1295,7 @@
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
-      "resolved": "https://registry.anpm.alibaba-inc.com/encodeurl/-/encodeurl-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
       "license": "MIT",
       "engines": {
@@ -1314,7 +1314,7 @@
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
-      "resolved": "https://registry.anpm.alibaba-inc.com/es-define-property/-/es-define-property-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "license": "MIT",
       "engines": {
@@ -1323,7 +1323,7 @@
     },
     "node_modules/es-errors": {
       "version": "1.3.0",
-      "resolved": "https://registry.anpm.alibaba-inc.com/es-errors/-/es-errors-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "license": "MIT",
       "engines": {
@@ -1332,7 +1332,7 @@
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.2",
-      "resolved": "https://registry.anpm.alibaba-inc.com/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
       "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
@@ -1354,13 +1354,13 @@
     },
     "node_modules/escape-html": {
       "version": "1.0.3",
-      "resolved": "https://registry.anpm.alibaba-inc.com/escape-html/-/escape-html-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
     },
     "node_modules/etag": {
       "version": "1.8.1",
-      "resolved": "https://registry.anpm.alibaba-inc.com/etag/-/etag-1.8.1.tgz",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
       "license": "MIT",
       "engines": {
@@ -1376,7 +1376,7 @@
     },
     "node_modules/eventsource": {
       "version": "3.0.7",
-      "resolved": "https://registry.anpm.alibaba-inc.com/eventsource/-/eventsource-3.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
       "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
       "license": "MIT",
       "dependencies": {
@@ -1388,7 +1388,7 @@
     },
     "node_modules/eventsource-parser": {
       "version": "3.1.0",
-      "resolved": "https://registry.anpm.alibaba-inc.com/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
       "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
       "license": "MIT",
       "engines": {
@@ -1397,7 +1397,7 @@
     },
     "node_modules/express": {
       "version": "5.2.1",
-      "resolved": "https://registry.anpm.alibaba-inc.com/express/-/express-5.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
       "dependencies": {
@@ -1440,7 +1440,7 @@
     },
     "node_modules/express-rate-limit": {
       "version": "8.5.2",
-      "resolved": "https://registry.anpm.alibaba-inc.com/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
       "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "license": "MIT",
       "dependencies": {
@@ -1458,13 +1458,13 @@
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "resolved": "https://registry.anpm.alibaba-inc.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
     "node_modules/fast-uri": {
       "version": "3.1.3",
-      "resolved": "https://registry.anpm.alibaba-inc.com/fast-uri/-/fast-uri-3.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
       "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
       "funding": [
         {
@@ -1515,7 +1515,7 @@
     },
     "node_modules/finalhandler": {
       "version": "2.1.1",
-      "resolved": "https://registry.anpm.alibaba-inc.com/finalhandler/-/finalhandler-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
       "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
       "license": "MIT",
       "dependencies": {
@@ -1536,7 +1536,7 @@
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
-      "resolved": "https://registry.anpm.alibaba-inc.com/forwarded/-/forwarded-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
       "license": "MIT",
       "engines": {
@@ -1545,7 +1545,7 @@
     },
     "node_modules/fresh": {
       "version": "2.0.0",
-      "resolved": "https://registry.anpm.alibaba-inc.com/fresh/-/fresh-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
       "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
       "license": "MIT",
       "engines": {
@@ -1569,7 +1569,7 @@
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
-      "resolved": "https://registry.anpm.alibaba-inc.com/function-bind/-/function-bind-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "license": "MIT",
       "funding": {
@@ -1601,7 +1601,7 @@
     },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
-      "resolved": "https://registry.anpm.alibaba-inc.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "license": "MIT",
       "dependencies": {
@@ -1625,7 +1625,7 @@
     },
     "node_modules/get-proto": {
       "version": "1.0.1",
-      "resolved": "https://registry.anpm.alibaba-inc.com/get-proto/-/get-proto-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
       "license": "MIT",
       "dependencies": {
@@ -1638,7 +1638,7 @@
     },
     "node_modules/gopd": {
       "version": "1.2.0",
-      "resolved": "https://registry.anpm.alibaba-inc.com/gopd/-/gopd-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "license": "MIT",
       "engines": {
@@ -1657,7 +1657,7 @@
     },
     "node_modules/has-symbols": {
       "version": "1.1.0",
-      "resolved": "https://registry.anpm.alibaba-inc.com/has-symbols/-/has-symbols-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
       "engines": {
@@ -1669,7 +1669,7 @@
     },
     "node_modules/hasown": {
       "version": "2.0.4",
-      "resolved": "https://registry.anpm.alibaba-inc.com/hasown/-/hasown-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
       "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
@@ -1681,7 +1681,7 @@
     },
     "node_modules/hono": {
       "version": "4.12.30",
-      "resolved": "https://registry.anpm.alibaba-inc.com/hono/-/hono-4.12.30.tgz",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.30.tgz",
       "integrity": "sha512-emn+JoJjrN9YTpRDS5it/UI2SO9BAE37T6I3d963RxcZ81G9A4pr2SZTEiiaiKbzx+NKRg5BZ89fCL7gCJCUog==",
       "license": "MIT",
       "engines": {
@@ -1690,7 +1690,7 @@
     },
     "node_modules/http-errors": {
       "version": "2.0.1",
-      "resolved": "https://registry.anpm.alibaba-inc.com/http-errors/-/http-errors-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
       "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
       "license": "MIT",
       "dependencies": {
@@ -1710,7 +1710,7 @@
     },
     "node_modules/iconv-lite": {
       "version": "0.7.3",
-      "resolved": "https://registry.anpm.alibaba-inc.com/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
       "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
       "license": "MIT",
       "dependencies": {
@@ -1736,7 +1736,7 @@
     },
     "node_modules/inherits": {
       "version": "2.0.4",
-      "resolved": "https://registry.anpm.alibaba-inc.com/inherits/-/inherits-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
@@ -1749,7 +1749,7 @@
     },
     "node_modules/ip-address": {
       "version": "10.2.0",
-      "resolved": "https://registry.anpm.alibaba-inc.com/ip-address/-/ip-address-10.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
       "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
@@ -1758,7 +1758,7 @@
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
-      "resolved": "https://registry.anpm.alibaba-inc.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
       "license": "MIT",
       "engines": {
@@ -1890,7 +1890,7 @@
     },
     "node_modules/is-promise": {
       "version": "4.0.0",
-      "resolved": "https://registry.anpm.alibaba-inc.com/is-promise/-/is-promise-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
     },
@@ -1919,7 +1919,7 @@
     },
     "node_modules/jose": {
       "version": "6.2.3",
-      "resolved": "https://registry.anpm.alibaba-inc.com/jose/-/jose-6.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
       "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
       "license": "MIT",
       "funding": {
@@ -1928,13 +1928,13 @@
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
-      "resolved": "https://registry.anpm.alibaba-inc.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
     "node_modules/json-schema-typed": {
       "version": "8.0.2",
-      "resolved": "https://registry.anpm.alibaba-inc.com/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
     },
@@ -2000,7 +2000,7 @@
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
-      "resolved": "https://registry.anpm.alibaba-inc.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
       "license": "MIT",
       "engines": {
@@ -2009,7 +2009,7 @@
     },
     "node_modules/media-typer": {
       "version": "1.1.0",
-      "resolved": "https://registry.anpm.alibaba-inc.com/media-typer/-/media-typer-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
       "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
       "license": "MIT",
       "engines": {
@@ -2018,7 +2018,7 @@
     },
     "node_modules/merge-descriptors": {
       "version": "2.0.0",
-      "resolved": "https://registry.anpm.alibaba-inc.com/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
       "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
       "license": "MIT",
       "engines": {
@@ -2030,7 +2030,7 @@
     },
     "node_modules/mime-db": {
       "version": "1.54.0",
-      "resolved": "https://registry.anpm.alibaba-inc.com/mime-db/-/mime-db-1.54.0.tgz",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "license": "MIT",
       "engines": {
@@ -2039,7 +2039,7 @@
     },
     "node_modules/mime-types": {
       "version": "3.0.2",
-      "resolved": "https://registry.anpm.alibaba-inc.com/mime-types/-/mime-types-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "license": "MIT",
       "dependencies": {
@@ -2126,7 +2126,7 @@
     },
     "node_modules/negotiator": {
       "version": "1.0.0",
-      "resolved": "https://registry.anpm.alibaba-inc.com/negotiator/-/negotiator-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
       "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
       "license": "MIT",
       "engines": {
@@ -2224,7 +2224,7 @@
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
-      "resolved": "https://registry.anpm.alibaba-inc.com/object-assign/-/object-assign-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "license": "MIT",
       "engines": {
@@ -2233,7 +2233,7 @@
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",
-      "resolved": "https://registry.anpm.alibaba-inc.com/object-inspect/-/object-inspect-1.13.4.tgz",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "license": "MIT",
       "engines": {
@@ -2245,7 +2245,7 @@
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
-      "resolved": "https://registry.anpm.alibaba-inc.com/on-finished/-/on-finished-2.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
       "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
       "license": "MIT",
       "dependencies": {
@@ -2257,7 +2257,7 @@
     },
     "node_modules/once": {
       "version": "1.4.0",
-      "resolved": "https://registry.anpm.alibaba-inc.com/once/-/once-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "license": "ISC",
       "dependencies": {
@@ -2331,7 +2331,7 @@
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
-      "resolved": "https://registry.anpm.alibaba-inc.com/parseurl/-/parseurl-1.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "license": "MIT",
       "engines": {
@@ -2349,7 +2349,7 @@
     },
     "node_modules/path-to-regexp": {
       "version": "8.4.2",
-      "resolved": "https://registry.anpm.alibaba-inc.com/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
       "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
       "funding": {
@@ -2359,7 +2359,7 @@
     },
     "node_modules/pkce-challenge": {
       "version": "5.0.1",
-      "resolved": "https://registry.anpm.alibaba-inc.com/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
       "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
       "license": "MIT",
       "engines": {
@@ -2419,7 +2419,7 @@
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
-      "resolved": "https://registry.anpm.alibaba-inc.com/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
       "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
       "license": "MIT",
       "dependencies": {
@@ -2432,7 +2432,7 @@
     },
     "node_modules/qs": {
       "version": "6.15.3",
-      "resolved": "https://registry.anpm.alibaba-inc.com/qs/-/qs-6.15.3.tgz",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
       "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -2448,7 +2448,7 @@
     },
     "node_modules/range-parser": {
       "version": "1.3.0",
-      "resolved": "https://registry.anpm.alibaba-inc.com/range-parser/-/range-parser-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
       "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
       "license": "MIT",
       "engines": {
@@ -2461,7 +2461,7 @@
     },
     "node_modules/raw-body": {
       "version": "3.0.2",
-      "resolved": "https://registry.anpm.alibaba-inc.com/raw-body/-/raw-body-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
       "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
       "license": "MIT",
       "dependencies": {
@@ -2502,7 +2502,7 @@
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
-      "resolved": "https://registry.anpm.alibaba-inc.com/require-from-string/-/require-from-string-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "license": "MIT",
       "engines": {
@@ -2551,7 +2551,7 @@
     },
     "node_modules/router": {
       "version": "2.2.0",
-      "resolved": "https://registry.anpm.alibaba-inc.com/router/-/router-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
       "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
       "license": "MIT",
       "dependencies": {
@@ -2567,7 +2567,7 @@
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
-      "resolved": "https://registry.anpm.alibaba-inc.com/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
@@ -2586,7 +2586,7 @@
     },
     "node_modules/send": {
       "version": "1.2.1",
-      "resolved": "https://registry.anpm.alibaba-inc.com/send/-/send-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
       "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
       "license": "MIT",
       "dependencies": {
@@ -2612,7 +2612,7 @@
     },
     "node_modules/serve-static": {
       "version": "2.2.1",
-      "resolved": "https://registry.anpm.alibaba-inc.com/serve-static/-/serve-static-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
       "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
       "license": "MIT",
       "dependencies": {
@@ -2631,7 +2631,7 @@
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
-      "resolved": "https://registry.anpm.alibaba-inc.com/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
     },
@@ -2658,7 +2658,7 @@
     },
     "node_modules/side-channel": {
       "version": "1.1.1",
-      "resolved": "https://registry.anpm.alibaba-inc.com/side-channel/-/side-channel-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
       "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
@@ -2677,7 +2677,7 @@
     },
     "node_modules/side-channel-list": {
       "version": "1.0.1",
-      "resolved": "https://registry.anpm.alibaba-inc.com/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
       "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
@@ -2693,7 +2693,7 @@
     },
     "node_modules/side-channel-map": {
       "version": "1.0.1",
-      "resolved": "https://registry.anpm.alibaba-inc.com/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
       "license": "MIT",
       "dependencies": {
@@ -2711,7 +2711,7 @@
     },
     "node_modules/side-channel-weakmap": {
       "version": "1.0.2",
-      "resolved": "https://registry.anpm.alibaba-inc.com/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
       "license": "MIT",
       "dependencies": {
@@ -2779,7 +2779,7 @@
     },
     "node_modules/statuses": {
       "version": "2.0.2",
-      "resolved": "https://registry.anpm.alibaba-inc.com/statuses/-/statuses-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
       "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
       "license": "MIT",
       "engines": {
@@ -2915,7 +2915,7 @@
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",
-      "resolved": "https://registry.anpm.alibaba-inc.com/toidentifier/-/toidentifier-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "license": "MIT",
       "engines": {
@@ -2933,7 +2933,7 @@
     },
     "node_modules/type-is": {
       "version": "2.1.0",
-      "resolved": "https://registry.anpm.alibaba-inc.com/type-is/-/type-is-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
       "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "dependencies": {
@@ -2951,7 +2951,7 @@
     },
     "node_modules/type-is/node_modules/content-type": {
       "version": "2.0.0",
-      "resolved": "https://registry.anpm.alibaba-inc.com/content-type/-/content-type-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
       "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
       "license": "MIT",
       "engines": {
@@ -2995,7 +2995,7 @@
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
-      "resolved": "https://registry.anpm.alibaba-inc.com/unpipe/-/unpipe-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
       "license": "MIT",
       "engines": {
@@ -3021,7 +3021,7 @@
     },
     "node_modules/vary": {
       "version": "1.1.2",
-      "resolved": "https://registry.anpm.alibaba-inc.com/vary/-/vary-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "license": "MIT",
       "engines": {
@@ -3134,7 +3134,7 @@
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
-      "resolved": "https://registry.anpm.alibaba-inc.com/wrappy/-/wrappy-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
     },
@@ -3250,7 +3250,7 @@
     },
     "node_modules/zod": {
       "version": "3.25.76",
-      "resolved": "https://registry.anpm.alibaba-inc.com/zod/-/zod-3.25.76.tgz",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
       "funding": {
@@ -3259,7 +3259,7 @@
     },
     "node_modules/zod-to-json-schema": {
       "version": "3.25.2",
-      "resolved": "https://registry.anpm.alibaba-inc.com/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
       "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
       "license": "ISC",
       "peerDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,12 @@
       "version": "0.1.4",
       "license": "Apache-2.0",
       "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "@vscode/ripgrep": "^1.18.0",
         "@zvec/zvec": "^0.5.0",
         "tree-sitter-wasms": "^0.1.13",
-        "web-tree-sitter": "^0.20.8"
+        "web-tree-sitter": "^0.20.8",
+        "zod": "^3.25.76"
       },
       "bin": {
         "zg": "dist/cli/index.js"
@@ -26,6 +28,18 @@
       },
       "optionalDependencies": {
         "node-llama-cpp": "3.18.1"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
       }
     },
     "node_modules/@huggingface/jinja": {
@@ -68,6 +82,46 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/@node-llama-cpp/linux-arm64": {
       "version": "3.18.1",
       "resolved": "https://registry.npmjs.org/@node-llama-cpp/linux-arm64/-/linux-arm64-3.18.1.tgz",
@@ -75,9 +129,6 @@
       "cpu": [
         "arm64",
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -96,9 +147,6 @@
         "arm",
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -114,9 +162,6 @@
       "integrity": "sha512-tRmWcsyvAcqJHQHXHsaOkx6muGbcirA9nRdNgH6n7bjGUw4VuoBD3dChyNF3/Ktt7ohB9kz+XhhyZjbDHpXyMA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -134,9 +179,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -153,9 +195,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -171,9 +210,6 @@
       "integrity": "sha512-SIaNTK5pUPhwJD0gmiQfHa8OrRctVMmnqu+slJrz2Mzgg/XrwFndJlS9hvc+jSjTXCouwf7sYeQaaJWvQgBh/A==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -357,9 +393,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -375,9 +408,6 @@
       "integrity": "sha512-37iO/Dp6m5DDaC2sf3zPtx/hl9FV3Xze4xoYidrxxS9bgP3S8ALroxRK6xBG/1TtfXKTvolvp+IjrUU6ujIGmA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -395,9 +425,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -413,9 +440,6 @@
       "integrity": "sha512-e9FBWDe+lv7QKAwtKOt6A2W/fyy/aEEfr0g6j/hWzvQcrzHCsz07BNQYlNOjTfeytrtLU7k449H1PI95jA4OjQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -743,6 +767,52 @@
         "@zvec/bindings-win32-x64": "0.5.0"
       }
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.anpm.alibaba-inc.com/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.anpm.alibaba-inc.com/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.anpm.alibaba-inc.com/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/ansi-escapes": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-6.2.1.tgz",
@@ -801,14 +871,79 @@
         "file-uri-to-path": "1.0.0"
       }
     },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.anpm.alibaba-inc.com/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.anpm.alibaba-inc.com/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.anpm.alibaba-inc.com/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.anpm.alibaba-inc.com/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/chalk": {
@@ -1003,12 +1138,68 @@
         "node": ">=14"
       }
     },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.anpm.alibaba-inc.com/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.anpm.alibaba-inc.com/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.anpm.alibaba-inc.com/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.anpm.alibaba-inc.com/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.anpm.alibaba-inc.com/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -1022,15 +1213,13 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/cross-spawn/node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -1046,7 +1235,6 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -1069,12 +1257,50 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.anpm.alibaba-inc.com/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.anpm.alibaba-inc.com/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.anpm.alibaba-inc.com/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.anpm.alibaba-inc.com/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/env-var": {
       "version": "7.5.0",
@@ -1084,6 +1310,36 @@
       "optional": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.anpm.alibaba-inc.com/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.anpm.alibaba-inc.com/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.anpm.alibaba-inc.com/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/escalade": {
@@ -1096,12 +1352,131 @@
         "node": ">=6"
       }
     },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.anpm.alibaba-inc.com/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.anpm.alibaba-inc.com/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.anpm.alibaba-inc.com/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.anpm.alibaba-inc.com/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.anpm.alibaba-inc.com/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.anpm.alibaba-inc.com/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.anpm.alibaba-inc.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.3",
+      "resolved": "https://registry.anpm.alibaba-inc.com/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
@@ -1138,6 +1513,45 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.anpm.alibaba-inc.com/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.anpm.alibaba-inc.com/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.anpm.alibaba-inc.com/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/fs-extra": {
       "version": "11.3.5",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
@@ -1151,6 +1565,15 @@
       },
       "engines": {
         "node": ">=14.14"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.anpm.alibaba-inc.com/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/get-caller-file": {
@@ -1176,12 +1599,130 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.anpm.alibaba-inc.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.anpm.alibaba-inc.com/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.anpm.alibaba-inc.com/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC",
       "optional": true
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.anpm.alibaba-inc.com/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.anpm.alibaba-inc.com/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.30",
+      "resolved": "https://registry.anpm.alibaba-inc.com/hono/-/hono-4.12.30.tgz",
+      "integrity": "sha512-emn+JoJjrN9YTpRDS5it/UI2SO9BAE37T6I3d963RxcZ81G9A4pr2SZTEiiaiKbzx+NKRg5BZ89fCL7gCJCUog==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.anpm.alibaba-inc.com/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.anpm.alibaba-inc.com/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/ignore": {
       "version": "7.0.5",
@@ -1193,12 +1734,36 @@
         "node": ">= 4"
       }
     },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.anpm.alibaba-inc.com/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
     "node_modules/ini": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC",
       "optional": true
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.anpm.alibaba-inc.com/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.anpm.alibaba-inc.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/ipull": {
       "version": "3.9.5",
@@ -1323,6 +1888,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.anpm.alibaba-inc.com/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
     "node_modules/is-unicode-supported": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
@@ -1345,6 +1916,27 @@
       "engines": {
         "node": ">=20"
       }
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.anpm.alibaba-inc.com/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.anpm.alibaba-inc.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.anpm.alibaba-inc.com/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/jsonfile": {
       "version": "6.2.1",
@@ -1406,6 +1998,61 @@
         "url": "https://github.com/sponsors/typicode"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.anpm.alibaba-inc.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.anpm.alibaba-inc.com/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.anpm.alibaba-inc.com/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.anpm.alibaba-inc.com/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.anpm.alibaba-inc.com/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/mimic-function": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
@@ -1456,8 +2103,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "5.1.15",
@@ -1476,6 +2122,15 @@
       },
       "engines": {
         "node": "^18 || >=20"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.anpm.alibaba-inc.com/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/node-addon-api": {
@@ -1567,6 +2222,48 @@
         }
       }
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.anpm.alibaba-inc.com/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.anpm.alibaba-inc.com/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.anpm.alibaba-inc.com/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.anpm.alibaba-inc.com/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/onetime": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
@@ -1632,14 +2329,41 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.anpm.alibaba-inc.com/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.anpm.alibaba-inc.com/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.anpm.alibaba-inc.com/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/pretty-bytes": {
@@ -1693,6 +2417,63 @@
         "node": ">= 4"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.anpm.alibaba-inc.com/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.anpm.alibaba-inc.com/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.anpm.alibaba-inc.com/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.anpm.alibaba-inc.com/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -1715,6 +2496,15 @@
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "license": "MIT",
       "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.anpm.alibaba-inc.com/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1759,6 +2549,28 @@
         "node": ">= 4"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.anpm.alibaba-inc.com/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.anpm.alibaba-inc.com/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
     "node_modules/semver": {
       "version": "7.8.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
@@ -1772,12 +2584,62 @@
         "node": ">=10"
       }
     },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.anpm.alibaba-inc.com/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.anpm.alibaba-inc.com/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.anpm.alibaba-inc.com/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -1790,9 +2652,80 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.anpm.alibaba-inc.com/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.anpm.alibaba-inc.com/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.anpm.alibaba-inc.com/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.anpm.alibaba-inc.com/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/signal-exit": {
@@ -1842,6 +2775,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.anpm.alibaba-inc.com/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/stdin-discarder": {
@@ -1971,6 +2913,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.anpm.alibaba-inc.com/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/tree-sitter-wasms": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/tree-sitter-wasms/-/tree-sitter-wasms-0.1.13.tgz",
@@ -1978,6 +2929,37 @@
       "license": "Unlicense",
       "dependencies": {
         "tree-sitter-wasms": "^0.1.11"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.anpm.alibaba-inc.com/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.anpm.alibaba-inc.com/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typescript": {
@@ -2011,6 +2993,15 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.anpm.alibaba-inc.com/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/url-join": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
@@ -2026,6 +3017,15 @@
       "optional": true,
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.anpm.alibaba-inc.com/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/web-tree-sitter": {
@@ -2131,6 +3131,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.anpm.alibaba-inc.com/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
     },
     "node_modules/y18n": {
       "version": "5.0.8",
@@ -2240,6 +3246,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.anpm.alibaba-inc.com/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.anpm.alibaba-inc.com/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -44,10 +44,12 @@
     "typescript": "^5.9.3"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@vscode/ripgrep": "^1.18.0",
     "@zvec/zvec": "^0.5.0",
     "tree-sitter-wasms": "^0.1.13",
-    "web-tree-sitter": "^0.20.8"
+    "web-tree-sitter": "^0.20.8",
+    "zod": "^3.25.76"
   },
   "optionalDependencies": {
     "node-llama-cpp": "3.18.1"

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -59,8 +59,16 @@ const MANAGED_RG_OUTPUT_OPTIONS = new Set([
 export function parseArgs(args: readonly string[]): ParsedArgs {
   const options: CliOptions = {};
   const positionals: string[] = [];
+  let startIndex = 0;
+  if (args[0] === "install") {
+    options.install = true;
+    startIndex = 1;
+  } else if (args[0] === "serve") {
+    options.serve = true;
+    startIndex = 1;
+  }
 
-  for (let index = 0; index < args.length; index++) {
+  for (let index = startIndex; index < args.length; index++) {
     const arg = args[index]!;
 
     if (arg === "--") {
@@ -85,6 +93,21 @@ export function parseArgs(args: readonly string[]): ParsedArgs {
       options.status = true;
     } else if (arg === "--collections") {
       options.collections = true;
+    } else if (arg === "--mcp") {
+      options.mcp = true;
+    } else if (isLongOptionWithValue(arg, "--target")) {
+      options.installTargets = appendInstallTargets(options.installTargets, valueFromLongOption(arg));
+    } else if (arg === "--target") {
+      options.installTargets = appendInstallTargets(options.installTargets, readOptionValue(args, ++index, arg));
+    } else if (isLongOptionWithValue(arg, "--mcp-tool-timeout")) {
+      options.installMcpToolTimeoutSeconds = parsePositiveInteger(
+        valueFromLongOption(arg),
+        "--mcp-tool-timeout",
+      );
+    } else if (arg === "--mcp-tool-timeout") {
+      options.installMcpToolTimeoutSeconds = parsePositiveInteger(readOptionValue(args, ++index, arg), arg);
+    } else if (arg === "--yes") {
+      options.yes = true;
     } else if (arg === "--rg") {
       options.rg = true;
     } else if (arg === "--debug") {
@@ -103,6 +126,8 @@ export function parseArgs(args: readonly string[]): ParsedArgs {
       options.color = "never";
     } else if (arg === "--rebuild") {
       options.rebuild = true;
+    } else if (arg === "--force") {
+      options.force = true;
     } else if (arg === "--reset-paths") {
       options.resetPaths = true;
     } else if (arg === "--no-fallback") {
@@ -249,8 +274,35 @@ export function parseArgs(args: readonly string[]): ParsedArgs {
 
 
 function validateCliShape(options: CliOptions): void {
+  const hasUtilityCommand = options.index
+    || options.disableIndex
+    || options.status
+    || options.collections
+    || options.install
+    || options.serve;
+
   if (options.index && options.collections) {
     throw new Error("--index and --collections cannot be used together");
+  }
+
+  if (options.install && (options.index || options.disableIndex || options.status || options.collections)) {
+    throw new Error("zg install cannot be combined with index, status, or collections commands");
+  }
+
+  if (options.serve && (options.index || options.disableIndex || options.status || options.collections)) {
+    throw new Error("zg serve cannot be combined with index, status, or collections commands");
+  }
+
+  if (options.serve && options.install) {
+    throw new Error("zg serve cannot be combined with install");
+  }
+
+  if (options.serve && !options.mcp) {
+    throw new Error("zg serve currently requires --mcp");
+  }
+
+  if (options.mcp && !options.serve) {
+    throw new Error("--mcp can only be used with zg serve");
   }
 
   if (options.disableIndex && options.collections) {
@@ -293,19 +345,31 @@ function validateCliShape(options: CliOptions): void {
     throw new Error("--collections and --collection cannot be used together");
   }
 
-  if ((options.index || options.disableIndex || options.status || options.collections) && hasExplicitRoutes(options)) {
+  if (options.install && options.collection) {
+    throw new Error("zg install does not accept --collection");
+  }
+
+  if (options.installMcpToolTimeoutSeconds !== undefined && !options.install) {
+    throw new Error("--mcp-tool-timeout can only be used with zg install");
+  }
+
+  if (options.serve && options.collection) {
+    throw new Error("zg serve does not accept --collection");
+  }
+
+  if (hasUtilityCommand && hasExplicitRoutes(options)) {
     throw new Error("--fts and --vector can only be used with query commands");
   }
 
-  if ((options.index || options.disableIndex || options.status || options.collections) && options.rg) {
+  if (hasUtilityCommand && options.rg) {
     throw new Error("--rg can only be used with query commands");
   }
 
-  if ((options.index || options.disableIndex || options.status || options.collections) && options.preview) {
+  if (hasUtilityCommand && options.preview) {
     throw new Error("--preview can only be used with query commands");
   }
 
-  if ((options.index || options.disableIndex || options.status || options.collections) && options.noAutoUpdate) {
+  if (hasUtilityCommand && options.noAutoUpdate) {
     throw new Error("--no-auto-update can only be used with query commands");
   }
 
@@ -520,6 +584,16 @@ function appendRgPattern(
 }
 
 
+function appendInstallTargets(existing: string[] | undefined, value: string): string[] {
+  const targets = value
+    .split(/[,\s]+/)
+    .map((target) => target.trim())
+    .filter((target) => target.length > 0);
+
+  return [...(existing ?? []), ...targets];
+}
+
+
 function setRgContext(
   existing: CliRgOptions | undefined,
   direction: "before" | "after" | "both",
@@ -629,7 +703,7 @@ function parsePreviewMode(value: string): PreviewMode {
 }
 
 
-function parseLlamaGpu(value: string): "auto" | "metal" | "vulkan" | "cuda" | false {
+export function parseLlamaGpu(value: string): "auto" | "metal" | "vulkan" | "cuda" | false {
   const normalized = value.trim().toLowerCase();
   if (normalized === "auto" || normalized === "metal" || normalized === "vulkan" || normalized === "cuda") {
     return normalized;
@@ -669,17 +743,20 @@ function parseSymbolType(value: string): CodeSymbolType {
 }
 
 
-function appendPathFilters(existing: string[] | undefined, value: string): string[] {
-  const values = value
+export function splitPathFilters(value: string): string[] {
+  return value
     .split(",")
     .map((item) => item.trim())
     .filter((item) => item.length > 0);
-
-  return [...(existing ?? []), ...values];
 }
 
 
-function parseModifiedTime(value: string, option: string): number {
+function appendPathFilters(existing: string[] | undefined, value: string): string[] {
+  return [...(existing ?? []), ...splitPathFilters(value)];
+}
+
+
+export function parseModifiedTime(value: string, option: string): number {
   if (/^\d+$/.test(value)) {
     const parsed = Number.parseInt(value, 10);
     if (Number.isSafeInteger(parsed) && parsed >= 0) {

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -1,4 +1,18 @@
-import { resolve } from "node:path";
+import { randomUUID } from "node:crypto";
+import {
+  chmod,
+  lstat,
+  mkdir,
+  open,
+  readFile,
+  readlink,
+  rename,
+  stat,
+  unlink,
+} from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, resolve } from "node:path";
+import { createInterface } from "node:readline/promises";
 import {
   createZvecGrep,
   type CreateZvecGrepOptions,
@@ -6,6 +20,10 @@ import {
   type RootPath,
   type ZvecGrepContextOptions,
 } from "../index.js";
+import {
+  globalConfigPath,
+  updateGlobalConfigFromExplicitOptions,
+} from "../engine/config.js";
 import { findNearestAnonymousWorkspace } from "../engine/service/root.js";
 import type { ParsedArgs, CliOptions } from "./types.js";
 import { contextWarningLines, printAgentContextResult, printHumanContextResult } from "./format/context.js";
@@ -21,7 +39,48 @@ import {
 } from "./format/status.js";
 
 
+type AgentInstaller = {
+  id: string;
+  label: string;
+  description: string;
+  install: (options: InstallAgentOptions) => Promise<InstallAgentResult>;
+};
+
+
+type InstallAgentOptions = {
+  force: boolean;
+  mcpToolTimeoutSeconds: number;
+};
+
+
+type InstallAgentResult = {
+  files: string[];
+};
+
+
+const AGENT_INSTALLERS: readonly AgentInstaller[] = [
+  {
+    id: "codex",
+    label: "Codex",
+    description: "configure zvec-grep MCP and Codex guidance",
+    install: installCodexIntegration,
+  },
+];
+
+
+const ZVEC_GREP_CONFIG_START = "# ZVEC_GREP_START";
+const ZVEC_GREP_CONFIG_END = "# ZVEC_GREP_END";
+const ZVEC_GREP_AGENTS_START = "<!-- ZVEC_GREP_START -->";
+const ZVEC_GREP_AGENTS_END = "<!-- ZVEC_GREP_END -->";
+const DEFAULT_MCP_TOOL_TIMEOUT_SECONDS = 600;
+
+
 export async function runParsedCommand(parsed: ParsedArgs): Promise<void> {
+  if (parsed.options.install) {
+    await runInstall(parsed);
+    return;
+  }
+
   if (parsed.options.index) {
     await runIndex(parsed);
     return;
@@ -42,7 +101,157 @@ export async function runParsedCommand(parsed: ParsedArgs): Promise<void> {
     return;
   }
 
+  if (parsed.options.serve) {
+    await runServe(parsed);
+    return;
+  }
+
   await runQuery(parsed);
+}
+
+
+async function runInstall(parsed: ParsedArgs): Promise<void> {
+  const installers = await resolveInstallers(parsed);
+  if (installers.length === 0) {
+    console.log("No agents selected.");
+    return;
+  }
+
+  console.log(`Installing zvec-grep for: ${installers.map((installer) => installer.label).join(", ")}`);
+  for (const installer of installers) {
+    const result = await installer.install({
+      force: parsed.options.force === true,
+      mcpToolTimeoutSeconds: parsed.options.installMcpToolTimeoutSeconds
+        ?? DEFAULT_MCP_TOOL_TIMEOUT_SECONDS,
+    });
+    console.log(`Installed ${installer.label}:`);
+    for (const file of result.files) {
+      console.log(`  ${file}`);
+    }
+  }
+
+  console.log("Restart the selected agent or start a new session to pick up the integration.");
+  if (installers.some((installer) => installer.id === "codex")) {
+    console.log("Codex MCP server: zg serve --mcp");
+  }
+}
+
+
+async function installCodexIntegration(options: InstallAgentOptions): Promise<InstallAgentResult> {
+  const codexHome = resolveCodexHome();
+  const configPath = resolve(codexHome, "config.toml");
+  const agentsPath = resolve(codexHome, "AGENTS.md");
+
+  await writeMarkedFile({
+    path: configPath,
+    startMarker: ZVEC_GREP_CONFIG_START,
+    endMarker: ZVEC_GREP_CONFIG_END,
+    block: codexConfigBlock(options.mcpToolTimeoutSeconds),
+    force: options.force,
+    conflictPattern: /^\[mcp_servers\.zvec_grep\]/m,
+    conflictMessage: `Existing [mcp_servers.zvec_grep] found in ${configPath}. Re-run with --force after removing or moving that table into the zvec-grep managed block.`,
+    removeConflict: removeCodexMcpServerConfig,
+  });
+
+  await writeMarkedFile({
+    path: agentsPath,
+    startMarker: ZVEC_GREP_AGENTS_START,
+    endMarker: ZVEC_GREP_AGENTS_END,
+    block: codexAgentsBlock(),
+    force: true,
+  });
+
+  return { files: [configPath, agentsPath] };
+}
+
+
+async function resolveInstallers(parsed: ParsedArgs): Promise<AgentInstaller[]> {
+  const targetTokens = [
+    ...(parsed.options.installTargets ?? []),
+    ...parsed.positionals,
+  ];
+
+  if (targetTokens.length > 0) {
+    return installersFromTokens(targetTokens);
+  }
+
+  if (parsed.options.yes === true || !process.stdin.isTTY || !process.stdout.isTTY) {
+    return installersFromTokens(["auto"]);
+  }
+
+  return promptInstallers();
+}
+
+
+async function promptInstallers(): Promise<AgentInstaller[]> {
+  console.log("Select agents to configure:");
+  AGENT_INSTALLERS.forEach((installer, index) => {
+    console.log(`  ${index + 1}. ${installer.label} - ${installer.description}`);
+  });
+  console.log("  all. All supported agents");
+  console.log("  none. Cancel");
+
+  const readline = createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+  try {
+    const answer = await readline.question("Agents [codex]: ");
+    const normalized = answer.trim();
+    return installersFromTokens(normalized.length > 0 ? splitTargetTokens(normalized) : ["codex"]);
+  } finally {
+    readline.close();
+  }
+}
+
+
+function installersFromTokens(tokens: readonly string[]): AgentInstaller[] {
+  const normalized = tokens.flatMap(splitTargetTokens);
+  if (normalized.length === 0) {
+    return installersFromTokens(["auto"]);
+  }
+
+  const selected = new Map<string, AgentInstaller>();
+  for (const token of normalized) {
+    const lower = token.toLowerCase();
+    if (lower === "none") {
+      return [];
+    }
+
+    if (lower === "auto" || lower === "all") {
+      for (const installer of AGENT_INSTALLERS) {
+        selected.set(installer.id, installer);
+      }
+      continue;
+    }
+
+    const numbered = Number.parseInt(lower, 10);
+    if (Number.isInteger(numbered) && numbered >= 1 && numbered <= AGENT_INSTALLERS.length) {
+      const installer = AGENT_INSTALLERS[numbered - 1]!;
+      selected.set(installer.id, installer);
+      continue;
+    }
+
+    const installer = AGENT_INSTALLERS.find((candidate) => (
+      candidate.id === lower
+      || candidate.label.toLowerCase() === lower
+    ));
+    if (!installer) {
+      throw new Error(`Unknown install target: ${token}`);
+    }
+
+    selected.set(installer.id, installer);
+  }
+
+  return [...selected.values()];
+}
+
+
+function splitTargetTokens(value: string): string[] {
+  return value
+    .split(/[,\s]+/)
+    .map((target) => target.trim())
+    .filter((target) => target.length > 0);
 }
 
 
@@ -71,12 +280,23 @@ async function runIndex(parsed: ParsedArgs): Promise<void> {
     progress.finish();
     const info = await zvecGrep.info({ root: rootPath.absolutePath });
     printIndexResult("Indexed anonymous workspace", result, parsed.options, info.collection?.rootPaths);
+    persistExplicitGlobalConfig(parsed.options, info.collection?.embedding?.provider);
   } catch (error) {
     progress.finish();
     throw error;
   } finally {
     await zvecGrep.close();
   }
+}
+
+
+async function runServe(parsed: ParsedArgs): Promise<void> {
+  if (parsed.positionals.length > 0) {
+    throw new Error("zg serve --mcp does not accept positional arguments");
+  }
+
+  const { runMcpServer } = await import("./mcp.js");
+  await runMcpServer(createServiceOptions(parsed.options, process.cwd()));
 }
 
 
@@ -168,6 +388,7 @@ async function runCollections(parsed: ParsedArgs): Promise<void> {
         progress.finish();
         const info = await zvecGrep.collections.info(name);
         printIndexResult(`Indexed collection ${name}`, result, parsed.options, info?.rootPaths);
+        persistExplicitGlobalConfig(parsed.options, info?.embedding?.provider);
       } catch (error) {
         progress.finish();
         throw error;
@@ -294,7 +515,7 @@ function normalizeRgInput(parsed: ParsedArgs): { queries: string[]; options: Cli
 }
 
 
-function createServiceOptions(
+export function createServiceOptions(
   options: CliOptions,
   root: string | undefined,
 ): CreateZvecGrepOptions {
@@ -315,6 +536,15 @@ function createServiceOptions(
     llamaGpu: options.llamaGpu ?? parseEnvLlamaGpu(process.env.ZVEC_GREP_LLAMA_GPU),
     embeddingParallelism: options.embeddingParallelism ?? parseEnvPositiveInteger(process.env.ZVEC_GREP_EMBED_PARALLELISM),
   };
+}
+
+
+function persistExplicitGlobalConfig(options: CliOptions, indexedProvider: string | undefined): void {
+  if (!updateGlobalConfigFromExplicitOptions(options, indexedProvider)) {
+    return;
+  }
+
+  console.log(`Global config: ${globalConfigPath()}`);
 }
 
 
@@ -344,6 +574,272 @@ function parseEnvPositiveInteger(value: string | undefined): number | undefined 
 
   const parsed = Number.parseInt(normalized, 10);
   return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+
+function resolveCodexHome(): string {
+  return resolve(process.env.CODEX_HOME ?? resolve(homedir(), ".codex"));
+}
+
+
+async function writeMarkedFile(options: {
+  path: string;
+  startMarker: string;
+  endMarker: string;
+  block: string;
+  force: boolean;
+  conflictPattern?: RegExp;
+  conflictMessage?: string;
+  removeConflict?: (existing: string) => string;
+}): Promise<void> {
+  let existing = await readTextFileIfExists(options.path);
+  const next = replaceMarkedBlock(existing, options.startMarker, options.endMarker, options.block);
+
+  if (next === null) {
+    existing = removeOrphanedMarkers(existing, options.startMarker, options.endMarker);
+  }
+
+  if (
+    next === null
+    && options.conflictPattern?.test(existing)
+  ) {
+    if (!options.force) {
+      throw new Error(options.conflictMessage ?? `Existing unmanaged configuration found in ${options.path}`);
+    }
+    existing = options.removeConflict ? options.removeConflict(existing) : existing;
+  }
+
+  await writeTextFileAtomic(options.path, next ?? appendMarkedBlock(existing, options.block));
+}
+
+
+async function writeTextFileAtomic(path: string, content: string): Promise<void> {
+  const targetPath = await resolveAtomicWriteTarget(path);
+  await mkdir(dirname(targetPath), { recursive: true });
+
+  const mode = await fileModeIfExists(targetPath);
+  const temporaryPath = `${targetPath}.${process.pid}.${randomUUID()}.tmp`;
+  let temporaryFile;
+
+  try {
+    temporaryFile = await open(temporaryPath, "wx", mode);
+    await temporaryFile.writeFile(content, "utf8");
+    await temporaryFile.sync();
+    await temporaryFile.close();
+    temporaryFile = undefined;
+
+    if (mode !== undefined) {
+      await chmod(temporaryPath, mode);
+    }
+    await rename(temporaryPath, targetPath);
+  } catch (error) {
+    await temporaryFile?.close().catch(() => undefined);
+    await unlink(temporaryPath).catch(() => undefined);
+    throw error;
+  }
+}
+
+
+async function resolveAtomicWriteTarget(path: string, visited = new Set<string>()): Promise<string> {
+  const absolutePath = resolve(path);
+  if (visited.has(absolutePath)) {
+    throw new Error(`Cannot atomically write through circular symbolic link: ${path}`);
+  }
+
+  try {
+    const file = await lstat(absolutePath);
+    if (!file.isSymbolicLink()) {
+      return absolutePath;
+    }
+
+    visited.add(absolutePath);
+    const link = await readlink(absolutePath);
+    return resolveAtomicWriteTarget(resolve(dirname(absolutePath), link), visited);
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return absolutePath;
+    }
+    throw error;
+  }
+}
+
+
+async function fileModeIfExists(path: string): Promise<number | undefined> {
+  try {
+    return (await stat(path)).mode & 0o777;
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+
+async function readTextFileIfExists(path: string): Promise<string> {
+  try {
+    return await readFile(path, "utf8");
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+      return "";
+    }
+    throw error;
+  }
+}
+
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return typeof error === "object" && error !== null && "code" in error;
+}
+
+
+function replaceMarkedBlock(
+  existing: string,
+  startMarker: string,
+  endMarker: string,
+  block: string,
+): string | null {
+  const lines = existing.split(/\r?\n/);
+  const markerLines = new Set<number>();
+  const ranges: Array<{ start: number; end: number; }> = [];
+  let pendingStart: number | undefined;
+
+  for (const [index, line] of lines.entries()) {
+    const trimmed = line.trim();
+    if (trimmed === startMarker) {
+      markerLines.add(index);
+      pendingStart = index;
+      continue;
+    }
+    if (trimmed === endMarker) {
+      markerLines.add(index);
+      if (pendingStart !== undefined) {
+        ranges.push({ start: pendingStart, end: index });
+        pendingStart = undefined;
+      }
+    }
+  }
+
+  const first = ranges[0];
+  if (!first) {
+    return null;
+  }
+
+  const before = retainedMarkedLines(lines, 0, first.start, markerLines, []).join("\n").trimEnd();
+  const after = retainedMarkedLines(
+    lines,
+    first.end + 1,
+    lines.length,
+    markerLines,
+    ranges.slice(1),
+  ).join("\n").trim();
+  return [before, block.trim(), after.trim()]
+    .filter((part) => part.length > 0)
+    .join("\n\n") + "\n";
+}
+
+
+function retainedMarkedLines(
+  lines: readonly string[],
+  start: number,
+  end: number,
+  markerLines: ReadonlySet<number>,
+  removedRanges: readonly { start: number; end: number; }[],
+): string[] {
+  const retained: string[] = [];
+  for (let index = start; index < end; index += 1) {
+    if (markerLines.has(index)) {
+      continue;
+    }
+    if (removedRanges.some((range) => index >= range.start && index <= range.end)) {
+      continue;
+    }
+    retained.push(lines[index]!);
+  }
+  return retained;
+}
+
+
+function removeOrphanedMarkers(
+  existing: string,
+  startMarker: string,
+  endMarker: string,
+): string {
+  return existing
+    .split(/\r?\n/)
+    .filter((line) => {
+      const trimmed = line.trim();
+      return trimmed !== startMarker && trimmed !== endMarker;
+    })
+    .join("\n")
+    .trimEnd() + "\n";
+}
+
+
+function appendMarkedBlock(existing: string, block: string): string {
+  const prefix = existing.trimEnd();
+  return `${prefix.length > 0 ? `${prefix}\n\n` : ""}${block.trim()}\n`;
+}
+
+
+function removeCodexMcpServerConfig(existing: string): string {
+  const lines = existing.split(/\r?\n/);
+  const kept: string[] = [];
+  let skipping = false;
+
+  for (const line of lines) {
+    const tableName = line.match(/^\s*\[([^\]]+)\]\s*$/)?.[1]?.trim();
+    if (tableName) {
+      skipping = tableName === "mcp_servers.zvec_grep" || tableName.startsWith("mcp_servers.zvec_grep.");
+    }
+
+    if (!skipping) {
+      kept.push(line);
+    }
+  }
+
+  return kept.join("\n").trimEnd() + "\n";
+}
+
+
+function codexConfigBlock(mcpToolTimeoutSeconds: number): string {
+  return `${ZVEC_GREP_CONFIG_START}
+[mcp_servers.zvec_grep]
+command = "zg"
+args = ["serve", "--mcp"]
+env_vars = [
+  "DASHSCOPE_API_KEY",
+  "QWEN_API_KEY",
+  "ZVEC_GREP_API_KEY",
+  "ZVEC_GREP_EMBEDDING",
+  "ZVEC_GREP_ENDPOINT",
+  "ZVEC_GREP_HOME",
+  "ZVEC_GREP_MODEL_CACHE",
+  "ZVEC_GREP_LLAMA_GPU",
+  "ZVEC_GREP_EMBED_PARALLELISM",
+  "NODE_LLAMA_CPP_CMAKE_OPTION_GGML_OPENMP",
+  "NODE_LLAMA_CPP_CMAKE_OPTION_GGML_NATIVE",
+  "NODE_LLAMA_CPP_CMAKE_OPTION_GGML_CPU_ARM_ARCH"
+]
+startup_timeout_sec = 20
+tool_timeout_sec = ${mcpToolTimeoutSeconds}
+default_tools_approval_mode = "auto"
+${ZVEC_GREP_CONFIG_END}`;
+}
+
+
+function codexAgentsBlock(): string {
+  return `${ZVEC_GREP_AGENTS_START}
+## zvec-grep
+
+Use zvec-grep before grep, rg, or broad file reads when you need to understand or locate code.
+
+- **MCP tools**: Use \`zvec_grep_search\` for indexed semantic/lexical code search and \`zvec_grep_rg\` for explicit no-index lexical search.
+- **Indexing and status**: These are CLI-only operations. If an index is missing, use \`zvec_grep_rg\` and mention \`zg --index\` as the opt-in setup path; use \`zg --status\` when status inspection is needed.
+- **Shell fallback**: If the MCP server is unavailable, use \`zg --status\`, \`zg "<query>"\`, and \`zg --rg "<pattern>"\`.
+
+Prefer focused include/exclude filters, and exclude dependencies, generated output, caches, build artifacts, and logs unless the task is about those files.
+${ZVEC_GREP_AGENTS_END}`;
 }
 
 

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -148,7 +148,7 @@ async function installCodexIntegration(options: InstallAgentOptions): Promise<In
     endMarker: ZVEC_GREP_CONFIG_END,
     block: codexConfigBlock(options.mcpToolTimeoutSeconds),
     force: options.force,
-    conflictPattern: /^\[mcp_servers\.zvec_grep\]/m,
+    hasConflict: hasCodexMcpServerConfig,
     conflictMessage: `Existing [mcp_servers.zvec_grep] found in ${configPath}. Re-run with --force after removing or moving that table into the zvec-grep managed block.`,
     removeConflict: removeCodexMcpServerConfig,
   });
@@ -588,7 +588,7 @@ async function writeMarkedFile(options: {
   endMarker: string;
   block: string;
   force: boolean;
-  conflictPattern?: RegExp;
+  hasConflict?: (existing: string) => boolean;
   conflictMessage?: string;
   removeConflict?: (existing: string) => string;
 }): Promise<void> {
@@ -601,7 +601,7 @@ async function writeMarkedFile(options: {
 
   if (
     next === null
-    && options.conflictPattern?.test(existing)
+    && options.hasConflict?.(existing)
   ) {
     if (!options.force) {
       throw new Error(options.conflictMessage ?? `Existing unmanaged configuration found in ${options.path}`);
@@ -782,15 +782,23 @@ function appendMarkedBlock(existing: string, block: string): string {
 }
 
 
+function hasCodexMcpServerConfig(existing: string): boolean {
+  return existing.split(/\r?\n/).some((line) => {
+    const tableName = tomlTableName(line);
+    return tableName !== undefined && isCodexMcpServerTableName(tableName);
+  });
+}
+
+
 function removeCodexMcpServerConfig(existing: string): string {
   const lines = existing.split(/\r?\n/);
   const kept: string[] = [];
   let skipping = false;
 
   for (const line of lines) {
-    const tableName = line.match(/^\s*\[([^\]]+)\]\s*$/)?.[1]?.trim();
-    if (tableName) {
-      skipping = tableName === "mcp_servers.zvec_grep" || tableName.startsWith("mcp_servers.zvec_grep.");
+    const tableName = tomlTableName(line);
+    if (tableName !== undefined) {
+      skipping = isCodexMcpServerTableName(tableName);
     }
 
     if (!skipping) {
@@ -799,6 +807,16 @@ function removeCodexMcpServerConfig(existing: string): string {
   }
 
   return kept.join("\n").trimEnd() + "\n";
+}
+
+
+function tomlTableName(line: string): string | undefined {
+  return line.match(/^\s*\[([^\]]+)\]\s*(?:#.*)?$/)?.[1]?.trim();
+}
+
+
+function isCodexMcpServerTableName(tableName: string): boolean {
+  return /^(?:mcp_servers|"mcp_servers"|'mcp_servers')\s*\.\s*(?:zvec_grep|"zvec_grep"|'zvec_grep')(?:\s*\.|$)/.test(tableName);
 }
 
 

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -14,6 +14,8 @@ Usage:
   zg --index --embedding local/embeddinggemma-300m [root]
   zg --disable-index [root]
   zg --status [root]
+  zg install [--target codex|all|auto] [--mcp-tool-timeout <seconds>] [--yes] [--force]
+  zg serve --mcp
   zg --collection <name> [options] <query...>
   zg --collections
   zg --collections info <name>
@@ -34,7 +36,9 @@ Query:
   Use --disable-index to remember that this workspace should not be indexed.
   Existing anonymous indexes are checked and incrementally refreshed before query.
   Indexing skips dependency/third-party/generated/build/cache dirs, hidden paths, nested git repos, .gitignore entries, and files over 1 MB by default.
-  New indexes require --embedding <model> or ZVEC_GREP_EMBEDDING; existing indexes reuse stored schema.
+  New indexes require --embedding <model>, ZVEC_GREP_EMBEDDING, or defaults.embedding in ~/.zvec-grep/config.json; existing indexes reuse stored schema.
+  Successful index commands persist explicitly passed global model/provider options to ~/.zvec-grep/config.json.
+  CLI options override environment variables, which override global config. Environment-only values are not persisted.
   --rg is explicit exhaustive ripgrep search and works without an index.
   Without --limit, --rg returns every match.
   --rg uses rg regex syntax by default. Use -F/--fixed-strings for literal text.
@@ -59,6 +63,11 @@ Options:
   --no-fallback                   Compatibility flag; anonymous queries already require an index
   --collection <name>             Query a named collection
   --collections                   Manage named collections
+  --target <agent>                Agent install target; currently codex, all, auto, none
+  --mcp-tool-timeout <seconds>    Codex MCP tool timeout written during install (default 600)
+  --yes                           Use default install choices without prompting
+  --force                         Replace an existing agent integration during install
+  --mcp                           Run stdio MCP server with zg serve
   --home <path>                   Named collection registry home
   --embedding <model>             Embedding model, e.g. local/embeddinggemma-300m or qwen/text-embedding-v4
   --model-cache <path>            Local model cache directory
@@ -66,8 +75,8 @@ Options:
   --no-gpu                        Force CPU local embeddings
   --llama-gpu <mode>              CPU by default; auto, metal, vulkan, cuda, off
   --embedding-parallelism <n>     Local embedding context parallelism
-  --api-key <key>                 Embedding provider API key
-  --endpoint <url>                Embedding provider endpoint
+  --api-key <key>                 Embedding provider API key; explicit index values are persisted globally
+  --endpoint <url>                Provider endpoint; explicit index values are persisted globally
   --include <glob>                Include indexed/query paths
   --exclude <glob>                Exclude indexed/query paths
   --modified-after <time>         Query files modified after time
@@ -77,6 +86,10 @@ Options:
   --rebuild                       Rebuild on --index/collections index
   --reset-paths                   Clear inherited include/exclude filters on rebuild
 
+Global config:
+  ~/.zvec-grep/config.json        Global model defaults and provider credentials (user-only permissions)
+                                  Running MCP servers reload provider settings on the next model request
+
 Environment:
   ZVEC_GREP_HOME
   ZVEC_GREP_EMBEDDING
@@ -85,6 +98,7 @@ Environment:
   ZVEC_GREP_EMBED_PARALLELISM
   ZVEC_GREP_API_KEY
   ZVEC_GREP_ENDPOINT
+  NODE_LLAMA_CPP_CMAKE_OPTION_<name>
   NO_COLOR
 `);
 }

--- a/src/cli/mcp.ts
+++ b/src/cli/mcp.ts
@@ -1,0 +1,381 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+import {
+  createZvecGrep,
+  type CodeSymbolType,
+  type CreateZvecGrepOptions,
+  type ZvecGrep,
+  type ZvecGrepContextOptions,
+  type ZvecGrepContextResult,
+  type ZvecGrepSearchOptions,
+} from "../index.js";
+import { parseModifiedTime, splitPathFilters } from "./args.js";
+import { readPackageVersion } from "./version.js";
+
+
+const stringListInputSchema = z.union([z.string(), z.array(z.string())]).optional();
+const timeInputSchema = z.union([z.number().int().nonnegative(), z.string()]).optional();
+const codeSymbolTypeSchema = z.enum(["module", "class", "interface", "function", "value", "alias"]);
+
+
+type StringListInput = z.infer<typeof stringListInputSchema>;
+type TimeInput = z.infer<typeof timeInputSchema>;
+
+
+export async function runMcpServer(options: CreateZvecGrepOptions): Promise<void> {
+  const zvecGrep = await createZvecGrep(options);
+  const server = createMcpServer(zvecGrep);
+  const transport = new StdioServerTransport();
+
+  const close = async () => {
+    await zvecGrep.close();
+    await server.close();
+  };
+  process.once("SIGINT", () => {
+    void close().finally(() => process.exit(130));
+  });
+  process.once("SIGTERM", () => {
+    void close().finally(() => process.exit(143));
+  });
+
+  await server.connect(transport);
+}
+
+
+function createMcpServer(zvecGrep: ZvecGrep): McpServer {
+  const server = new McpServer(
+    {
+      name: "zvec-grep",
+      version: readPackageVersion(),
+    },
+    {
+      instructions: [
+        "Use zvec-grep for repository code search before grep, rg, or broad file reads.",
+        "Use zvec_grep_search for indexed semantic and lexical retrieval, and zvec_grep_rg for explicit no-index lexical search.",
+        "Index management and status inspection are CLI-only operations.",
+      ].join(" "),
+    },
+  );
+
+  server.registerTool(
+    "zvec_grep_search",
+    {
+      title: "zvec-grep indexed search",
+      description: "Search an indexed repository with zvec-grep hybrid semantic and lexical retrieval. Like the CLI, this may refresh a stale anonymous index unless autoUpdate is false.",
+      inputSchema: {
+        query: z.string().optional().describe("Natural-language or exact search query."),
+        queries: stringListInputSchema.describe("Multiple query groups. Use this for related concepts."),
+        fts: stringListInputSchema.describe("Exact lexical anchors, such as symbols, flags, or error messages."),
+        vector: stringListInputSchema.describe("Explicit semantic/vector-only queries."),
+        root: z.string().optional().describe("Repository root. Defaults to the MCP server working directory."),
+        collection: z.string().optional().describe("Named collection to query instead of the anonymous repository index."),
+        limit: z.number().int().positive().max(50).optional().describe("Maximum returned items per query/group."),
+        include: stringListInputSchema.describe("Glob filters for paths to include. Accepts an array or CLI-style comma-separated string."),
+        exclude: stringListInputSchema.describe("Glob filters for paths to exclude. Accepts an array or CLI-style comma-separated string."),
+        preferSymbol: z.boolean().optional().describe("Prefer exact indexed symbols when query names a symbol."),
+        symbolTypes: z.array(codeSymbolTypeSchema).default([]).describe("Restrict indexed results to symbol types."),
+        modifiedAfter: timeInputSchema.describe("Only query files modified after this time. Accepts epoch milliseconds or a parseable date string."),
+        modifiedBefore: timeInputSchema.describe("Only query files modified before this time. Accepts epoch milliseconds or a parseable date string."),
+        autoUpdate: z.boolean().optional().describe("Refresh an existing stale anonymous index before query. Defaults to CLI behavior: true."),
+        embeddingConcurrency: z.number().int().positive().max(64).optional().describe("Embedding task concurrency for automatic index refresh."),
+        trace: z.boolean().optional().describe("Include per-hit search trace in structured output."),
+        maxContentChars: z.number().int().positive().max(6000).default(1200).describe("Maximum source characters to include per hit."),
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    async (input) => {
+      const result = await zvecGrep.context(contextOptionsFromSearchInput(input));
+      return toolResult(contextText(result, input.maxContentChars), {
+        result: simplifyContextResult(result, input.maxContentChars),
+      });
+    },
+  );
+
+  server.registerTool(
+    "zvec_grep_rg",
+    {
+      title: "zvec-grep no-index lexical search",
+      description: "Run explicit no-index lexical search through zvec-grep managed ripgrep output.",
+      inputSchema: {
+        pattern: z.string().optional().describe("Regex or literal pattern to search for."),
+        patterns: stringListInputSchema.describe("Multiple regex or literal patterns to search for."),
+        root: z.string().optional().describe("Repository root. Defaults to the MCP server working directory."),
+        paths: stringListInputSchema.describe("Optional paths to search within the root."),
+        fixedStrings: z.boolean().optional().describe("Treat pattern as a literal string."),
+        ignoreCase: z.boolean().optional().describe("Search case-insensitively."),
+        wordRegexp: z.boolean().optional().describe("Only match whole words."),
+        context: z.number().int().nonnegative().max(20).optional().describe("Context lines before and after each match."),
+        beforeContext: z.number().int().nonnegative().max(20).optional().describe("Context lines before each match."),
+        afterContext: z.number().int().nonnegative().max(20).optional().describe("Context lines after each match."),
+        hidden: z.boolean().optional().describe("Search hidden files and directories."),
+        glob: stringListInputSchema.describe("ripgrep glob filters, for example '*.ts' or '!dist/**'. Accepts an array or CLI-style comma-separated string."),
+        limit: z.number().int().positive().max(200).optional().describe("Maximum returned matches."),
+        maxContentChars: z.number().int().positive().max(6000).default(1200).describe("Maximum source characters to include per hit."),
+      },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async (input) => {
+      const result = await zvecGrep.context(contextOptionsFromRgInput(input));
+      return toolResult(contextText(result, input.maxContentChars), {
+        result: simplifyContextResult(result, input.maxContentChars),
+      });
+    },
+  );
+
+  return server;
+}
+
+
+function contextOptionsFromSearchInput(input: {
+  query?: string;
+  queries?: StringListInput;
+  fts?: StringListInput;
+  vector?: StringListInput;
+  root?: string;
+  collection?: string;
+  limit?: number;
+  include?: StringListInput;
+  exclude?: StringListInput;
+  preferSymbol?: boolean;
+  symbolTypes: CodeSymbolType[];
+  modifiedAfter?: TimeInput;
+  modifiedBefore?: TimeInput;
+  autoUpdate?: boolean;
+  embeddingConcurrency?: number;
+  trace?: boolean;
+}): ZvecGrepContextOptions {
+  const queries = [
+    ...normalizeQueryList(input.query),
+    ...normalizeQueryList(input.queries),
+  ];
+  const fts = normalizeQueryList(input.fts);
+  const vector = normalizeQueryList(input.vector);
+  if (queries.length === 0 && fts.length === 0 && vector.length === 0) {
+    throw new Error("zvec_grep_search requires query, queries, fts, or vector.");
+  }
+
+  const includePaths = normalizePathFilters(input.include);
+  const excludePaths = normalizePathFilters(input.exclude);
+  return {
+    queries: queries.length > 0 ? queries : undefined,
+    routes: [
+      ...fts.map((query) => ({ mode: "fts" as const, query })),
+      ...vector.map((query) => ({ mode: "vector" as const, query })),
+    ],
+    root: normalizeOptionalString(input.root),
+    collection: normalizeOptionalString(input.collection),
+    limit: input.limit,
+    fallback: "disabled",
+    autoUpdate: input.autoUpdate ?? true,
+    trace: input.trace,
+    preferSymbol: input.preferSymbol,
+    symbolTypes: input.symbolTypes.length > 0 ? input.symbolTypes : undefined,
+    includePaths: includePaths.length > 0 ? includePaths : undefined,
+    excludePaths: excludePaths.length > 0 ? excludePaths : undefined,
+    modifiedAfter: normalizeModifiedTime(input.modifiedAfter, "modifiedAfter"),
+    modifiedBefore: normalizeModifiedTime(input.modifiedBefore, "modifiedBefore"),
+    embeddingConcurrency: input.embeddingConcurrency,
+  };
+}
+
+
+function contextOptionsFromRgInput(input: {
+  pattern?: string;
+  patterns?: StringListInput;
+  root?: string;
+  paths?: StringListInput;
+  fixedStrings?: boolean;
+  ignoreCase?: boolean;
+  wordRegexp?: boolean;
+  context?: number;
+  beforeContext?: number;
+  afterContext?: number;
+  hidden?: boolean;
+  glob?: StringListInput;
+  limit?: number;
+}): ZvecGrepContextOptions {
+  const queries = [
+    ...normalizeQueryList(input.pattern),
+    ...normalizeQueryList(input.patterns),
+  ];
+  if (queries.length === 0) {
+    throw new Error("zvec_grep_rg requires pattern or patterns.");
+  }
+
+  const { includePaths, excludePaths } = pathFiltersFromRgGlobs(input.glob);
+  const rgOptions: ZvecGrepSearchOptions = {
+    fixedStrings: input.fixedStrings,
+    ignoreCase: input.ignoreCase,
+    wordRegexp: input.wordRegexp,
+    beforeContext: input.beforeContext ?? input.context,
+    afterContext: input.afterContext ?? input.context,
+    hidden: input.hidden,
+  };
+  return {
+    queries,
+    rg: true,
+    rgOptions,
+    rgPaths: normalizePlainStringList(input.paths),
+    root: normalizeOptionalString(input.root),
+    limit: input.limit,
+    includePaths,
+    excludePaths,
+  };
+}
+
+
+function pathFiltersFromRgGlobs(value: StringListInput): {
+  includePaths?: string[];
+  excludePaths?: string[];
+} {
+  const includePaths: string[] = [];
+  const excludePaths: string[] = [];
+  for (const glob of normalizePathFilters(value)) {
+    if (glob.startsWith("!")) {
+      const exclude = glob.slice(1).trim();
+      if (exclude.length > 0) {
+        excludePaths.push(exclude);
+      }
+      continue;
+    }
+    includePaths.push(glob);
+  }
+
+  return {
+    includePaths: includePaths.length > 0 ? includePaths : undefined,
+    excludePaths: excludePaths.length > 0 ? excludePaths : undefined,
+  };
+}
+
+
+function normalizeQueryList(value: StringListInput): string[] {
+  return normalizePlainStringList(value) ?? [];
+}
+
+
+function normalizePlainStringList(value: StringListInput): string[] | undefined {
+  const items = value === undefined
+    ? []
+    : Array.isArray(value)
+      ? value
+      : [value];
+  const normalized = items
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+
+function normalizePathFilters(value: StringListInput): string[] {
+  const items = value === undefined
+    ? []
+    : Array.isArray(value)
+      ? value
+      : [value];
+  return items.flatMap(splitPathFilters);
+}
+
+
+function normalizeModifiedTime(value: TimeInput, option: string): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  return typeof value === "number" ? value : parseModifiedTime(value, option);
+}
+
+
+function normalizeOptionalString(value: string | undefined): string | undefined {
+  const normalized = value?.trim() ?? "";
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+
+function toolResult(text: string, structuredContent: Record<string, unknown>) {
+  return {
+    content: [{ type: "text" as const, text }],
+    structuredContent,
+  };
+}
+
+
+function contextText(result: ZvecGrepContextResult, maxContentChars: number): string {
+  const lines = [
+    `query: ${result.query}`,
+    `root: ${result.root}`,
+    `source: ${result.source}`,
+    `coverage: ${result.coverage}`,
+    `hits: ${result.items.length}`,
+  ];
+
+  for (const item of result.items) {
+    lines.push("");
+    lines.push(`${item.file.relativePath}:${rangeLabel(item.range)} rank=${item.rank} matchedBy=${item.matchedBy}`);
+    if (item.outline) {
+      lines.push(`outline: ${truncate(item.outline, maxContentChars)}`);
+    }
+    lines.push("source:");
+    lines.push(truncate(item.content, maxContentChars));
+  }
+
+  return lines.join("\n");
+}
+
+
+function simplifyContextResult(result: ZvecGrepContextResult, maxContentChars: number): Record<string, unknown> {
+  return {
+    query: result.query,
+    root: result.root,
+    source: result.source,
+    coverage: result.coverage,
+    collection: result.collection,
+    diagnostics: result.diagnostics,
+    items: result.items.map((item) => ({
+      kind: item.kind,
+      rank: item.rank,
+      file: item.file,
+      range: item.range,
+      excerptRange: item.excerptRange,
+      outline: item.outline ? truncate(item.outline, maxContentChars) : undefined,
+      content: truncate(item.content, maxContentChars),
+      contentRole: item.contentRole,
+      status: item.status,
+      score: item.score,
+      matchedBy: item.matchedBy,
+      metadata: item.metadata,
+      entityId: item.entityId,
+      container: item.container,
+      trace: item.trace,
+    })),
+  };
+}
+
+
+function rangeLabel(range: { kind: string; startLine?: number; endLine?: number; startOffset?: number; endOffset?: number; }): string {
+  if (range.kind === "text" && typeof range.startLine === "number" && typeof range.endLine === "number") {
+    return `${range.startLine}-${range.endLine}`;
+  }
+  if (typeof range.startOffset === "number" && typeof range.endOffset === "number") {
+    return `${range.startOffset}-${range.endOffset}`;
+  }
+  return range.kind;
+}
+
+
+function truncate(value: string, maxChars: number): string {
+  if (value.length <= maxChars) {
+    return value;
+  }
+
+  return `${value.slice(0, maxChars)}\n...[truncated ${value.length - maxChars} chars]`;
+}

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -23,6 +23,12 @@ export type CliOptions = {
   disableIndex?: boolean;
   status?: boolean;
   collections?: boolean;
+  install?: boolean;
+  serve?: boolean;
+  mcp?: boolean;
+  installTargets?: string[];
+  installMcpToolTimeoutSeconds?: number;
+  yes?: boolean;
   collection?: string;
   rg?: boolean;
   rgCompatibilityOptions?: string[];
@@ -43,6 +49,7 @@ export type CliOptions = {
   limit?: number;
   routes?: ZvecGrepContextRoute[];
   rebuild?: boolean;
+  force?: boolean;
   resetPaths?: boolean;
   noFallback?: boolean;
   noAutoUpdate?: boolean;

--- a/src/engine/config.ts
+++ b/src/engine/config.ts
@@ -1,0 +1,284 @@
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { EngineError } from "./errors/index.js";
+import type { LlamaGpuMode } from "./models/types.js";
+import { readJsonFileSync, writeJsonFileSync } from "./utils/json.js";
+import { acquireReadWriteLock } from "./utils/lock.js";
+
+
+export type ZvecGrepGlobalDefaults = {
+  embedding?: string;
+  modelCacheDir?: string;
+  llamaGpu?: LlamaGpuMode;
+  embeddingParallelism?: number;
+};
+
+
+export type ZvecGrepProviderConfig = {
+  apiKey?: string;
+  endpoint?: string;
+};
+
+
+export type ZvecGrepGlobalConfig = {
+  version: 1;
+  defaults?: ZvecGrepGlobalDefaults;
+  providers?: Record<string, ZvecGrepProviderConfig>;
+};
+
+
+export type ZvecGrepGlobalConfigUpdate = {
+  defaults?: ZvecGrepGlobalDefaults;
+  providers?: Record<string, ZvecGrepProviderConfig>;
+};
+
+
+export type ZvecGrepExplicitGlobalOptions = ZvecGrepGlobalDefaults & {
+  apiKey?: string;
+  endpoint?: string;
+};
+
+
+const GLOBAL_CONFIG_VERSION = 1;
+const GLOBAL_CONFIG_DIRECTORY_MODE = 0o700;
+const GLOBAL_CONFIG_FILE_MODE = 0o600;
+
+
+export function globalConfigPath(): string {
+  return resolve(homedir(), ".zvec-grep", "config.json");
+}
+
+
+export function readGlobalConfig(path = globalConfigPath()): ZvecGrepGlobalConfig {
+  const value = readJsonFileSync<unknown>(path, null);
+  if (value === null) {
+    return emptyGlobalConfig();
+  }
+
+  return parseGlobalConfig(value, path);
+}
+
+
+export function updateGlobalConfig(
+  update: ZvecGrepGlobalConfigUpdate,
+  path = globalConfigPath(),
+): ZvecGrepGlobalConfig {
+  const lock = acquireReadWriteLock(join(dirname(path), "locks", "config"), "write", {
+    operation: "global-config.update",
+  });
+  try {
+    const current = readGlobalConfig(path);
+    const next = parseGlobalConfig({
+      version: GLOBAL_CONFIG_VERSION,
+      defaults: {
+        ...current.defaults,
+        ...update.defaults,
+      },
+      providers: mergeProviderConfigs(current.providers, update.providers),
+    }, path);
+
+    writeJsonFileSync(path, next, {
+      directoryMode: GLOBAL_CONFIG_DIRECTORY_MODE,
+      fileMode: GLOBAL_CONFIG_FILE_MODE,
+    });
+    return next;
+  } finally {
+    lock.release();
+  }
+}
+
+
+export function updateGlobalConfigFromExplicitOptions(
+  options: ZvecGrepExplicitGlobalOptions,
+  indexedProvider?: string,
+  path = globalConfigPath(),
+): boolean {
+  const defaults: ZvecGrepGlobalDefaults = {
+    ...(options.embedding !== undefined ? { embedding: options.embedding } : {}),
+    ...(options.modelCacheDir !== undefined ? { modelCacheDir: options.modelCacheDir } : {}),
+    ...(options.llamaGpu !== undefined ? { llamaGpu: options.llamaGpu } : {}),
+    ...(options.embeddingParallelism !== undefined
+      ? { embeddingParallelism: options.embeddingParallelism }
+      : {}),
+  };
+  const provider = providerFromEmbedding(options.embedding) ?? indexedProvider;
+  const providerConfig: ZvecGrepProviderConfig = provider && provider !== "local"
+    ? {
+      ...(options.apiKey !== undefined ? { apiKey: options.apiKey } : {}),
+      ...(options.endpoint !== undefined ? { endpoint: options.endpoint } : {}),
+    }
+    : {};
+  const update: ZvecGrepGlobalConfigUpdate = {
+    ...(Object.keys(defaults).length > 0 ? { defaults } : {}),
+    ...(provider && Object.keys(providerConfig).length > 0
+      ? { providers: { [provider]: providerConfig } }
+      : {}),
+  };
+
+  if (!update.defaults && !update.providers) {
+    return false;
+  }
+
+  updateGlobalConfig(update, path);
+  return true;
+}
+
+
+function emptyGlobalConfig(): ZvecGrepGlobalConfig {
+  return { version: GLOBAL_CONFIG_VERSION };
+}
+
+
+function providerFromEmbedding(embedding: string | undefined): string | undefined {
+  if (!embedding) {
+    return undefined;
+  }
+  const separator = embedding.indexOf("/");
+  return separator > 0 ? embedding.slice(0, separator) : undefined;
+}
+
+
+function parseGlobalConfig(value: unknown, path: string): ZvecGrepGlobalConfig {
+  if (!isRecord(value) || value.version !== GLOBAL_CONFIG_VERSION) {
+    throw invalidConfig(path, "version must be 1");
+  }
+
+  const defaults = parseDefaults(value.defaults, path);
+  const providers = parseProviders(value.providers, path);
+  return {
+    version: GLOBAL_CONFIG_VERSION,
+    ...(defaults ? { defaults } : {}),
+    ...(providers ? { providers } : {}),
+  };
+}
+
+
+function parseDefaults(value: unknown, path: string): ZvecGrepGlobalDefaults | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!isRecord(value)) {
+    throw invalidConfig(path, "defaults must be an object");
+  }
+
+  const embedding = optionalNonEmptyString(value.embedding, path, "defaults.embedding");
+  const modelCacheDir = optionalNonEmptyString(value.modelCacheDir, path, "defaults.modelCacheDir");
+  const llamaGpu = optionalLlamaGpu(value.llamaGpu, path);
+  const embeddingParallelism = optionalPositiveInteger(
+    value.embeddingParallelism,
+    path,
+    "defaults.embeddingParallelism",
+  );
+  const defaults: ZvecGrepGlobalDefaults = {
+    ...(embedding ? { embedding } : {}),
+    ...(modelCacheDir ? { modelCacheDir } : {}),
+    ...(llamaGpu !== undefined ? { llamaGpu } : {}),
+    ...(embeddingParallelism !== undefined ? { embeddingParallelism } : {}),
+  };
+  return Object.keys(defaults).length > 0 ? defaults : undefined;
+}
+
+
+function parseProviders(
+  value: unknown,
+  path: string,
+): Record<string, ZvecGrepProviderConfig> | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!isRecord(value)) {
+    throw invalidConfig(path, "providers must be an object");
+  }
+
+  const providers: Record<string, ZvecGrepProviderConfig> = {};
+  for (const [provider, providerValue] of Object.entries(value)) {
+    if (!/^[a-z][a-z0-9_-]*$/.test(provider) || !isRecord(providerValue)) {
+      throw invalidConfig(path, `providers.${provider} must be an object with a valid provider name`);
+    }
+
+    const apiKey = optionalNonEmptyString(providerValue.apiKey, path, `providers.${provider}.apiKey`);
+    const endpoint = optionalNonEmptyString(providerValue.endpoint, path, `providers.${provider}.endpoint`);
+    const config: ZvecGrepProviderConfig = {
+      ...(apiKey ? { apiKey } : {}),
+      ...(endpoint ? { endpoint } : {}),
+    };
+    if (Object.keys(config).length > 0) {
+      providers[provider] = config;
+    }
+  }
+
+  return Object.keys(providers).length > 0 ? providers : undefined;
+}
+
+
+function mergeProviderConfigs(
+  current: Record<string, ZvecGrepProviderConfig> | undefined,
+  update: Record<string, ZvecGrepProviderConfig> | undefined,
+): Record<string, ZvecGrepProviderConfig> | undefined {
+  if (!current && !update) {
+    return undefined;
+  }
+
+  const merged = { ...current };
+  for (const [provider, config] of Object.entries(update ?? {})) {
+    merged[provider] = {
+      ...merged[provider],
+      ...config,
+    };
+  }
+  return merged;
+}
+
+
+function optionalNonEmptyString(
+  value: unknown,
+  path: string,
+  field: string,
+): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw invalidConfig(path, `${field} must be a non-empty string`);
+  }
+  return value.trim();
+}
+
+
+function optionalPositiveInteger(
+  value: unknown,
+  path: string,
+  field: string,
+): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!Number.isInteger(value) || (value as number) <= 0) {
+    throw invalidConfig(path, `${field} must be a positive integer`);
+  }
+  return value as number;
+}
+
+
+function optionalLlamaGpu(value: unknown, path: string): LlamaGpuMode | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (value === false || value === "auto" || value === "metal" || value === "vulkan" || value === "cuda") {
+    return value;
+  }
+  throw invalidConfig(path, "defaults.llamaGpu must be auto, metal, vulkan, cuda, or false");
+}
+
+
+function invalidConfig(path: string, detail: string): EngineError {
+  return new EngineError("zvec-grep global config is invalid", {
+    code: "ZVEC_GREP.ENGINE.CONFIG.INVALID",
+    context: `path=${path}\ndetail=${detail}`,
+  });
+}
+
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/engine/models/providers/llama-cpp/embedding.ts
+++ b/src/engine/models/providers/llama-cpp/embedding.ts
@@ -59,6 +59,13 @@ type NodeLlamaCppLoader = () => Promise<NodeLlamaCppModule>;
 const DEFAULT_MODEL_CACHE_DIR = join(defaultHome(), "models");
 const GGUF_MAGIC = Buffer.from("GGUF");
 const DEFAULT_PARALLELISM_CAP = 8;
+const DEFAULT_DARWIN_CMAKE_OPTIONS = {
+  GGML_OPENMP: "OFF",
+} as const;
+const DEFAULT_DARWIN_ARM64_CMAKE_OPTIONS = {
+  ...DEFAULT_DARWIN_CMAKE_OPTIONS,
+  GGML_NATIVE: "OFF",
+} as const;
 const SUPPRESSED_LLAMA_CPP_LOG_MESSAGES = new Set([
   "Failed to get swap info",
 ]);
@@ -240,6 +247,7 @@ export class LlamaCppEmbeddingModel extends EmbeddingModel {
       logLevel: runtime.LlamaLogLevel?.error,
       logger: llamaCppLogger,
       gpu,
+      cmakeOptions: defaultLlamaCppCmakeOptions(),
       progressLogs: false,
     });
 
@@ -551,6 +559,21 @@ function formatLlamaCppLogMessage(message: string): string {
     .split("\n")
     .map((line) => `[node-llama-cpp] ${line}`)
     .join("\n")}\n`;
+}
+
+
+function defaultLlamaCppCmakeOptions(): Record<string, string> | undefined {
+  if (process.platform !== "darwin") {
+    return undefined;
+  }
+
+  // macOS machines commonly lack libomp, and Apple Clang's native ARM flag
+  // probe emits a scary CMake warning despite falling back successfully.
+  if (process.arch === "arm64") {
+    return { ...DEFAULT_DARWIN_ARM64_CMAKE_OPTIONS };
+  }
+
+  return { ...DEFAULT_DARWIN_CMAKE_OPTIONS };
 }
 
 

--- a/src/engine/models/providers/qwen/embedding.ts
+++ b/src/engine/models/providers/qwen/embedding.ts
@@ -1,4 +1,5 @@
 import { EngineError } from "../../../errors/index.js";
+import { globalConfigPath } from "../../../config.js";
 import type { Content, ImageFormat, TextContent } from "../../../types.js";
 import {
   EmbeddingModel,
@@ -41,7 +42,7 @@ export class QwenTextEmbeddingV4Model extends EmbeddingModel {
     if (options.apiKey.trim().length === 0) {
       throw new EngineError("Qwen text-embedding-v4 model requires an API key", {
         code: "ZVEC_GREP.ENGINE.MODELS.QWEN_TEXT_EMBEDDING_V4_MISSING_API_KEY",
-        context: `model=${this.ref.model}`,
+        context: `model=${this.ref.model}\nhint=Pass --api-key, set ZVEC_GREP_API_KEY, or configure providers.qwen.apiKey in ${globalConfigPath()}.`,
       });
     }
 
@@ -192,7 +193,7 @@ export class Qwen3VlEmbeddingModel extends EmbeddingModel {
     if (options.apiKey.trim().length === 0) {
       throw new EngineError("Qwen3 VL embedding model requires an API key", {
         code: "ZVEC_GREP.ENGINE.MODELS.QWEN3_VL_EMBEDDING_MISSING_API_KEY",
-        context: `model=${this.ref.model}`,
+        context: `model=${this.ref.model}\nhint=Pass --api-key, set ZVEC_GREP_API_KEY, or configure providers.qwen.apiKey in ${globalConfigPath()}.`,
       });
     }
 

--- a/src/engine/service/index.ts
+++ b/src/engine/service/index.ts
@@ -23,4 +23,5 @@ export type {
   ZvecGrepInfoResult,
   ZvecGrepIndexOptions,
   ZvecGrepLexicalFallbackDiagnostics,
+  ZvecGrepSearchOptions,
 } from "./types.js";

--- a/src/engine/service/zvec-grep.ts
+++ b/src/engine/service/zvec-grep.ts
@@ -2,6 +2,11 @@ import { mkdirSync, readdirSync, readFileSync, statSync, unlinkSync, writeFileSy
 import { createHash } from "node:crypto";
 import { dirname, join, relative, resolve } from "node:path";
 import {
+  globalConfigPath,
+  readGlobalConfig,
+  type ZvecGrepGlobalConfig,
+} from "../config.js";
+import {
   Collection,
   CollectionRegistry,
   isCollectionIndexed,
@@ -60,6 +65,7 @@ import { enrichLexicalItemsWithStructure } from "./structure-enrichment.js";
 const DEFAULT_CONTEXT_LIMIT = 10;
 const DEFAULT_CONTEXT_TOTAL_LIMIT = 30;
 const DEFAULT_LOCAL_EMBEDDING = "local/embeddinggemma-300m";
+const MAX_RECOVERED_EMBEDDING_MODELS = 4;
 
 
 export async function createZvecGrep(options: CreateZvecGrepOptions = {}): Promise<ZvecGrep> {
@@ -71,15 +77,15 @@ class ZvecGrepService implements ZvecGrep {
   readonly root: string;
   readonly collections: ZvecGrepCollections;
   private readonly embeddingModel?: EmbeddingModel;
-  private readonly embeddingModelExplicit: boolean;
   private readonly recoveredEmbeddingModels = new Map<string, EmbeddingModel>();
+  private readonly retiredEmbeddingModels = new Set<EmbeddingModel>();
+  private activeEmbeddingModelOperations = 0;
   private closed = false;
 
 
   constructor(private readonly options: CreateZvecGrepOptions) {
     this.root = resolveZvecGrepRoot(options.root);
-    this.embeddingModelExplicit = hasExplicitEmbeddingModel(options);
-    this.embeddingModel = resolveEmbeddingModel(options, this.root);
+    this.embeddingModel = options.embeddingModel;
     this.collections = {
       list: () => this.listCollections(),
       info: (name) => this.collectionInfo(name),
@@ -94,50 +100,54 @@ class ZvecGrepService implements ZvecGrep {
     this.ensureOpen();
     const root = resolveZvecGrepRoot(options.root ?? this.root);
     const location = anonymousIndexLocation(root);
-    return await withHomeWriteLock(location.home, options.rebuild ? "index.rebuild" : "index", async () => {
-      const existing = readCollectionInfo(location.home, ANONYMOUS_COLLECTION_NAME);
-      const embeddingModel = this.embeddingModelForIndex(existing, location.home, "index");
-      const registry = new CollectionRegistry(location.home, embeddingModel);
+    return await this.withEmbeddingModelOperation(() => withHomeWriteLock(
+      location.home,
+      options.rebuild ? "index.rebuild" : "index",
+      async () => {
+        const existing = readCollectionInfo(location.home, ANONYMOUS_COLLECTION_NAME);
+        const embeddingModel = this.embeddingModelForIndex(existing, location.home, "index");
+        const registry = new CollectionRegistry(location.home, embeddingModel);
 
-      try {
-        const rootPaths = resolveIndexRootPaths(
-          existing,
-          options.rootPaths,
-          root,
-          {
-            resetPaths: options.resetPaths === true,
-            includePaths: options.includePaths,
-            excludePaths: options.excludePaths,
-          },
-        );
-
-        if (options.rebuild) {
-          registry.remove(ANONYMOUS_COLLECTION_NAME);
-        }
-
-        const existingAfterRebuild = registry.get(ANONYMOUS_COLLECTION_NAME);
-        if (isCollectionIndexed(existingAfterRebuild)) {
-          assertCollectionEmbeddingMatchesCurrentModel(
-            existingAfterRebuild,
-            embeddingModel,
-            "zg --index --rebuild",
+        try {
+          const rootPaths = resolveIndexRootPaths(
+            existing,
+            options.rootPaths,
+            root,
+            {
+              resetPaths: options.resetPaths === true,
+              includePaths: options.includePaths,
+              excludePaths: options.excludePaths,
+            },
           );
-        }
-        registry.prepareIndex(
-          ANONYMOUS_COLLECTION_NAME,
-          rootPaths,
-          anonymousCollectionPath(root),
-        );
 
-        return await registry.open(ANONYMOUS_COLLECTION_NAME).index({
-          rebuild: false,
-          embeddingConcurrency: options.embeddingConcurrency,
-          onProgress: options.onProgress,
-        });
-      } finally {
-        registry.close();
-      }
-    });
+          if (options.rebuild) {
+            registry.remove(ANONYMOUS_COLLECTION_NAME);
+          }
+
+          const existingAfterRebuild = registry.get(ANONYMOUS_COLLECTION_NAME);
+          if (isCollectionIndexed(existingAfterRebuild)) {
+            assertCollectionEmbeddingMatchesCurrentModel(
+              existingAfterRebuild,
+              embeddingModel,
+              "zg --index --rebuild",
+            );
+          }
+          registry.prepareIndex(
+            ANONYMOUS_COLLECTION_NAME,
+            rootPaths,
+            anonymousCollectionPath(root),
+          );
+
+          return await registry.open(ANONYMOUS_COLLECTION_NAME).index({
+            rebuild: false,
+            embeddingConcurrency: options.embeddingConcurrency,
+            onProgress: options.onProgress,
+          });
+        } finally {
+          registry.close();
+        }
+      },
+    ));
   }
 
 
@@ -165,9 +175,11 @@ class ZvecGrepService implements ZvecGrep {
 
   async context(options: ZvecGrepContextOptions): Promise<ZvecGrepContextResult> {
     this.ensureOpen();
-    const timings = new TimingCollector();
-    const result = await timings.time("total", () => this.contextWithTimings(options, timings));
-    return withContextTimings(result, timings);
+    return await this.withEmbeddingModelOperation(async () => {
+      const timings = new TimingCollector();
+      const result = await timings.time("total", () => this.contextWithTimings(options, timings));
+      return withContextTimings(result, timings);
+    });
   }
 
 
@@ -260,8 +272,10 @@ class ZvecGrepService implements ZvecGrep {
     const models = new Set<EmbeddingModel>([
       ...(this.embeddingModel ? [this.embeddingModel] : []),
       ...this.recoveredEmbeddingModels.values(),
+      ...this.retiredEmbeddingModels,
     ]);
     this.recoveredEmbeddingModels.clear();
+    this.retiredEmbeddingModels.clear();
 
     for (const model of models) {
       await model.dispose();
@@ -317,49 +331,53 @@ class ZvecGrepService implements ZvecGrep {
   ): Promise<IndexResult> {
     this.ensureOpen();
     const home = serviceHome(this.options);
-    return await withHomeWriteLock(home, options.rebuild ? "collections.index.rebuild" : "collections.index", async () => {
-      const existing = readCollectionInfo(home, name);
-      const embeddingModel = this.embeddingModelForIndex(existing, home, "collections.index");
-      const registry = this.createRegistry(false, embeddingModel);
-      try {
-        const requestedRootPaths = paths === undefined
-          ? undefined
-          : Array.isArray(paths)
-            ? paths
-            : [paths];
-        const rootPaths = resolveIndexRootPaths(
-          existing,
-          requestedRootPaths,
-          this.root,
-          {
-            resetPaths: options.resetPaths === true,
-            includePaths: options.includePaths,
-            excludePaths: options.excludePaths,
-          },
-        );
-
-        if (options.rebuild) {
-          registry.remove(name);
-        }
-
-        const existingAfterRebuild = registry.get(name);
-        if (isCollectionIndexed(existingAfterRebuild)) {
-          assertCollectionEmbeddingMatchesCurrentModel(
-            existingAfterRebuild,
-            embeddingModel,
-            "zg --collections index <name> --rebuild",
+    return await this.withEmbeddingModelOperation(() => withHomeWriteLock(
+      home,
+      options.rebuild ? "collections.index.rebuild" : "collections.index",
+      async () => {
+        const existing = readCollectionInfo(home, name);
+        const embeddingModel = this.embeddingModelForIndex(existing, home, "collections.index");
+        const registry = this.createRegistry(false, embeddingModel);
+        try {
+          const requestedRootPaths = paths === undefined
+            ? undefined
+            : Array.isArray(paths)
+              ? paths
+              : [paths];
+          const rootPaths = resolveIndexRootPaths(
+            existing,
+            requestedRootPaths,
+            this.root,
+            {
+              resetPaths: options.resetPaths === true,
+              includePaths: options.includePaths,
+              excludePaths: options.excludePaths,
+            },
           );
-        }
-        registry.prepareIndex(name, rootPaths);
 
-        return await registry.open(name).index({
-          embeddingConcurrency: options.embeddingConcurrency,
-          onProgress: options.onProgress,
-        });
-      } finally {
-        registry.close();
-      }
-    });
+          if (options.rebuild) {
+            registry.remove(name);
+          }
+
+          const existingAfterRebuild = registry.get(name);
+          if (isCollectionIndexed(existingAfterRebuild)) {
+            assertCollectionEmbeddingMatchesCurrentModel(
+              existingAfterRebuild,
+              embeddingModel,
+              "zg --collections index <name> --rebuild",
+            );
+          }
+          registry.prepareIndex(name, rootPaths);
+
+          return await registry.open(name).index({
+            embeddingConcurrency: options.embeddingConcurrency,
+            onProgress: options.onProgress,
+          });
+        } finally {
+          registry.close();
+        }
+      },
+    ));
   }
 
 
@@ -699,11 +717,16 @@ class ZvecGrepService implements ZvecGrep {
     registryHome: string,
     operation: string,
   ): EmbeddingModel {
-    if (isCollectionIndexed(existing) && !this.embeddingModelExplicit) {
+    if (isCollectionIndexed(existing) && !this.embeddingModel && !this.options.embedding) {
       return this.recoverEmbeddingModel(existing.embedding, registryHome);
     }
 
-    return this.requireEmbeddingModel(operation);
+    const reference = this.options.embedding
+      ?? (this.options.defaultEmbedding === true ? DEFAULT_LOCAL_EMBEDDING : undefined);
+    return this.embeddingModel
+      ?? (reference ? this.embeddingModelFromReference(reference, registryHome) : undefined)
+      ?? this.configuredEmbeddingModel(registryHome)
+      ?? this.requireEmbeddingModel(operation);
   }
 
 
@@ -711,18 +734,89 @@ class ZvecGrepService implements ZvecGrep {
     schema: CollectionEmbeddingSchema,
     registryHome: string,
   ): EmbeddingModel {
-    const key = `${schema.provider}/${schema.model}/${modelCacheDir(this.options, this.root, registryHome)}`;
+    const config = readGlobalConfig();
+    const options = providerOptions(this.options, this.root, registryHome, schema.provider, config);
+    const key = `${schema.provider}/${schema.model}/${providerOptionsFingerprint(options)}`;
+    return this.cachedEmbeddingModel(key, () => createEmbeddingModel({
+      provider: schema.provider,
+      model: schema.model,
+    }, options));
+  }
+
+
+  private configuredEmbeddingModel(registryHome: string): EmbeddingModel | undefined {
+    const config = readGlobalConfig();
+    const reference = config.defaults?.embedding;
+    if (!reference) {
+      return undefined;
+    }
+
+    return this.embeddingModelFromReference(reference, registryHome, config);
+  }
+
+
+  private embeddingModelFromReference(
+    reference: string,
+    registryHome: string,
+    config: ZvecGrepGlobalConfig = readGlobalConfig(),
+  ): EmbeddingModel {
+    const provider = providerFromReference(reference);
+    const options = providerOptions(this.options, this.root, registryHome, provider, config);
+    const key = `configured/${reference}/${providerOptionsFingerprint(options)}`;
+    return this.cachedEmbeddingModel(key, () => createEmbeddingModelFromReference(reference, options));
+  }
+
+
+  private cachedEmbeddingModel(key: string, create: () => EmbeddingModel): EmbeddingModel {
     const cached = this.recoveredEmbeddingModels.get(key);
     if (cached) {
+      this.recoveredEmbeddingModels.delete(key);
+      this.recoveredEmbeddingModels.set(key, cached);
       return cached;
     }
 
-    const model = createEmbeddingModel({
-      provider: schema.provider,
-      model: schema.model,
-    }, providerOptions(this.options, this.root, registryHome));
+    const model = create();
     this.recoveredEmbeddingModels.set(key, model);
+    this.trimRecoveredEmbeddingModels();
     return model;
+  }
+
+
+  private trimRecoveredEmbeddingModels(): void {
+    while (this.recoveredEmbeddingModels.size > MAX_RECOVERED_EMBEDDING_MODELS) {
+      const oldestKey = this.recoveredEmbeddingModels.keys().next().value;
+      if (oldestKey === undefined) {
+        return;
+      }
+
+      const model = this.recoveredEmbeddingModels.get(oldestKey);
+      this.recoveredEmbeddingModels.delete(oldestKey);
+      if (model) {
+        this.retiredEmbeddingModels.add(model);
+      }
+    }
+  }
+
+
+  private async withEmbeddingModelOperation<T>(operation: () => Promise<T>): Promise<T> {
+    this.activeEmbeddingModelOperations += 1;
+    try {
+      return await operation();
+    } finally {
+      this.activeEmbeddingModelOperations -= 1;
+      if (this.activeEmbeddingModelOperations === 0) {
+        await this.disposeRetiredEmbeddingModels();
+      }
+    }
+  }
+
+
+  private async disposeRetiredEmbeddingModels(): Promise<void> {
+    const models = [...this.retiredEmbeddingModels];
+    this.retiredEmbeddingModels.clear();
+    for (const model of models) {
+      await model.dispose();
+    }
   }
 
 
@@ -732,7 +826,7 @@ class ZvecGrepService implements ZvecGrep {
         code: "ZVEC_GREP.ENGINE.SERVICE.EMBEDDING_MODEL_REQUIRED",
         context: errorDetails([
           detail("operation", operation),
-          detail("hint", 'Pass "--embedding <model>" or set ZVEC_GREP_EMBEDDING. Existing indexes can rerun --index without --embedding to reuse the stored schema.'),
+          detail("hint", `Pass "--embedding <model>", set ZVEC_GREP_EMBEDDING, or configure defaults.embedding in ${globalConfigPath()}. Existing indexes can rerun --index without --embedding to reuse the stored schema.`),
           detail("examples", "local/embeddinggemma-300m, qwen/text-embedding-v4"),
         ]),
       });
@@ -1002,38 +1096,6 @@ function applyRootPathFilterOverrides(
 }
 
 
-function resolveEmbeddingModel(
-  options: CreateZvecGrepOptions,
-  root: string,
-): EmbeddingModel | undefined {
-  if (options.embeddingModel) {
-    return options.embeddingModel;
-  }
-
-  if (options.embedding) {
-    return createEmbeddingModelFromReference(
-      options.embedding,
-      providerOptions(options, root),
-    );
-  }
-
-  if (options.defaultEmbedding === true) {
-    return createEmbeddingModelFromReference(
-      DEFAULT_LOCAL_EMBEDDING,
-      providerOptions(options, root),
-    );
-  }
-
-  return undefined;
-}
-
-
-function hasExplicitEmbeddingModel(options: CreateZvecGrepOptions): boolean {
-  return options.embeddingModel !== undefined
-    || options.embedding !== undefined;
-}
-
-
 function readCollectionInfo(home: string, name: string): CollectionInfo | null {
   const registry = new CollectionRegistry(home, undefined, true);
   try {
@@ -1063,14 +1125,45 @@ function providerOptions(
   options: CreateZvecGrepOptions,
   root: string,
   registryHome?: string,
+  provider?: string,
+  config: ZvecGrepGlobalConfig = readGlobalConfig(),
 ) {
+  const providerConfig = provider ? config.providers?.[provider] : undefined;
   return {
-    apiKey: options.apiKey ?? "",
-    endpoint: options.endpoint,
-    modelCacheDir: modelCacheDir(options, root, registryHome),
-    llamaGpu: options.llamaGpu,
-    embeddingParallelism: options.embeddingParallelism,
+    apiKey: options.apiKey ?? providerConfig?.apiKey ?? "",
+    endpoint: options.endpoint ?? providerConfig?.endpoint,
+    modelCacheDir: options.modelCacheDir
+      ?? process.env.ZVEC_GREP_MODEL_CACHE
+      ?? config.defaults?.modelCacheDir
+      ?? modelCacheDir(options, root, registryHome),
+    llamaGpu: options.llamaGpu ?? config.defaults?.llamaGpu,
+    embeddingParallelism: options.embeddingParallelism ?? config.defaults?.embeddingParallelism,
   };
+}
+
+
+function providerFromReference(reference: string): string | undefined {
+  const separator = reference.indexOf("/");
+  return separator > 0 ? reference.slice(0, separator) : undefined;
+}
+
+
+function providerOptionsFingerprint(options: {
+  apiKey: string;
+  endpoint?: string;
+  modelCacheDir?: string;
+  llamaGpu?: "auto" | "metal" | "vulkan" | "cuda" | false;
+  embeddingParallelism?: number;
+}): string {
+  return createHash("sha256")
+    .update(JSON.stringify([
+      options.apiKey,
+      options.endpoint,
+      options.modelCacheDir,
+      options.llamaGpu,
+      options.embeddingParallelism,
+    ]))
+    .digest("hex");
 }
 
 

--- a/src/engine/utils/json.ts
+++ b/src/engine/utils/json.ts
@@ -1,6 +1,13 @@
-import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
-import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { chmodSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import { chmod, mkdir, readFile, rename, unlink, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
+
+
+export type JsonWriteOptions = {
+  directoryMode?: number;
+  fileMode?: number;
+};
 
 
 export async function readJsonFile<T>(path: string, fallback: T): Promise<T> {
@@ -31,25 +38,67 @@ export function readJsonFileSync<T>(path: string, fallback: T): T {
 }
 
 
-export async function writeJsonFile(path: string, value: unknown): Promise<void> {
-  await mkdir(dirname(path), { recursive: true });
+export async function writeJsonFile(
+  path: string,
+  value: unknown,
+  options: JsonWriteOptions = {},
+): Promise<void> {
+  const directory = dirname(path);
+  await mkdir(directory, { recursive: true, mode: options.directoryMode });
+  if (options.directoryMode !== undefined) {
+    await chmod(directory, options.directoryMode);
+  }
 
-  const tmpPath = `${path}.tmp`;
+  const tmpPath = `${path}.${process.pid}.${randomUUID()}.tmp`;
   const text = `${JSON.stringify(value, null, 2)}\n`;
 
-  await writeFile(tmpPath, text, "utf8");
-  await rename(tmpPath, path);
+  try {
+    await writeFile(tmpPath, text, {
+      encoding: "utf8",
+      mode: options.fileMode,
+    });
+    if (options.fileMode !== undefined) {
+      await chmod(tmpPath, options.fileMode);
+    }
+    await rename(tmpPath, path);
+  } catch (error) {
+    await unlink(tmpPath).catch(() => undefined);
+    throw error;
+  }
 }
 
 
-export function writeJsonFileSync(path: string, value: unknown): void {
-  mkdirSync(dirname(path), { recursive: true });
+export function writeJsonFileSync(
+  path: string,
+  value: unknown,
+  options: JsonWriteOptions = {},
+): void {
+  const directory = dirname(path);
+  mkdirSync(directory, { recursive: true, mode: options.directoryMode });
+  if (options.directoryMode !== undefined) {
+    chmodSync(directory, options.directoryMode);
+  }
 
-  const tmpPath = `${path}.tmp`;
+  const tmpPath = `${path}.${process.pid}.${randomUUID()}.tmp`;
   const text = `${JSON.stringify(value, null, 2)}\n`;
 
-  writeFileSync(tmpPath, text, "utf8");
-  renameSync(tmpPath, path);
+  try {
+    writeFileSync(tmpPath, text, {
+      encoding: "utf8",
+      mode: options.fileMode,
+    });
+    if (options.fileMode !== undefined) {
+      chmodSync(tmpPath, options.fileMode);
+    }
+    renameSync(tmpPath, path);
+  } catch (error) {
+    try {
+      unlinkSync(tmpPath);
+    } catch {
+      // The temporary file may not have been created.
+    }
+    throw error;
+  }
 }
 
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ export type {
   ZvecGrepInfoResult,
   ZvecGrepIndexOptions,
   ZvecGrepLexicalFallbackDiagnostics,
+  ZvecGrepSearchOptions,
 } from "./engine/service/index.js";
 export {
   EMBEDDING_MODEL_CATALOG,

--- a/test/config.test.mjs
+++ b/test/config.test.mjs
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import {
+  readGlobalConfig,
+  updateGlobalConfig,
+  updateGlobalConfigFromExplicitOptions,
+} from "../dist/engine/config.js";
+
+
+test("global config is created securely and merged incrementally", async (t) => {
+  const temporaryDirectory = await mkdtemp(join(tmpdir(), "zvec-grep-config-"));
+  const configPath = join(temporaryDirectory, ".zvec-grep", "config.json");
+  t.after(async () => {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  });
+
+  assert.deepEqual(readGlobalConfig(configPath), { version: 1 });
+
+  updateGlobalConfig({
+    defaults: {
+      embedding: "qwen/text-embedding-v4",
+      llamaGpu: false,
+    },
+    providers: {
+      qwen: {
+        apiKey: "first-key",
+      },
+    },
+  }, configPath);
+  updateGlobalConfig({
+    defaults: {
+      embeddingParallelism: 3,
+    },
+    providers: {
+      qwen: {
+        endpoint: "https://example.test/embeddings",
+      },
+    },
+  }, configPath);
+
+  assert.deepEqual(readGlobalConfig(configPath), {
+    version: 1,
+    defaults: {
+      embedding: "qwen/text-embedding-v4",
+      llamaGpu: false,
+      embeddingParallelism: 3,
+    },
+    providers: {
+      qwen: {
+        apiKey: "first-key",
+        endpoint: "https://example.test/embeddings",
+      },
+    },
+  });
+
+  if (process.platform !== "win32") {
+    const [directoryInfo, fileInfo] = await Promise.all([
+      stat(join(temporaryDirectory, ".zvec-grep")),
+      stat(configPath),
+    ]);
+    assert.equal(directoryInfo.mode & 0o777, 0o700);
+    assert.equal(fileInfo.mode & 0o777, 0o600);
+  }
+});
+
+
+test("explicit index options become provider-aware global config", async (t) => {
+  const temporaryDirectory = await mkdtemp(join(tmpdir(), "zvec-grep-config-explicit-"));
+  const configPath = join(temporaryDirectory, ".zvec-grep", "config.json");
+  t.after(async () => {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  });
+
+  assert.equal(updateGlobalConfigFromExplicitOptions({
+    embedding: "qwen/text-embedding-v4",
+    apiKey: "explicit-key",
+    endpoint: "https://example.test/embeddings",
+  }, undefined, configPath), true);
+  assert.deepEqual(readGlobalConfig(configPath), {
+    version: 1,
+    defaults: {
+      embedding: "qwen/text-embedding-v4",
+    },
+    providers: {
+      qwen: {
+        apiKey: "explicit-key",
+        endpoint: "https://example.test/embeddings",
+      },
+    },
+  });
+  assert.equal(updateGlobalConfigFromExplicitOptions({}, "qwen", configPath), false);
+});
+
+
+test("global config rejects malformed fields without echoing secrets", async (t) => {
+  const temporaryDirectory = await mkdtemp(join(tmpdir(), "zvec-grep-config-invalid-"));
+  const configPath = join(temporaryDirectory, "config.json");
+  t.after(async () => {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  });
+
+  await writeFile(configPath, JSON.stringify({
+    version: 1,
+    providers: {
+      qwen: {
+        apiKey: 12345,
+      },
+    },
+  }));
+
+  assert.throws(
+    () => readGlobalConfig(configPath),
+    (error) => {
+      assert.equal(error.code, "ZVEC_GREP.ENGINE.CONFIG.INVALID");
+      assert.doesNotMatch(error.message, /12345/);
+      assert.doesNotMatch(error.context, /12345/);
+      return true;
+    },
+  );
+});

--- a/test/install.test.mjs
+++ b/test/install.test.mjs
@@ -1,0 +1,263 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import {
+  chmod,
+  lstat,
+  mkdir,
+  mkdtemp,
+  readdir,
+  readFile,
+  rm,
+  stat,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { promisify } from "node:util";
+import test from "node:test";
+
+
+const execFileAsync = promisify(execFile);
+const cliPath = resolve("dist/cli/index.js");
+
+
+test("Codex installer removes orphaned managed markers", async (t) => {
+  const temporaryDirectory = await mkdtemp(join(tmpdir(), "zvec-grep-install-"));
+  const codexHome = join(temporaryDirectory, ".codex");
+  const configPath = join(codexHome, "config.toml");
+  const agentsPath = join(codexHome, "AGENTS.md");
+  t.after(async () => {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  });
+
+  await mkdir(codexHome, { recursive: true });
+  await writeFile(configPath, [
+    "[mcp_servers.other]",
+    'command = "other"',
+    "# ZVEC_GREP_END",
+    "",
+  ].join("\n"));
+
+  await execFileAsync(process.execPath, [
+    cliPath,
+    "install",
+    "--target",
+    "codex",
+    "--yes",
+  ], {
+    env: {
+      ...process.env,
+      CODEX_HOME: codexHome,
+    },
+  });
+
+  const installed = await readFile(configPath, "utf8");
+  const agents = await readFile(agentsPath, "utf8");
+  assert.match(installed, /\[mcp_servers\.other\]/);
+  assert.doesNotMatch(installed, /mcp_servers\.zvec_grep\.tools\.zvec_grep_index/);
+  assert.doesNotMatch(agents, /zvec_grep_(?:index|status)/);
+  assert.match(agents, /zg --index/);
+  assert.match(agents, /zg --status/);
+  assert.match(installed, /^tool_timeout_sec = 600$/m);
+  assert.equal(countOccurrences(installed, "# ZVEC_GREP_START"), 1);
+  assert.equal(countOccurrences(installed, "# ZVEC_GREP_END"), 1);
+  assert.equal(countOccurrences(installed, "[mcp_servers.zvec_grep]"), 1);
+});
+
+
+test("Codex installer ignores an orphaned end marker before a complete block", async (t) => {
+  const temporaryDirectory = await mkdtemp(join(tmpdir(), "zvec-grep-install-existing-"));
+  const codexHome = join(temporaryDirectory, ".codex");
+  const configPath = join(codexHome, "config.toml");
+  t.after(async () => {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  });
+
+  await mkdir(codexHome, { recursive: true });
+  await writeFile(configPath, [
+    "[mcp_servers.other]",
+    'command = "other"',
+    "# ZVEC_GREP_END",
+    "",
+    "# ZVEC_GREP_START",
+    "[mcp_servers.zvec_grep]",
+    'command = "old-zg"',
+    "# ZVEC_GREP_END",
+    "",
+  ].join("\n"));
+
+  await execFileAsync(process.execPath, [
+    cliPath,
+    "install",
+    "--target",
+    "codex",
+    "--yes",
+  ], {
+    env: {
+      ...process.env,
+      CODEX_HOME: codexHome,
+    },
+  });
+
+  const installed = await readFile(configPath, "utf8");
+  assert.match(installed, /\[mcp_servers\.other\]/);
+  assert.doesNotMatch(installed, /old-zg/);
+  assert.equal(countOccurrences(installed, "# ZVEC_GREP_START"), 1);
+  assert.equal(countOccurrences(installed, "# ZVEC_GREP_END"), 1);
+  assert.equal(countOccurrences(installed, "[mcp_servers.zvec_grep]"), 1);
+});
+
+
+test("Codex installer preserves user config after an orphaned start marker", async (t) => {
+  const temporaryDirectory = await mkdtemp(join(tmpdir(), "zvec-grep-install-orphan-start-"));
+  const codexHome = join(temporaryDirectory, ".codex");
+  const configPath = join(codexHome, "config.toml");
+  t.after(async () => {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  });
+
+  await mkdir(codexHome, { recursive: true });
+  await writeFile(configPath, [
+    "# ZVEC_GREP_START",
+    "[mcp_servers.other]",
+    'command = "other"',
+    "",
+    "# ZVEC_GREP_START",
+    "[mcp_servers.zvec_grep]",
+    'command = "old-zg"',
+    "# ZVEC_GREP_END",
+    "",
+  ].join("\n"));
+
+  await installCodex(codexHome);
+
+  const installed = await readFile(configPath, "utf8");
+  assert.match(installed, /\[mcp_servers\.other\]\ncommand = "other"/);
+  assert.doesNotMatch(installed, /old-zg/);
+  assert.equal(countOccurrences(installed, "# ZVEC_GREP_START"), 1);
+  assert.equal(countOccurrences(installed, "# ZVEC_GREP_END"), 1);
+  assert.equal(countOccurrences(installed, "[mcp_servers.zvec_grep]"), 1);
+});
+
+
+test("Codex installer collapses duplicate managed blocks without deleting config between them", async (t) => {
+  const temporaryDirectory = await mkdtemp(join(tmpdir(), "zvec-grep-install-duplicate-"));
+  const codexHome = join(temporaryDirectory, ".codex");
+  const configPath = join(codexHome, "config.toml");
+  t.after(async () => {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  });
+
+  await mkdir(codexHome, { recursive: true });
+  await writeFile(configPath, [
+    "# ZVEC_GREP_START",
+    "[mcp_servers.zvec_grep]",
+    'command = "old-zg-one"',
+    "# ZVEC_GREP_END",
+    "",
+    "[mcp_servers.other]",
+    'command = "other"',
+    "",
+    "# ZVEC_GREP_START",
+    "[mcp_servers.zvec_grep]",
+    'command = "old-zg-two"',
+    "# ZVEC_GREP_END",
+    "",
+  ].join("\n"));
+
+  await installCodex(codexHome);
+
+  const installed = await readFile(configPath, "utf8");
+  assert.match(installed, /\[mcp_servers\.other\]\ncommand = "other"/);
+  assert.doesNotMatch(installed, /old-zg-(?:one|two)/);
+  assert.equal(countOccurrences(installed, "# ZVEC_GREP_START"), 1);
+  assert.equal(countOccurrences(installed, "# ZVEC_GREP_END"), 1);
+  assert.equal(countOccurrences(installed, "[mcp_servers.zvec_grep]"), 1);
+});
+
+
+test("Codex installer atomically updates symlink targets and preserves their modes", async (t) => {
+  const temporaryDirectory = await mkdtemp(join(tmpdir(), "zvec-grep-install-symlink-"));
+  const codexHome = join(temporaryDirectory, ".codex");
+  const dotfiles = join(temporaryDirectory, "dotfiles");
+  const configTarget = join(dotfiles, "config.toml");
+  const agentsTarget = join(dotfiles, "AGENTS.md");
+  const configPath = join(codexHome, "config.toml");
+  const agentsPath = join(codexHome, "AGENTS.md");
+  t.after(async () => {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  });
+
+  await mkdir(codexHome, { recursive: true });
+  await mkdir(dotfiles, { recursive: true });
+  await writeFile(configTarget, "[mcp_servers.other]\ncommand = \"other\"\n");
+  await writeFile(agentsTarget, "# Existing instructions\n");
+  await chmod(configTarget, 0o640);
+  await chmod(agentsTarget, 0o600);
+  await symlink(configTarget, configPath);
+  await symlink(agentsTarget, agentsPath);
+
+  await installCodex(codexHome);
+
+  assert.equal((await lstat(configPath)).isSymbolicLink(), true);
+  assert.equal((await lstat(agentsPath)).isSymbolicLink(), true);
+  assert.equal((await stat(configTarget)).mode & 0o777, 0o640);
+  assert.equal((await stat(agentsTarget)).mode & 0o777, 0o600);
+  assert.match(await readFile(configTarget, "utf8"), /\[mcp_servers\.zvec_grep\]/);
+  assert.match(await readFile(agentsTarget, "utf8"), /## zvec-grep/);
+});
+
+
+test("Codex installer removes temporary files when an atomic replacement fails", async (t) => {
+  const temporaryDirectory = await mkdtemp(join(tmpdir(), "zvec-grep-install-failure-"));
+  const codexHome = join(temporaryDirectory, ".codex");
+  const agentsPath = join(codexHome, "AGENTS.md");
+  t.after(async () => {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  });
+
+  await mkdir(agentsPath, { recursive: true });
+
+  await assert.rejects(installCodex(codexHome));
+
+  const entries = await readdir(codexHome);
+  assert.equal(entries.some((entry) => entry.endsWith(".tmp")), false);
+});
+
+
+test("Codex installer accepts a custom MCP tool timeout", async (t) => {
+  const temporaryDirectory = await mkdtemp(join(tmpdir(), "zvec-grep-install-timeout-"));
+  const codexHome = join(temporaryDirectory, ".codex");
+  const configPath = join(codexHome, "config.toml");
+  t.after(async () => {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  });
+
+  await installCodex(codexHome, ["--mcp-tool-timeout=900"]);
+
+  const installed = await readFile(configPath, "utf8");
+  assert.match(installed, /^tool_timeout_sec = 900$/m);
+});
+
+
+async function installCodex(codexHome, extraArgs = []) {
+  await execFileAsync(process.execPath, [
+    cliPath,
+    "install",
+    "--target",
+    "codex",
+    "--yes",
+    ...extraArgs,
+  ], {
+    env: {
+      ...process.env,
+      CODEX_HOME: codexHome,
+    },
+  });
+}
+
+
+function countOccurrences(value, search) {
+  return value.split(search).length - 1;
+}

--- a/test/install.test.mjs
+++ b/test/install.test.mjs
@@ -66,6 +66,45 @@ test("Codex installer removes orphaned managed markers", async (t) => {
 });
 
 
+test("Codex installer detects and replaces equivalent unmanaged MCP table headers", async (t) => {
+  const temporaryDirectory = await mkdtemp(join(tmpdir(), "zvec-grep-install-conflict-"));
+  t.after(async () => {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  });
+
+  const cases = [
+    ["leading-whitespace", "  [mcp_servers.zvec_grep]"],
+    ["quoted-key", "[mcp_servers.\"zvec_grep\"]"],
+  ];
+
+  for (const [name, tableHeader] of cases) {
+    const codexHome = join(temporaryDirectory, name);
+    const configPath = join(codexHome, "config.toml");
+    const existing = [
+      "[mcp_servers.other]",
+      'command = "other"',
+      "",
+      tableHeader,
+      'command = "old-zg"',
+      "",
+    ].join("\n");
+
+    await mkdir(codexHome, { recursive: true });
+    await writeFile(configPath, existing);
+
+    await assert.rejects(installCodex(codexHome));
+    assert.equal(await readFile(configPath, "utf8"), existing);
+
+    await installCodex(codexHome, ["--force"]);
+
+    const installed = await readFile(configPath, "utf8");
+    assert.match(installed, /\[mcp_servers\.other\]\ncommand = "other"/);
+    assert.doesNotMatch(installed, /old-zg/);
+    assert.equal(countOccurrences(installed, "[mcp_servers.zvec_grep]"), 1);
+  }
+});
+
+
 test("Codex installer ignores an orphaned end marker before a complete block", async (t) => {
   const temporaryDirectory = await mkdtemp(join(tmpdir(), "zvec-grep-install-existing-"));
   const codexHome = join(temporaryDirectory, ".codex");

--- a/test/mcp.test.mjs
+++ b/test/mcp.test.mjs
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import test from "node:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+
+const cliPath = resolve("dist/cli/index.js");
+
+
+test("MCP exposes only search tools", async (t) => {
+  const temporaryDirectory = await mkdtemp(join(tmpdir(), "zvec-grep-mcp-"));
+  const client = new Client({ name: "zvec-grep-test", version: "1.0.0" });
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: [cliPath, "serve", "--mcp"],
+    cwd: temporaryDirectory,
+    env: {
+      ...process.env,
+      HOME: temporaryDirectory,
+    },
+    stderr: "pipe",
+  });
+  t.after(async () => {
+    await client.close();
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  });
+
+  await client.connect(transport);
+  const listed = await client.listTools();
+  const names = listed.tools.map((tool) => tool.name).sort();
+
+  assert.deepEqual(names, ["zvec_grep_rg", "zvec_grep_search"]);
+  assert.equal(names.includes("zvec_grep_index"), false);
+  assert.equal(names.includes("zvec_grep_status"), false);
+});

--- a/test/service-config-reload.test.mjs
+++ b/test/service-config-reload.test.mjs
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { updateGlobalConfig } from "../dist/engine/config.js";
+import { createZvecGrep } from "../dist/index.js";
+
+
+test("explicit embedding reference reloads provider config before refresh and query", async () => {
+  const temporaryDirectory = await mkdtemp(join(tmpdir(), "zvec-grep-config-reload-"));
+  const root = join(temporaryDirectory, "repo");
+  const originalHome = process.env.HOME;
+  const originalFetch = globalThis.fetch;
+  const requests = [];
+  let service;
+
+  process.env.HOME = temporaryDirectory;
+  globalThis.fetch = async (input, init) => {
+    const body = JSON.parse(String(init?.body));
+    const contents = Array.isArray(body.input) ? body.input : [];
+    requests.push({
+      url: String(input),
+      authorization: init?.headers?.Authorization,
+    });
+    return new Response(JSON.stringify({
+      data: contents.map((_, index) => ({
+        index,
+        embedding: new Array(1024).fill(0.01),
+      })),
+    }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+
+  try {
+    await mkdir(join(root, "src"), { recursive: true });
+    await writeFile(join(root, "src", "example.ts"), "export const answer = 42;\n");
+    updateGlobalConfig({
+      providers: {
+        qwen: {
+          apiKey: "key-a",
+          endpoint: "https://endpoint-a.test/embeddings",
+        },
+      },
+    });
+
+    service = await createZvecGrep({
+      root,
+      embedding: "qwen/text-embedding-v4",
+    });
+    await service.index();
+    assert.ok(requests.length > 0);
+    assert.ok(requests.every((request) => request.url === "https://endpoint-a.test/embeddings"));
+    assert.ok(requests.every((request) => request.authorization === "Bearer key-a"));
+
+    requests.length = 0;
+    updateGlobalConfig({
+      providers: {
+        qwen: {
+          apiKey: "key-b",
+          endpoint: "https://endpoint-b.test/embeddings",
+        },
+      },
+    });
+    await writeFile(join(root, "src", "example.ts"), "export const answer = 43;\n");
+
+    await service.context({
+      root,
+      query: "where is the answer defined",
+      limit: 1,
+    });
+    assert.ok(requests.length > 0);
+    assert.ok(requests.every((request) => request.url === "https://endpoint-b.test/embeddings"));
+    assert.ok(requests.every((request) => request.authorization === "Bearer key-b"));
+  } finally {
+    await service?.close();
+    globalThis.fetch = originalFetch;
+    if (originalHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = originalHome;
+    }
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  }
+});

--- a/test/service-model-cache.test.mjs
+++ b/test/service-model-cache.test.mjs
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { updateGlobalConfig } from "../dist/engine/config.js";
+import { EmbeddingModel } from "../dist/engine/models/embeddings.js";
+import { createZvecGrep } from "../dist/index.js";
+
+
+test("recovered embedding model cache is bounded and defers disposal until active queries finish", async () => {
+  const temporaryDirectory = await mkdtemp(join(tmpdir(), "zvec-grep-model-cache-"));
+  const root = join(temporaryDirectory, "repo");
+  const originalHome = process.env.HOME;
+  const originalFetch = globalThis.fetch;
+  const originalDispose = EmbeddingModel.prototype.dispose;
+  const disposedModels = [];
+  let releaseBlockedRequest;
+  let service;
+  let blockedContext;
+
+  const blockedRequestStarted = new Promise((resolve) => {
+    globalThis.fetch = async (input, init) => {
+      if (String(input) === "https://blocked.test/embeddings") {
+        resolve();
+        await new Promise((release) => {
+          releaseBlockedRequest = release;
+        });
+      }
+
+      return embeddingResponse(init);
+    };
+  });
+
+  process.env.HOME = temporaryDirectory;
+  EmbeddingModel.prototype.dispose = async function disposeForTest() {
+    disposedModels.push(this);
+  };
+
+  try {
+    await mkdir(join(root, "src"), { recursive: true });
+    await writeFile(join(root, "src", "example.ts"), "export const answer = 42;\n");
+    configureQwen("https://initial.test/embeddings");
+
+    service = await createZvecGrep({
+      root,
+      embedding: "qwen/text-embedding-v4",
+    });
+    await service.index();
+
+    configureQwen("https://blocked.test/embeddings");
+    blockedContext = service.context({
+      root,
+      query: "where is the answer defined",
+      limit: 1,
+      autoUpdate: false,
+    });
+    await blockedRequestStarted;
+
+    for (const name of ["third", "fourth", "fifth", "sixth"]) {
+      configureQwen(`https://${name}.test/embeddings`);
+      await service.context({
+        root,
+        query: "where is the answer defined",
+        limit: 1,
+        autoUpdate: false,
+      });
+    }
+
+    assert.equal(disposedModels.length, 0);
+    releaseBlockedRequest();
+    await blockedContext;
+    blockedContext = undefined;
+    assert.equal(disposedModels.length, 2);
+
+    await service.close();
+    service = undefined;
+    assert.equal(disposedModels.length, 6);
+  } finally {
+    releaseBlockedRequest?.();
+    await blockedContext?.catch(() => undefined);
+    await service?.close();
+    EmbeddingModel.prototype.dispose = originalDispose;
+    globalThis.fetch = originalFetch;
+    if (originalHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = originalHome;
+    }
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  }
+});
+
+
+function configureQwen(endpoint) {
+  updateGlobalConfig({
+    providers: {
+      qwen: {
+        apiKey: "test-key",
+        endpoint,
+      },
+    },
+  });
+}
+
+
+function embeddingResponse(init) {
+  const body = JSON.parse(String(init?.body));
+  const contents = Array.isArray(body.input) ? body.input : [];
+  return new Response(JSON.stringify({
+    data: contents.map((_, index) => ({
+      index,
+      embedding: new Array(1024).fill(0.01),
+    })),
+  }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}


### PR DESCRIPTION
## Summary

- add a stdio MCP server exposing zvec-grep search tools
- add global embedding/provider configuration with safe JSON persistence and runtime reload
- extend CLI installation and configuration flows for Codex MCP integration
- document MCP setup in English and Chinese
- add coverage for MCP exposure, config handling, installer behavior, config reload, and model cache lifecycle

## Why

This makes zvec-grep directly usable as an MCP search server while keeping embedding configuration persistent, reloadable, and compatible with the CLI installation flow.

## Impact

Users can install and run zvec-grep through MCP, configure embedding providers globally, and rely on bounded model caching and safer installer updates.

## Validation

- `npm test`
- 13 tests passed
- TypeScript build passed as part of the test command
- `git diff --check`
