### PR TITLE
ci: verify Node 22.13 integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            node: 22.0.0
+            node: 22.13.0
           - os: ubuntu-latest
             node: 22
           - os: ubuntu-latest
@@ -104,7 +104,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            node: 22.0.0
+            node: 22.13.0
           - os: ubuntu-latest
             node: 24
           - os: macos-latest


### PR DESCRIPTION
## What changed

- Replace the Ubuntu Node 22.0.0 CI entries with Node 22.13.0 for the unit and integration/e2e matrices.

## Why

The integration/e2e job consistently hangs on Ubuntu with Node 22.0.0 when the first Zvec-backed integration test starts. The root test process completes 136/136 tests, then the integration process prints only `TAP version 13` and remains stuck until the 30-minute timeout.

Node 22.0.0 is also outside the supported range of the current ESLint 10 toolchain, which requires Node 22.13.0 or newer on the Node 22 release line.

## Impact

This is a minimal CI probe. It does not change runtime code or the package's declared Node requirement. The PR exists to verify the same Ubuntu integration/e2e path on Node 22.13.0 before changing compatibility documentation.

## Validation

- Workflow YAML passes Prettier.
- `git diff --check` passes.
- Awaiting GitHub Actions results for Ubuntu Node 22.13.0.
