### PR TITLE
fix: use path for MCP rg scope

### DIFF
--- a/src/mcp/input-normalization.ts
+++ b/src/mcp/input-normalization.ts
@@ -75,7 +75,7 @@ export function contextOptionsFromRgInput(
     queries,
     rg: true,
     rgOptions,
-    rgPaths: normalizePlainStringList(input.paths),
+    rgPaths: normalizePlainStringList(input.path),
     root: input.root,
     limit: input.limit,
     includePaths,

--- a/src/mcp/schemas.ts
+++ b/src/mcp/schemas.ts
@@ -238,8 +238,8 @@ export const zvecGrepRgInputSchema = z.object({
     "Multiple regex or literal patterns to search for.",
   ),
   root: absoluteRootSchema,
-  paths: unboundedStringList.describe(
-    "Optional paths to search within the root.",
+  path: unboundedStringList.describe(
+    "Optional path or array of paths to search within the root.",
   ),
   fixedStrings: z
     .boolean()

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -200,7 +200,7 @@ export const ZVEC_GREP_MCP_INSTRUCTIONS = [
   "zvec-grep is a more capable superset replacement for rg.",
   "When the exact keyword, text, or symbol is unknown, start with zvec_grep_search to quickly identify relevant concepts, files, and locations.",
   "When the exact keyword, text, or symbol is known, use zvec_grep_rg.",
-  "Scope searches with paths or globs when you already know likely locations or file types, and refine broad or noisy searches by narrowing the query and search scope.",
+  "Scope searches with the path parameter or glob filters when you already know likely locations or file types, and refine broad or noisy searches by narrowing the query and search scope.",
   "Trust zvec-grep results; if results are too broad, sparse, or low-quality, refine the query, scope, or search options and try zvec-grep again instead of switching to another local text-search tool.",
 ].join(" ");
 
@@ -404,7 +404,7 @@ export function registerZvecGrepTools(
     {
       title: "Search with managed ripgrep",
       description:
-        "Run exhaustive managed ripgrep locally without requiring an index. Use it first when an exact keyword, text, symbol, filename, path, configuration key, error message, source fragment, literal, or regex anchor is known. A named class, function, or symbol remains an exact anchor even when its file or definition location is unknown. Scope broad matches with paths or globs.",
+        "Run exhaustive managed ripgrep locally without requiring an index. Use it first when an exact keyword, text, symbol, filename, path, configuration key, error message, source fragment, literal, or regex anchor is known. A named class, function, or symbol remains an exact anchor even when its file or definition location is unknown. Scope broad matches with the path parameter or glob filters.",
       inputSchema: zvecGrepRgInputSchema.shape,
       annotations: {
         readOnlyHint: true,

--- a/test/mcp-contract.test.mjs
+++ b/test/mcp-contract.test.mjs
@@ -285,7 +285,7 @@ test("full server contract exposes all tools with stable annotations", async (t)
   assert.match(instructions, /start with zvec_grep_search/);
   assert.match(instructions, /exact keyword, text, or symbol is known/);
   assert.match(instructions, /use zvec_grep_rg/);
-  assert.match(instructions, /Scope searches with paths or globs/);
+  assert.match(instructions, /Scope searches with the path parameter/);
   assert.match(instructions, /refine broad or noisy searches/);
   assert.match(instructions, /Trust zvec-grep results/);
   assert.match(
@@ -352,7 +352,9 @@ test("full server contract exposes all tools with stable annotations", async (t)
     rg.description,
     /named class, function, or symbol remains an exact anchor/,
   );
-  assert.match(rg.description, /Scope broad matches with paths or globs/);
+  assert.match(rg.description, /Scope broad matches with the path parameter/);
+  assert.ok(rg.inputSchema.properties.path);
+  assert.equal(rg.inputSchema.properties.paths, undefined);
   assert.equal(rg.outputSchema, undefined);
   assert.equal(search.outputSchema, undefined);
   for (const tool of tools.filter(
@@ -914,6 +916,7 @@ test("rg normalizes managed ripgrep input before calling the backend", async (t)
       pattern: "needle",
       fixedStrings: true,
       ignoreCase: true,
+      path: ["src", "test"],
       glob: ["src/**", "!dist/**"],
       context: 2,
     },
@@ -922,6 +925,7 @@ test("rg normalizes managed ripgrep input before calling the backend", async (t)
   assert.equal(received.pattern, "needle");
   assert.equal(received.fixedStrings, true);
   assert.equal(received.ignoreCase, true);
+  assert.deepEqual(received.path, ["src", "test"]);
   assert.deepEqual(received.glob, ["src/**", "!dist/**"]);
   assert.equal(received.context, 2);
   assert.equal(result.structuredContent, undefined);
@@ -949,17 +953,17 @@ test("rg does not apply indexed search input bounds", async (t) => {
 
   const pattern = "n".repeat(4_001);
   const patterns = Array.from({ length: 33 }, (_, index) => `pattern-${index}`);
-  const paths = Array.from({ length: 129 }, (_, index) => `path-${index}`);
+  const path = Array.from({ length: 129 }, (_, index) => `path-${index}`);
   const glob = Array.from({ length: 129 }, (_, index) => `glob-${index}`);
   const result = await client.callTool({
     name: "zvec_grep_rg",
-    arguments: { root, pattern, patterns, paths, glob },
+    arguments: { root, pattern, patterns, path, glob },
   });
 
   assert.notEqual(result.isError, true);
   assert.equal(received.pattern, pattern);
   assert.deepEqual(received.patterns, patterns);
-  assert.deepEqual(received.paths, paths);
+  assert.deepEqual(received.path, path);
   assert.deepEqual(received.glob, glob);
 });
 

--- a/test/unit/core.test.mjs
+++ b/test/unit/core.test.mjs
@@ -154,6 +154,22 @@ test("MCP rg normalization preserves brace glob entries", () => {
   assert.deepEqual(array.excludePaths, ["test/**"]);
 });
 
+test("MCP rg normalization accepts scalar and array path input", () => {
+  const scalar = contextOptionsFromRgInput({
+    root: "/repo",
+    pattern: "valid",
+    path: "src",
+  });
+  assert.deepEqual(scalar.rgPaths, ["src"]);
+
+  const array = contextOptionsFromRgInput({
+    root: "/repo",
+    pattern: "valid",
+    path: ["src", "test"],
+  });
+  assert.deepEqual(array.rgPaths, ["src", "test"]);
+});
+
 test("CLI parser covers utility commands, provider controls, routes, and equals syntax", () => {
   const install = parseArgs([
     "install",


### PR DESCRIPTION
## What changed

- Rename the `zvec_grep_rg` MCP scope parameter from `paths` to `path`.
- Keep support for both a single string and an array of strings, normalized to the existing internal `rgPaths` representation.
- Update MCP server instructions and tool descriptions to name the `path` parameter explicitly.
- Extend MCP contract and normalization tests for scalar and array inputs.

## Why

OpenCode with GLM-5.2 generated the conventional singular `path` argument while the MCP schema exposed `paths`. The mismatched field could be dropped, widening an intended scoped search to the repository root and increasing returned context. Aligning the contract with the generated calls keeps the requested scope intact.

This is an MCP contract rename only. The CLI form `zg query --rg <pattern> [path...]` and the underlying ripgrep execution behavior are unchanged.

## Validation

- `npm run typecheck`
- Targeted Prettier and ESLint checks
- `node --test --test-concurrency=1 test/mcp-contract.test.mjs test/unit/core.test.mjs test/rg-cli.test.mjs` — 31/31 passed
- Remote protocol check confirmed `path` is exposed, `paths` is absent, and scalar/array values reach the backend
- Three paired Flask smoke runs per profile: baseline 3/3 and zvec-grep 3/3, with a real GLM-5.2 call successfully scoping `zvec_grep_rg` using `path: "/testbed/tests"`
