### PR TITLE
refactor: embedding runtime configuration

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -2,10 +2,6 @@ name: Security
 
 on:
   pull_request:
-  push:
-    branches: [main]
-  schedule:
-    - cron: "43 4 * * 2"
 
 permissions: {}
 
@@ -27,22 +23,3 @@ jobs:
       - uses: actions/dependency-review-action@v5
         with:
           fail-on-severity: high
-
-  codeql:
-    if: >-
-      github.event.repository.visibility == 'public' ||
-      vars.ENABLE_GHAS == 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    permissions:
-      actions: read
-      contents: read
-      security-events: write
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - uses: github/codeql-action/init@v3
-        with:
-          languages: javascript-typescript
-      - uses: github/codeql-action/analyze@v3

--- a/README.md
+++ b/README.md
@@ -183,7 +183,10 @@ zg index \
   --api-key "$DASHSCOPE_API_KEY"
 ```
 
-After a successful index, explicitly passed global model and provider options are saved to `~/.zvec-grep/config.json` with user-only permissions. This lets an already-running `zg` MCP server load a newly configured remote API key on its next model request without restarting Codex. Values read only from environment variables are not persisted.
+`zg config` is the only command that changes `~/.zvec-grep/config.json`. An
+index stores its effective endpoint/device snapshot and an explicitly supplied
+API key in the workspace's internal metadata. Keys inherited from global config
+or environment variables are not copied into the workspace.
 
 ```json
 {
@@ -193,11 +196,13 @@ After a successful index, explicitly passed global model and provider options ar
   },
   "providers": {
     "qwen": {
-      "apiKey": "...",
-      "endpoint": "https://dashscope.aliyuncs.com/compatible-mode/v1/embeddings"
+      "apiKey": "..."
     }
   },
   "models": {
+    "qwen/text-embedding-v4": {
+      "endpoint": "https://dashscope.aliyuncs.com/compatible-mode/v1/embeddings"
+    },
     "local/embeddinggemma-300m": {
       "device": "metal"
     },
@@ -208,13 +213,18 @@ After a successful index, explicitly passed global model and provider options ar
 }
 ```
 
-For local embeddings, `models["provider/model"]` selects the execution device independently for each model; these settings apply to both daemon indexing and searching, and do not require rebuilding an existing index. Explicit CLI or library options override model settings, which override global defaults and `ZVEC_GREP_DEVICE`. Remote embeddings ignore local device settings. Repository roots and include/exclude filters remain in each repository's `.zvec-grep` metadata rather than global config.
+Runtime values resolve from request, workspace snapshot, global config, and
+environment variables in that order. API key and device changes do not require
+a rebuild. Changing an indexed model or endpoint does. Search API key/device
+overrides are one-shot and are never persisted; endpoint is index-only.
 
 Configure the same settings without editing JSON:
 
 ```bash
+zg config provider set qwen --api-key "$DASHSCOPE_API_KEY"
+zg config model set qwen/text-embedding-v4 --endpoint https://dashscope.aliyuncs.com/compatible-mode/v1/embeddings
+zg config model set qwen/text-embedding-v4 --default
 zg config model set local/embeddinggemma-300m --device metal
-zg config model set local/qwen3-embedding-0.6b --device cpu
 ```
 
 llama.cpp context parallelism is selected automatically. For low-level performance diagnostics, set `ZVEC_GREP_LLAMA_CONTEXT_PARALLELISM` to a positive integer.

--- a/README_CN.md
+++ b/README_CN.md
@@ -200,7 +200,9 @@ zg index \
   --api-key "$DASHSCOPE_API_KEY"
 ```
 
-索引成功后，通过 CLI 显式传入的全局模型和 provider 参数会保存到 `~/.zvec-grep/config.json`，并使用仅当前用户可读写的权限。已经运行的 `zg` MCP server 会在下一次需要模型时读取新的远程 API key，不需要重启 Codex。只从环境变量读取、没有作为 CLI 参数显式传入的值不会被持久化。
+只有 `zg config` 会修改 `~/.zvec-grep/config.json`。索引会在 workspace
+内部元数据中保存实际使用的 endpoint/device 快照，以及本次显式传入的 API
+key；从 global config 或环境变量继承的 key 不会复制到 workspace。
 
 ```json
 {
@@ -210,11 +212,13 @@ zg index \
   },
   "providers": {
     "qwen": {
-      "apiKey": "...",
-      "endpoint": "https://dashscope.aliyuncs.com/compatible-mode/v1/embeddings"
+      "apiKey": "..."
     }
   },
   "models": {
+    "qwen/text-embedding-v4": {
+      "endpoint": "https://dashscope.aliyuncs.com/compatible-mode/v1/embeddings"
+    },
     "local/embeddinggemma-300m": {
       "device": "metal"
     },
@@ -225,13 +229,18 @@ zg index \
 }
 ```
 
-本地 embedding 会按 `models["provider/model"]` 为每个模型分别选择执行设备；daemon 建索引和搜索都会使用这份配置，切换运行配置不需要重建已有索引。显式 CLI 或库参数优先于模型配置，模型配置优先于全局默认值和 `ZVEC_GREP_DEVICE`。远程 embedding 会忽略本地设备配置。仓库 root 和 include/exclude 规则仍保存在各仓库自己的 `.zvec-grep` 元数据中，不进入全局配置。
+运行参数依次从请求、workspace 快照、global config 和环境变量解析。API key
+与 device 变化不需要 rebuild；已建索引的 model 或 endpoint 变化必须
+rebuild。搜索只支持单次覆盖 API key/device，永不持久化；endpoint 只在
+index 时设置。
 
 也可以通过命令配置，无需手工编辑 JSON：
 
 ```bash
+zg config provider set qwen --api-key "$DASHSCOPE_API_KEY"
+zg config model set qwen/text-embedding-v4 --endpoint https://dashscope.aliyuncs.com/compatible-mode/v1/embeddings
+zg config model set qwen/text-embedding-v4 --default
 zg config model set local/embeddinggemma-300m --device metal
-zg config model set local/qwen3-embedding-0.6b --device cpu
 ```
 
 llama.cpp context 并行度会自动选择。进行底层性能诊断时，可以将 `ZVEC_GREP_LLAMA_CONTEXT_PARALLELISM` 设置为正整数。

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -110,6 +110,9 @@ export function parseArgs(args: readonly string[]): ParsedArgs {
     if (args[1] === "model" && args[2] === "set") {
       options.configAction = "model-set";
       startIndex = 3;
+    } else if (args[1] === "provider" && args[2] === "set") {
+      options.configAction = "provider-set";
+      startIndex = 3;
     }
   } else if (commandInput.command === "auth") {
     if (args[1] === "grant" || args[1] === "status" || args[1] === "revoke") {
@@ -252,6 +255,8 @@ export function parseArgs(args: readonly string[]): ParsedArgs {
       options.force = true;
     } else if (arg === "--reset-paths") {
       options.resetPaths = true;
+    } else if (arg === "--default") {
+      options.defaultModel = true;
     } else if (isLongOptionWithValue(arg, "--refresh")) {
       options.refresh = parseQueryRefreshMode(valueFromLongOption(arg));
     } else if (arg === "--refresh") {
@@ -700,7 +705,7 @@ function validateCliShape(
 
   if (command === "config") {
     if (!options.configAction) {
-      throw new Error("zg config requires model set");
+      throw new Error("zg config requires provider set or model set");
     }
     const unsupported = firstEnabledOption([
       [options.installTargets?.length, "--target"],
@@ -711,15 +716,35 @@ function validateCliShape(
       [options.rg, "--rg"],
       [options.home, "--home"],
       [options.embedding, "--embedding"],
-      [options.apiKey, "--api-key"],
-      [options.endpoint, "--endpoint"],
+      [
+        options.configAction === "model-set" ? options.apiKey : undefined,
+        "--api-key",
+      ],
+      [
+        options.configAction === "provider-set" ? options.endpoint : undefined,
+        "--endpoint",
+      ],
+      [
+        options.configAction === "provider-set" ? options.device : undefined,
+        "--device",
+      ],
+      [
+        options.configAction === "provider-set"
+          ? options.defaultModel
+          : undefined,
+        "--default",
+      ],
       [options.mode, "--mode"],
       [options.listen, "--listen"],
       [options.serverTokenFile, "--token-file"],
     ]);
     if (unsupported) {
-      throw new Error(`zg config model set does not accept ${unsupported}`);
+      throw new Error(
+        `zg config ${options.configAction === "model-set" ? "model" : "provider"} set does not accept ${unsupported}`,
+      );
     }
+  } else if (options.defaultModel) {
+    throw new Error("--default can only be used with zg config model set");
   }
 
   if (command === "server") {
@@ -919,6 +944,7 @@ function validateCliShape(
   if (command === "query") {
     const unsupported = firstEnabledOption([
       [options.embedding, "--embedding"],
+      [options.endpoint, "--endpoint"],
       [options.embeddingConcurrency, "--embedding-concurrency"],
     ]);
     if (unsupported) {

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -983,7 +983,10 @@ async function runDirectIndex(
   const zvecGrep = await createZvecGrep(serviceOptions);
   const progress = createIndexProgressReporter({ color: parsed.options.color });
   try {
-    const infoBefore = await zvecGrep.info({ root: rootPath.absolutePath });
+    const infoBefore = await zvecGrep.info({
+      root: rootPath.absolutePath,
+      includeStatus: parsed.options.rebuild !== true,
+    });
     const schema = resolveAuthorizationSchema(
       configuredEmbeddingReference(parsed.options),
       infoBefore.collection?.embedding,

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -16,7 +16,6 @@ import { homedir } from "node:os";
 import { delimiter, dirname, resolve } from "node:path";
 import { createInterface } from "node:readline/promises";
 import {
-  createEmbeddingModel,
   createZvecGrep,
   type CreateZvecGrepOptions,
   type EmbeddingModelInfo,
@@ -29,9 +28,15 @@ import {
 } from "../index.js";
 import {
   globalConfigPath,
+  readGlobalConfig,
   updateGlobalConfig,
-  updateGlobalConfigFromExplicitOptions,
+  type EmbeddingRuntimeConfig,
 } from "../engine/config.js";
+import {
+  getEmbeddingModelCatalogEntry,
+  listEmbeddingModels,
+} from "../engine/models/index.js";
+import { CollectionRegistry } from "../engine/collection/index.js";
 import { DaemonClient } from "../client/daemon-client.js";
 import {
   resolveDirectSearchPolicy,
@@ -176,40 +181,102 @@ export async function runParsedCommand(parsed: ParsedArgs): Promise<void> {
 }
 
 async function runConfig(parsed: ParsedArgs): Promise<void> {
-  if (parsed.options.configAction !== "model-set") {
-    throw new Error("zg config requires model set");
-  }
   if (parsed.positionals.length !== 1) {
     throw new Error(
-      "zg config model set requires exactly one local embedding reference",
+      `zg config ${parsed.options.configAction === "provider-set" ? "provider" : "model"} set requires exactly one reference`,
     );
   }
   const reference = parsed.positionals[0]!;
-  if (!reference.startsWith("local/")) {
-    throw new Error("zg config model set only supports local embedding models");
-  }
-  if (parsed.options.device === undefined) {
-    throw new Error("zg config model set requires --device");
-  }
-  const model = createEmbeddingModel(reference, {
-    device: parsed.options.device,
-  });
-  try {
-    if (model.info.provider !== "local") {
-      throw new Error(`Unsupported local embedding model: ${reference}`);
+  if (parsed.options.configAction === "provider-set") {
+    if (!/^[a-z][a-z0-9_-]*$/.test(reference)) {
+      throw new Error(`Invalid embedding provider: ${reference}`);
     }
-  } finally {
-    await model.dispose();
+    if (
+      reference === "local" ||
+      !listEmbeddingModels().some((entry) => entry.provider === reference)
+    ) {
+      throw new Error(`Unsupported remote embedding provider: ${reference}`);
+    }
+    if (parsed.options.apiKey === undefined) {
+      throw new Error("zg config provider set requires --api-key");
+    }
+    updateGlobalConfig({
+      providers: {
+        [reference]: {
+          apiKey: parsed.options.apiKey,
+        },
+      },
+    });
+    console.log(`Provider config: ${reference}`);
+    console.log(`Global config: ${globalConfigPath()}`);
+    return;
+  }
+
+  if (parsed.options.configAction !== "model-set") {
+    throw new Error("zg config requires provider set or model set");
+  }
+  const catalogEntry = getEmbeddingModelCatalogEntry(reference);
+  if (!catalogEntry) {
+    throw new Error(`Unsupported embedding model: ${reference}`);
+  }
+  if (
+    parsed.options.endpoint === undefined &&
+    parsed.options.device === undefined &&
+    !parsed.options.defaultModel
+  ) {
+    throw new Error(
+      "zg config model set requires --endpoint, --device, or --default",
+    );
+  }
+  if (
+    catalogEntry.provider === "local" &&
+    parsed.options.endpoint !== undefined
+  ) {
+    throw new Error("--endpoint is only supported for remote embedding models");
+  }
+  if (
+    catalogEntry.provider !== "local" &&
+    parsed.options.device !== undefined
+  ) {
+    throw new Error("--device is only supported for local embedding models");
+  }
+  if (parsed.options.endpoint !== undefined) {
+    assertHttpEndpoint(parsed.options.endpoint);
   }
   updateGlobalConfig({
-    models: {
-      [reference]: {
-        device: parsed.options.device,
-      },
-    },
+    ...(parsed.options.endpoint !== undefined ||
+    parsed.options.device !== undefined
+      ? {
+          models: {
+            [reference]: {
+              ...(parsed.options.endpoint !== undefined
+                ? { endpoint: parsed.options.endpoint }
+                : {}),
+              ...(parsed.options.device !== undefined
+                ? { device: parsed.options.device }
+                : {}),
+            },
+          },
+        }
+      : {}),
+    ...(parsed.options.defaultModel
+      ? { defaults: { embedding: reference } }
+      : {}),
   });
   console.log(`Model config: ${reference}`);
   console.log(`Global config: ${globalConfigPath()}`);
+}
+
+function assertHttpEndpoint(endpoint: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(endpoint);
+  } catch {
+    throw new Error("--endpoint must be a valid HTTP(S) URL");
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error("--endpoint must be a valid HTTP(S) URL");
+  }
 }
 
 async function runInstall(parsed: ParsedArgs): Promise<void> {
@@ -301,7 +368,7 @@ async function runAuth(parsed: ParsedArgs): Promise<void> {
   try {
     const info = await service.info({ root });
     const schema = resolveAuthorizationSchema(
-      parsed.options.embedding ?? process.env.ZVEC_GREP_EMBEDDING,
+      configuredEmbeddingReference(parsed.options),
       info.collection?.embedding,
     );
     if (!schema) {
@@ -312,7 +379,11 @@ async function runAuth(parsed: ParsedArgs): Promise<void> {
     if (schema.provider === "local") {
       throw new Error("Local embedding models do not require authorization.");
     }
-    const modelInfo = await embeddingModelInfo(schema, serviceOptions);
+    const modelInfo = await embeddingModelInfo(
+      schema,
+      serviceOptions,
+      workspaceRuntimeFromInfo(info),
+    );
     const endpoint = modelInfo.endpoint;
     if (endpoint === undefined) {
       throw new Error(
@@ -837,6 +908,9 @@ async function runIndex(parsed: ParsedArgs): Promise<void> {
           {
             root: rootPath.absolutePath,
             embedding: parsed.options.embedding,
+            apiKey: parsed.options.apiKey,
+            endpoint: parsed.options.endpoint,
+            device: parsed.options.device,
             rebuild: parsed.options.rebuild,
             resetPaths: parsed.options.resetPaths,
             globs: parsed.options.globs,
@@ -911,7 +985,7 @@ async function runDirectIndex(
   try {
     const infoBefore = await zvecGrep.info({ root: rootPath.absolutePath });
     const schema = resolveAuthorizationSchema(
-      parsed.options.embedding ?? process.env.ZVEC_GREP_EMBEDDING,
+      configuredEmbeddingReference(parsed.options),
       infoBefore.collection?.embedding,
     );
     assertEmbeddingModelCompatible(
@@ -919,9 +993,16 @@ async function runDirectIndex(
       schema,
       parsed.options.rebuild === true,
     );
+    const workspaceRuntime = workspaceRuntimeFromInfo(infoBefore);
+    assertRequestedEndpointCompatible(
+      infoBefore,
+      workspaceRuntime,
+      parsed.options.endpoint,
+      parsed.options.rebuild === true,
+    );
     const modelInfo =
       schema?.provider === "qwen"
-        ? await embeddingModelInfo(schema, serviceOptions)
+        ? await embeddingModelInfo(schema, serviceOptions, workspaceRuntime)
         : undefined;
     const plan = modelInfo
       ? await planRemoteIndexAuthorization({
@@ -964,10 +1045,6 @@ async function runDirectIndex(
       result,
       parsed.options,
       info.collection?.rootPaths,
-    );
-    persistExplicitGlobalConfig(
-      parsed.options,
-      embeddingReference(info.collection?.embedding),
     );
   } catch (error) {
     progress.finish();
@@ -1193,7 +1270,7 @@ async function runCollections(parsed: ParsedArgs): Promise<void> {
           zvecGrep.collections.status(name),
         ]);
         const schema = resolveAuthorizationSchema(
-          parsed.options.embedding ?? process.env.ZVEC_GREP_EMBEDDING,
+          configuredEmbeddingReference(parsed.options),
           existing?.embedding,
         );
         assertEmbeddingModelCompatible(
@@ -1217,11 +1294,19 @@ async function runCollections(parsed: ParsedArgs): Promise<void> {
           collection: authorizationCollection,
           status,
         };
+        const workspaceRuntime = workspaceRuntimeFromInfo(infoBefore);
+        assertRequestedEndpointCompatible(
+          infoBefore,
+          workspaceRuntime,
+          parsed.options.endpoint,
+          parsed.options.rebuild === true,
+        );
         const modelInfo =
           schema?.provider === "qwen"
             ? await embeddingModelInfo(
                 schema,
                 createServiceOptions(parsed.options, undefined),
+                workspaceRuntime,
               )
             : undefined;
         const plan = modelInfo
@@ -1262,10 +1347,6 @@ async function runCollections(parsed: ParsedArgs): Promise<void> {
           result,
           parsed.options,
           info?.rootPaths,
-        );
-        persistExplicitGlobalConfig(
-          parsed.options,
-          embeddingReference(info?.embedding),
         );
       } catch (error) {
         progress.finish();
@@ -1420,11 +1501,13 @@ async function runDirectQuery(
     );
     const info = await directQueryInfo(zvecGrep, commandOptions);
     const schema = info.collection?.embedding;
+    const workspaceRuntime = workspaceRuntimeFromInfo(info);
     const modelInfo =
       !commandOptions.rg && schema?.provider === "qwen"
         ? await embeddingModelInfo(
             schema,
             createServiceOptions(commandOptions, info.root),
+            workspaceRuntime,
           )
         : undefined;
     const plan = modelInfo
@@ -1495,6 +1578,8 @@ async function runServerQuery(
     "zvec_grep_search",
     {
       root: resolve(process.cwd()),
+      apiKey: options.apiKey,
+      device: options.device,
       queries: queries.length ? queries : undefined,
       fts: fts.length ? fts : undefined,
       vector: vector.length ? vector : undefined,
@@ -1659,10 +1744,12 @@ function resolveAuthorizationSchema(
 async function embeddingModelInfo(
   schema: Pick<CollectionEmbeddingSchema, "provider" | "model">,
   options: CreateZvecGrepOptions,
+  workspaceRuntime: EmbeddingRuntimeConfig = {},
 ): Promise<EmbeddingModelInfo> {
   const model = createEmbeddingModelForIdentity(
     { provider: schema.provider, name: schema.model },
     options,
+    workspaceRuntime,
   );
   try {
     return model.info;
@@ -1726,10 +1813,57 @@ function normalizedDirectSearchInput(
   const policy = resolveDirectSearchPolicy(options);
   return {
     root,
+    apiKey: options.apiKey,
+    device: options.device,
     queries: !options.rg && queries.length > 0 ? [...queries] : undefined,
     routes: [...(options.routes ?? [])],
     ...policy,
   };
+}
+
+function configuredEmbeddingReference(options: CliOptions): string | undefined {
+  return (
+    options.embedding ??
+    readGlobalConfig().defaults?.embedding ??
+    process.env.ZVEC_GREP_EMBEDDING
+  );
+}
+
+function workspaceRuntimeFromInfo(
+  info: ZvecGrepInfoResult,
+): EmbeddingRuntimeConfig {
+  const collection = info.collection;
+  if (!collection) return {};
+  const home =
+    info.home ||
+    (collection.name === "__anonymous__"
+      ? dirname(collection.path)
+      : dirname(dirname(collection.path)));
+  const registry = new CollectionRegistry(home, undefined, true);
+  try {
+    return registry.getEmbeddingRuntime(collection.name);
+  } finally {
+    registry.close();
+  }
+}
+
+function assertRequestedEndpointCompatible(
+  info: ZvecGrepInfoResult,
+  workspaceRuntime: EmbeddingRuntimeConfig,
+  requestedEndpoint: string | undefined,
+  rebuild: boolean,
+): void {
+  if (
+    rebuild ||
+    !info.collection?.embedding ||
+    requestedEndpoint === undefined ||
+    workspaceRuntime.endpoint === requestedEndpoint
+  ) {
+    return;
+  }
+  throw new Error(
+    "The requested embedding endpoint differs from the workspace snapshot. Run zg index --endpoint <url> --rebuild first.",
+  );
 }
 
 async function daemonIsReady(home?: string): Promise<boolean> {
@@ -1795,41 +1929,16 @@ export function createServiceOptions(
   options: CliOptions,
   root: string | undefined,
 ): CreateZvecGrepOptions {
-  const embedding = options.embedding ?? process.env.ZVEC_GREP_EMBEDDING;
-  const apiKey =
-    options.apiKey ??
-    process.env.ZVEC_GREP_API_KEY ??
-    process.env.DASHSCOPE_API_KEY ??
-    process.env.QWEN_API_KEY;
-  const endpoint = options.endpoint ?? process.env.ZVEC_GREP_ENDPOINT;
-
   return {
     root,
     home: options.home ?? process.env.ZVEC_GREP_HOME,
-    embedding,
-    apiKey,
-    endpoint,
-    modelCacheDir: options.modelCacheDir ?? process.env.ZVEC_GREP_MODEL_CACHE,
+    embedding: options.embedding,
+    apiKey: options.apiKey,
+    endpoint: options.endpoint,
+    modelCacheDir: options.modelCacheDir,
     device: options.device,
     authorizationSigningKeyPath: process.env.ZVEC_GREP_AUTHORIZATION_KEY_FILE,
   };
-}
-
-function persistExplicitGlobalConfig(
-  options: CliOptions,
-  indexedEmbedding: string | undefined,
-): void {
-  if (!updateGlobalConfigFromExplicitOptions(options, indexedEmbedding)) {
-    return;
-  }
-
-  console.log(`Global config: ${globalConfigPath()}`);
-}
-
-function embeddingReference(
-  embedding: { provider: string; model: string } | null | undefined,
-): string | undefined {
-  return embedding ? `${embedding.provider}/${embedding.model}` : undefined;
 }
 
 function resolveCodexHome(): string {

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -368,7 +368,7 @@ async function runAuth(parsed: ParsedArgs): Promise<void> {
   try {
     const info = await service.info({ root });
     const schema = resolveAuthorizationSchema(
-      configuredEmbeddingReference(parsed.options),
+      configuredEmbeddingReference(parsed.options, info.collection?.embedding),
       info.collection?.embedding,
     );
     if (!schema) {
@@ -988,7 +988,10 @@ async function runDirectIndex(
       includeStatus: parsed.options.rebuild !== true,
     });
     const schema = resolveAuthorizationSchema(
-      configuredEmbeddingReference(parsed.options),
+      configuredEmbeddingReference(
+        parsed.options,
+        infoBefore.collection?.embedding,
+      ),
       infoBefore.collection?.embedding,
     );
     assertEmbeddingModelCompatible(
@@ -1273,7 +1276,7 @@ async function runCollections(parsed: ParsedArgs): Promise<void> {
           zvecGrep.collections.status(name),
         ]);
         const schema = resolveAuthorizationSchema(
-          configuredEmbeddingReference(parsed.options),
+          configuredEmbeddingReference(parsed.options, existing?.embedding),
           existing?.embedding,
         );
         assertEmbeddingModelCompatible(
@@ -1824,9 +1827,13 @@ function normalizedDirectSearchInput(
   };
 }
 
-function configuredEmbeddingReference(options: CliOptions): string | undefined {
+function configuredEmbeddingReference(
+  options: CliOptions,
+  existing?: CollectionEmbeddingSchema | null,
+): string | undefined {
   return (
     options.embedding ??
+    (existing ? `${existing.provider}/${existing.model}` : undefined) ??
     readGlobalConfig().defaults?.embedding ??
     process.env.ZVEC_GREP_EMBEDDING
   );

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -189,13 +189,16 @@ async function runConfig(parsed: ParsedArgs): Promise<void> {
   const reference = parsed.positionals[0]!;
   if (parsed.options.configAction === "provider-set") {
     if (!/^[a-z][a-z0-9_-]*$/.test(reference)) {
-      throw new Error(`Invalid embedding provider: ${reference}`);
+      throw unsupportedRemoteEmbeddingProvider(
+        reference,
+        "Invalid embedding provider",
+      );
     }
     if (
       reference === "local" ||
       !listEmbeddingModels().some((entry) => entry.provider === reference)
     ) {
-      throw new Error(`Unsupported remote embedding provider: ${reference}`);
+      throw unsupportedRemoteEmbeddingProvider(reference);
     }
     if (parsed.options.apiKey === undefined) {
       throw new Error("zg config provider set requires --api-key");
@@ -215,10 +218,7 @@ async function runConfig(parsed: ParsedArgs): Promise<void> {
   if (parsed.options.configAction !== "model-set") {
     throw new Error("zg config requires provider set or model set");
   }
-  const catalogEntry = getEmbeddingModelCatalogEntry(reference);
-  if (!catalogEntry) {
-    throw new Error(`Unsupported embedding model: ${reference}`);
-  }
+  const catalogEntry = requireEmbeddingModelCatalogEntry(reference);
   if (
     parsed.options.endpoint === undefined &&
     parsed.options.device === undefined &&
@@ -892,6 +892,9 @@ async function runIndex(parsed: ParsedArgs): Promise<void> {
     await runDropIndex(parsed, rootPath.absolutePath);
     return;
   }
+  if (parsed.options.embedding) {
+    requireEmbeddingModelCatalogEntry(parsed.options.embedding);
+  }
 
   const mode = resolveClientMode(parsed.options.mode);
   await routeByMode({
@@ -1219,6 +1222,9 @@ async function runCollections(parsed: ParsedArgs): Promise<void> {
     throw new Error(
       `${indexOption} can only be used with zg collections index`,
     );
+  }
+  if (action === "index" && parsed.options.embedding) {
+    requireEmbeddingModelCatalogEntry(parsed.options.embedding);
   }
   const zvecGrep = await createZvecGrep(
     createServiceOptions(parsed.options, undefined),
@@ -1836,6 +1842,42 @@ function configuredEmbeddingReference(
     (existing ? `${existing.provider}/${existing.model}` : undefined) ??
     readGlobalConfig().defaults?.embedding ??
     process.env.ZVEC_GREP_EMBEDDING
+  );
+}
+
+function requireEmbeddingModelCatalogEntry(reference: string) {
+  const entry = getEmbeddingModelCatalogEntry(reference);
+  if (entry) {
+    return entry;
+  }
+  throw new Error(
+    [
+      `Unsupported embedding model: ${reference}`,
+      "Supported embedding models:",
+      ...[...listEmbeddingModels()]
+        .sort((left, right) => left.provider.localeCompare(right.provider))
+        .map((model) => `  ${model.reference}`),
+    ].join("\n"),
+  );
+}
+
+function unsupportedRemoteEmbeddingProvider(
+  reference: string,
+  message = "Unsupported remote embedding provider",
+): Error {
+  const providers = [
+    ...new Set(
+      listEmbeddingModels()
+        .map((model) => model.provider)
+        .filter((provider) => provider !== "local"),
+    ),
+  ];
+  return new Error(
+    [
+      `${message}: ${reference}`,
+      "Supported remote embedding providers:",
+      ...providers.map((provider) => `  ${provider}`),
+    ].join("\n"),
   );
 }
 

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -72,7 +72,6 @@ Result options:
 
 Embedding runtime:
   --api-key <key>                   Embedding provider API key
-  --endpoint <url>                  Embedding provider endpoint
   --model-cache <path>              Local model cache directory
   --device <device>                 auto, cpu, metal, vulkan, cuda
   --allow-remote                    Allow Remote Embedding for this command only
@@ -148,10 +147,13 @@ Named collections support the same embedding, file-selection, discovery,
 rebuild, and embedding-concurrency options as zg index.`;
     case "config":
       return `Usage:
+  zg config provider set <provider> --api-key <key>
+  zg config model set <provider/model> --endpoint <url>
   zg config model set <local/model> --device <auto|cpu|metal|vulkan|cuda>
+  zg config model set <provider/model> --default
 
-Stores the runtime device for one local embedding model in
-~/.zvec-grep/config.json. These settings do not change index compatibility.`;
+Stores provider credentials, per-model runtime defaults, and the default
+embedding model in ~/.zvec-grep/config.json.`;
     case "auth":
       return `Usage:
   zg auth grant [root] --capability embedding --scope workspace [--embedding <model>]

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -22,7 +22,7 @@ Commands:
   index          Build, rebuild, or drop the workspace index
   status         Show workspace and index status
   collections    Manage named collections
-  config         Configure per-model local embedding runtime settings
+  config         Configure provider credentials and embedding model defaults
   auth           Manage Workspace Remote Embedding authorization
   server         Start, stop, inspect, or run the shared MCP server
   install        Install agent integrations
@@ -148,12 +148,21 @@ rebuild, and embedding-concurrency options as zg index.`;
     case "config":
       return `Usage:
   zg config provider set <provider> --api-key <key>
-  zg config model set <provider/model> --endpoint <url>
-  zg config model set <local/model> --device <auto|cpu|metal|vulkan|cuda>
-  zg config model set <provider/model> --default
+  zg config model set <model> [--endpoint <url> | --device <device>] [--default]
 
-Stores provider credentials, per-model runtime defaults, and the default
-embedding model in ~/.zvec-grep/config.json.`;
+Provider options:
+  --api-key <key>                   Default API key for the provider
+
+Model options:
+  --endpoint <url>                  Endpoint for a remote embedding model
+  --device <device>                 Local device: auto, cpu, metal, vulkan, cuda
+  --default                         Use this model for new indexes
+
+Remote models support --endpoint; local models support --device. At least one
+model option is required. --default may be used alone or with a runtime option.
+Existing indexes continue to use their stored model.
+
+Global configuration is stored in ~/.zvec-grep/config.json.`;
     case "auth":
       return `Usage:
   zg auth grant [root] --capability embedding --scope workspace [--embedding <model>]

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -9,7 +9,8 @@ export type PreviewMode = "none" | "short" | "full";
 export type QueryRefreshMode = "background" | "wait" | "off";
 
 export type CliOptions = {
-  configAction?: "model-set";
+  configAction?: "model-set" | "provider-set";
+  defaultModel?: boolean;
   authAction?: "grant" | "status" | "revoke";
   authorizationCapability?: "embedding";
   authorizationScope?: "workspace";

--- a/src/daemon/backend.ts
+++ b/src/daemon/backend.ts
@@ -4,6 +4,13 @@ import type {
   ZvecGrepInfoResult,
 } from "../engine/service/types.js";
 import { isEngineError } from "../engine/errors/index.js";
+import {
+  readGlobalConfig,
+  resolveEmbeddingRuntimeOptions,
+  type EmbeddingRuntimeConfig,
+} from "../engine/config.js";
+import { CollectionRegistry } from "../engine/collection/index.js";
+import { anonymousIndexLocation } from "../engine/service/root.js";
 import type {
   EmbeddingModel,
   EmbeddingModelInfo,
@@ -88,6 +95,7 @@ export type DaemonBackendOptions = {
 
 type DaemonIndexInput = ZvecGrepIndexInput & {
   changedPaths?: readonly string[];
+  runtimeOverridesAreEphemeral?: boolean;
 };
 
 export class DaemonBackend implements ZvecGrepDaemonBackend {
@@ -96,6 +104,10 @@ export class DaemonBackend implements ZvecGrepDaemonBackend {
   readonly scheduler: JobScheduler;
   private readonly startedAt = Date.now();
   private readonly statusCache = new Map<string, ZvecGrepInfoResult>();
+  private readonly workspaceRuntimeCache = new Map<
+    string,
+    EmbeddingRuntimeConfig
+  >();
   private readonly watchers = new Map<string, WatchManager>();
   private readonly indexCoordinators = new Map<string, IndexCoordinator>();
   private readonly droppingRoots = new Set<string>();
@@ -139,9 +151,9 @@ export class DaemonBackend implements ZvecGrepDaemonBackend {
       return undefined;
     }
     const info = await inspectRoot(input.root, this.options.serviceOptions);
-    let model: EmbeddingModelLoadRequest["model"];
+    let modelLoadRequest: EmbeddingModelLoadRequest;
     try {
-      model = this.indexModel(info, input);
+      modelLoadRequest = this.indexModelLoadRequest(info, input);
     } catch (error) {
       if (error instanceof DaemonError && error.code === "MODEL_LOAD_FAILED") {
         return undefined;
@@ -150,7 +162,7 @@ export class DaemonBackend implements ZvecGrepDaemonBackend {
     }
     let lease: ModelLease;
     try {
-      lease = await this.modelPool.acquire({ model });
+      lease = await this.modelPool.acquire(modelLoadRequest);
     } catch (error) {
       if (isEngineError(error)) {
         return undefined;
@@ -216,10 +228,8 @@ export class DaemonBackend implements ZvecGrepDaemonBackend {
     if (!info.indexed || !schema || schema.provider !== "qwen") {
       return undefined;
     }
-    const modelInfo = await this.loadEmbeddingModelInfo({
-      provider: schema.provider,
-      name: schema.model,
-    });
+    const modelLoadRequest = this.searchModelLoadRequest(info, input);
+    const modelInfo = await this.loadEmbeddingModelInfo(modelLoadRequest);
     return await planRemoteSearchAuthorization({
       info,
       model: modelInfo,
@@ -373,6 +383,7 @@ export class DaemonBackend implements ZvecGrepDaemonBackend {
       return { root: canonicalRoot, removed };
     } finally {
       this.statusCache.delete(canonicalRoot);
+      this.workspaceRuntimeCache.delete(canonicalRoot);
       try {
         await this.runtimeManager.evict(canonicalRoot);
       } finally {
@@ -389,6 +400,21 @@ export class DaemonBackend implements ZvecGrepDaemonBackend {
     const requestedRoot = await resolveRequestedRoot(input.root, false);
     this.assertRootNotDropping(requestedRoot);
     const runtime = await this.runtimeManager.activate(requestedRoot);
+    const searchInfo = await this.inspectRootWithCache(runtime.canonicalRoot);
+    const currentModelLoadRequest = runtime.currentModelLoadRequest();
+    const defaultModelLoadRequest = searchInfo.indexed
+      ? this.searchModelLoadRequest(searchInfo, {})
+      : currentModelLoadRequest;
+    if (!defaultModelLoadRequest) {
+      throw new DaemonError(
+        "INDEX_MISSING",
+        "Search requires an existing workspace index.",
+      );
+    }
+    const searchModelLoadRequest = searchInfo.indexed
+      ? this.searchModelLoadRequest(searchInfo, input)
+      : this.overrideActiveModelLoadRequest(defaultModelLoadRequest, input);
+    runtime.updateModelLoadRequest(defaultModelLoadRequest);
     this.ensureWatcher(runtime);
     await runtime.probeInitialFreshness(
       async () => {
@@ -411,35 +437,40 @@ export class DaemonBackend implements ZvecGrepDaemonBackend {
     let updateJob: IndexJobSnapshot | undefined;
     const executeSearch = () =>
       withRemoteEmbeddingOperationPermit(options.authorization, () =>
-        runtime.search({
-          queries: input.queries,
-          routes: input.routes,
-          fuse: input.fuse,
-          limit: input.limit,
-          trace: input.trace,
-          preferSymbol: input.preferSymbol,
-          symbolTypes: input.symbolTypes,
-          globs: normalizePlainStringList(input.globs),
-          insensitiveGlobs: normalizePlainStringList(input.insensitiveGlobs),
-          fileTypes: normalizePlainStringList(input.fileTypes),
-          excludedFileTypes: normalizePlainStringList(input.excludedFileTypes),
-          hidden: input.hidden,
-          noIgnore: input.noIgnore,
-          ignoreFiles: input.ignoreFiles,
-          maxDepth: input.maxDepth,
-          maxFileSizeBytes: input.maxFileSizeBytes,
-          follow: input.follow,
-          embeddingConcurrency: input.embeddingConcurrency,
-          modifiedAfter: input.modifiedAfter,
-          modifiedBefore: input.modifiedBefore,
-          autoUpdate: false,
-        }),
+        runtime.search(
+          {
+            queries: input.queries,
+            routes: input.routes,
+            fuse: input.fuse,
+            limit: input.limit,
+            trace: input.trace,
+            preferSymbol: input.preferSymbol,
+            symbolTypes: input.symbolTypes,
+            globs: normalizePlainStringList(input.globs),
+            insensitiveGlobs: normalizePlainStringList(input.insensitiveGlobs),
+            fileTypes: normalizePlainStringList(input.fileTypes),
+            excludedFileTypes: normalizePlainStringList(
+              input.excludedFileTypes,
+            ),
+            hidden: input.hidden,
+            noIgnore: input.noIgnore,
+            ignoreFiles: input.ignoreFiles,
+            maxDepth: input.maxDepth,
+            maxFileSizeBytes: input.maxFileSizeBytes,
+            follow: input.follow,
+            embeddingConcurrency: input.embeddingConcurrency,
+            modifiedAfter: input.modifiedAfter,
+            modifiedBefore: input.modifiedBefore,
+            autoUpdate: false,
+          },
+          searchModelLoadRequest,
+        ),
       );
     let result;
     if (input.freshness === "wait_for_fresh") {
       while (true) {
         updateJob =
-          (await this.waitForFresh(runtime, options.authorization)) ??
+          (await this.waitForFresh(runtime, options.authorization, input)) ??
           updateJob;
         const beforeSearch = runtime.snapshot();
         result = await executeSearch();
@@ -474,7 +505,12 @@ export class DaemonBackend implements ZvecGrepDaemonBackend {
       if (runtime.needsReconciliation() && !terminalKnownPathJob) {
         updateJob = await this.submitIndex(
           runtime,
-          { root: runtime.canonicalRoot },
+          {
+            root: runtime.canonicalRoot,
+            apiKey: input.apiKey,
+            device: input.device,
+            runtimeOverridesAreEphemeral: true,
+          },
           "background_reconcile",
           false,
           options.authorization,
@@ -628,6 +664,7 @@ export class DaemonBackend implements ZvecGrepDaemonBackend {
       await this.scheduler.close();
       await this.runtimeManager.close();
       await this.modelPool.close();
+      this.workspaceRuntimeCache.clear();
     })();
     return this.closePromise;
   }
@@ -647,8 +684,8 @@ export class DaemonBackend implements ZvecGrepDaemonBackend {
       true,
     );
     this.statusCache.set(runtime.canonicalRoot, before);
-    const model = this.indexModel(before, input);
-    const modelLoadRequest = { model };
+    const modelLoadRequest = this.indexModelLoadRequest(before, input);
+    const model = modelLoadRequest.model;
     runtime.updateModelLoadRequest(modelLoadRequest);
     let lease: ModelLease;
     try {
@@ -666,6 +703,14 @@ export class DaemonBackend implements ZvecGrepDaemonBackend {
         root: runtime.canonicalRoot,
         embeddingModel: lease.model,
         embeddingModelOwnership: "borrowed",
+        embedding: input.runtimeOverridesAreEphemeral
+          ? undefined
+          : input.embedding,
+        apiKey: input.runtimeOverridesAreEphemeral ? undefined : input.apiKey,
+        endpoint: input.runtimeOverridesAreEphemeral
+          ? undefined
+          : input.endpoint,
+        device: input.runtimeOverridesAreEphemeral ? undefined : input.device,
         daemonInstanceToken: this.runtimeManager.instanceToken,
       });
       await withRemoteEmbeddingOperationPermit(authorization, () =>
@@ -714,12 +759,7 @@ export class DaemonBackend implements ZvecGrepDaemonBackend {
         "Index completed without an embedding schema.",
       );
     }
-    runtime.updateModelLoadRequest({
-      model: {
-        provider: after.collection.embedding.provider,
-        name: after.collection.embedding.model,
-      },
-    });
+    runtime.updateModelLoadRequest(this.searchModelLoadRequest(after, {}));
     this.options.logger?.event("index.completed", {
       root_id: rootIdentity(runtime.canonicalRoot),
       duration_ms: Date.now() - startedAt,
@@ -905,10 +945,9 @@ export class DaemonBackend implements ZvecGrepDaemonBackend {
     const info = await inspectRoot(root, this.options.serviceOptions);
     const schema = info.collection?.embedding;
     if (!schema || schema.provider !== "qwen") return { allowed: true };
-    const modelInfo = await this.loadEmbeddingModelInfo({
-      provider: schema.provider,
-      name: schema.model,
-    });
+    const modelInfo = await this.loadEmbeddingModelInfo(
+      this.searchModelLoadRequest(info, {}),
+    );
     const plan = await planRemoteIndexAuthorization({
       info,
       model: modelInfo,
@@ -926,6 +965,7 @@ export class DaemonBackend implements ZvecGrepDaemonBackend {
   private async waitForFresh(
     runtime: RootRuntime,
     authorization?: RemoteEmbeddingOperationPermit,
+    runtimeOverrides: Pick<NormalizedSearchInput, "apiKey" | "device"> = {},
   ): Promise<IndexJobSnapshot | undefined> {
     let updateJob: IndexJobSnapshot | undefined;
     while (true) {
@@ -957,7 +997,12 @@ export class DaemonBackend implements ZvecGrepDaemonBackend {
       }
       updateJob = await this.submitIndex(
         runtime,
-        { root: runtime.canonicalRoot },
+        {
+          root: runtime.canonicalRoot,
+          apiKey: runtimeOverrides.apiKey,
+          device: runtimeOverrides.device,
+          runtimeOverridesAreEphemeral: true,
+        },
         "fresh_query",
         true,
         authorization,
@@ -973,9 +1018,9 @@ export class DaemonBackend implements ZvecGrepDaemonBackend {
   }
 
   private async loadEmbeddingModelInfo(
-    model: EmbeddingModelLoadRequest["model"],
+    request: EmbeddingModelLoadRequest,
   ): Promise<EmbeddingModelInfo> {
-    const lease = await this.modelPool.acquire({ model });
+    const lease = await this.modelPool.acquire(request);
     try {
       return lease.model.info;
     } finally {
@@ -1030,6 +1075,8 @@ export class DaemonBackend implements ZvecGrepDaemonBackend {
     const reference =
       input.embedding ??
       this.options.serviceOptions?.embedding ??
+      readGlobalConfig().defaults?.embedding ??
+      nonEmptyEnvironmentValue(process.env.ZVEC_GREP_EMBEDDING) ??
       (this.options.serviceOptions?.defaultEmbedding
         ? DEFAULT_LOCAL_EMBEDDING
         : undefined);
@@ -1041,6 +1088,152 @@ export class DaemonBackend implements ZvecGrepDaemonBackend {
     }
     return parseEmbeddingModelReference(reference);
   }
+
+  private indexModelLoadRequest(
+    info: ZvecGrepInfoResult,
+    input: Pick<
+      DaemonIndexInput,
+      "embedding" | "apiKey" | "endpoint" | "device" | "rebuild"
+    >,
+  ): EmbeddingModelLoadRequest {
+    const model = this.indexModel(info, input as ZvecGrepIndexInput);
+    const workspaceRuntime =
+      info.collection?.embedding?.provider === model.provider
+        ? this.readWorkspaceEmbeddingRuntime(info)
+        : {};
+    const runtime = this.resolveModelRuntime(model, workspaceRuntime, input);
+    if (
+      input.rebuild !== true &&
+      info.collection?.embedding &&
+      workspaceRuntime.endpoint !== runtime.endpoint
+    ) {
+      throw new DaemonError(
+        "EMBEDDING_ENDPOINT_MISMATCH",
+        "The requested embedding endpoint differs from the workspace snapshot; use rebuild to change endpoints.",
+      );
+    }
+    return { model, runtime };
+  }
+
+  private searchModelLoadRequest(
+    info: ZvecGrepInfoResult,
+    overrides: Pick<NormalizedSearchInput, "apiKey" | "device">,
+  ): EmbeddingModelLoadRequest {
+    const schema = info.collection?.embedding;
+    if (!info.indexed || !schema) {
+      throw new DaemonError(
+        "INDEX_MISSING",
+        "Search requires an existing workspace index.",
+      );
+    }
+    const model = {
+      provider: schema.provider,
+      name: schema.model,
+    };
+    const workspaceRuntime = this.readWorkspaceEmbeddingRuntime(info);
+    const runtime = this.resolveModelRuntime(
+      model,
+      workspaceRuntime,
+      overrides,
+    );
+    return { model, runtime };
+  }
+
+  private resolveModelRuntime(
+    model: EmbeddingModelLoadRequest["model"],
+    workspaceRuntime: EmbeddingRuntimeConfig,
+    overrides: {
+      apiKey?: string;
+      endpoint?: string;
+      device?: "auto" | "cpu" | "metal" | "vulkan" | "cuda";
+    },
+  ): EmbeddingRuntimeConfig {
+    const serviceOptions = this.options.serviceOptions;
+    return resolveEmbeddingRuntimeOptions(
+      embeddingModelReference(model),
+      {
+        apiKey: overrides.apiKey ?? serviceOptions?.apiKey,
+        endpoint: overrides.endpoint ?? serviceOptions?.endpoint,
+        device: overrides.device ?? serviceOptions?.device,
+      },
+      workspaceRuntime,
+      readGlobalConfig(),
+    );
+  }
+
+  private overrideActiveModelLoadRequest(
+    request: EmbeddingModelLoadRequest,
+    overrides: Pick<NormalizedSearchInput, "apiKey" | "device">,
+  ): EmbeddingModelLoadRequest {
+    const runtime = resolveEmbeddingRuntimeOptions(
+      embeddingModelReference(request.model),
+      overrides,
+      request.runtime ?? {},
+      readGlobalConfig(),
+    );
+    return { model: request.model, runtime };
+  }
+
+  private readWorkspaceEmbeddingRuntime(
+    info: ZvecGrepInfoResult,
+  ): EmbeddingRuntimeConfig {
+    try {
+      const runtime = readWorkspaceEmbeddingRuntime(info);
+      this.workspaceRuntimeCache.set(info.root, runtime);
+      return runtime;
+    } catch (error) {
+      const cached = this.workspaceRuntimeCache.get(info.root);
+      if (
+        cached &&
+        isEngineError(error) &&
+        (error.code === "ZVEC_GREP.ENGINE.STORAGE.ZVEC_OPEN_FAILED" ||
+          error.code === "ZVEC_GREP.ENGINE.LOCK.BUSY")
+      ) {
+        return cached;
+      }
+      throw error;
+    }
+  }
+
+  private async inspectRootWithCache(
+    root: string,
+  ): Promise<ZvecGrepInfoResult> {
+    try {
+      const info = await inspectRoot(root, this.options.serviceOptions);
+      this.statusCache.set(root, info);
+      return info;
+    } catch (error) {
+      const cached = this.statusCache.get(root);
+      if (
+        cached &&
+        isEngineError(error) &&
+        error.code === "ZVEC_GREP.ENGINE.LOCK.BUSY"
+      ) {
+        return cached;
+      }
+      throw error;
+    }
+  }
+}
+
+function readWorkspaceEmbeddingRuntime(
+  info: ZvecGrepInfoResult,
+): EmbeddingRuntimeConfig {
+  if (!info.collection) return {};
+  const location = anonymousIndexLocation(info.root);
+  const registry = new CollectionRegistry(location.home, undefined, true);
+  try {
+    return registry.getEmbeddingRuntime(info.collection.name);
+  } finally {
+    registry.close();
+  }
+}
+
+function nonEmptyEnvironmentValue(
+  value: string | undefined,
+): string | undefined {
+  const normalized = value?.trim();
+  return normalized ? normalized : undefined;
 }
 
 function indexStatusIsFresh(info: ZvecGrepInfoResult): boolean {
@@ -1059,6 +1252,9 @@ function indexStatusIsFresh(info: ZvecGrepInfoResult): boolean {
 function assertDropOnlyInput(input: ZvecGrepIndexInput): void {
   const conflicts: Array<[boolean, string]> = [
     [input.embedding !== undefined, "embedding"],
+    [input.apiKey !== undefined, "apiKey"],
+    [input.endpoint !== undefined, "endpoint"],
+    [input.device !== undefined, "device"],
     [input.rebuild !== undefined, "rebuild"],
     [input.resetPaths !== undefined, "resetPaths"],
     [input.globs !== undefined, "globs"],

--- a/src/daemon/backend.ts
+++ b/src/daemon/backend.ts
@@ -743,7 +743,8 @@ export class DaemonBackend implements ZvecGrepDaemonBackend {
           changedPaths: input.changedPaths,
           signal,
           onProgress: report,
-          onWriterContext: (context) => runtime.setWriterContext(context),
+          onWriterContext: (context) =>
+            runtime.setWriterContext(context, lease.key),
         }),
       );
     } finally {

--- a/src/daemon/backend.ts
+++ b/src/daemon/backend.ts
@@ -150,7 +150,11 @@ export class DaemonBackend implements ZvecGrepDaemonBackend {
     if (input.rebuild !== true && this.scheduler.hasActiveRoot(requestedRoot)) {
       return undefined;
     }
-    const info = await inspectRoot(input.root, this.options.serviceOptions);
+    const info = await inspectRoot(
+      input.root,
+      this.options.serviceOptions,
+      input.rebuild !== true,
+    );
     let modelLoadRequest: EmbeddingModelLoadRequest;
     try {
       modelLoadRequest = this.indexModelLoadRequest(info, input);
@@ -400,151 +404,158 @@ export class DaemonBackend implements ZvecGrepDaemonBackend {
     const requestedRoot = await resolveRequestedRoot(input.root, false);
     this.assertRootNotDropping(requestedRoot);
     const runtime = await this.runtimeManager.activate(requestedRoot);
-    const searchInfo = await this.inspectRootWithCache(runtime.canonicalRoot);
-    const currentModelLoadRequest = runtime.currentModelLoadRequest();
-    const defaultModelLoadRequest = searchInfo.indexed
-      ? this.searchModelLoadRequest(searchInfo, {})
-      : currentModelLoadRequest;
-    if (!defaultModelLoadRequest) {
-      throw new DaemonError(
-        "INDEX_MISSING",
-        "Search requires an existing workspace index.",
-      );
-    }
-    const searchModelLoadRequest = searchInfo.indexed
-      ? this.searchModelLoadRequest(searchInfo, input)
-      : this.overrideActiveModelLoadRequest(defaultModelLoadRequest, input);
-    runtime.updateModelLoadRequest(defaultModelLoadRequest);
-    this.ensureWatcher(runtime);
-    await runtime.probeInitialFreshness(
-      async () => {
-        const info = await inspectRoot(
-          runtime.canonicalRoot,
-          this.options.serviceOptions,
+    const releaseRuntimeActivity = runtime.beginActivity();
+    try {
+      const searchInfo = await this.inspectRootWithCache(runtime.canonicalRoot);
+      const currentModelLoadRequest = runtime.currentModelLoadRequest();
+      const defaultModelLoadRequest = searchInfo.indexed
+        ? this.searchModelLoadRequest(searchInfo, {})
+        : currentModelLoadRequest;
+      if (!defaultModelLoadRequest) {
+        throw new DaemonError(
+          "INDEX_MISSING",
+          "Search requires an existing workspace index.",
         );
-        this.statusCache.set(runtime.canonicalRoot, info);
-        return indexStatusIsFresh(info);
-      },
-      (initialFreshness) => {
-        this.options.logger?.event(
-          `runtime.initial_probe_${initialFreshness}`,
-          {
-            root_id: rootIdentity(runtime.canonicalRoot),
-          },
-        );
-      },
-    );
-    let updateJob: IndexJobSnapshot | undefined;
-    const executeSearch = () =>
-      withRemoteEmbeddingOperationPermit(options.authorization, () =>
-        runtime.search(
-          {
-            queries: input.queries,
-            routes: input.routes,
-            fuse: input.fuse,
-            limit: input.limit,
-            trace: input.trace,
-            preferSymbol: input.preferSymbol,
-            symbolTypes: input.symbolTypes,
-            globs: normalizePlainStringList(input.globs),
-            insensitiveGlobs: normalizePlainStringList(input.insensitiveGlobs),
-            fileTypes: normalizePlainStringList(input.fileTypes),
-            excludedFileTypes: normalizePlainStringList(
-              input.excludedFileTypes,
-            ),
-            hidden: input.hidden,
-            noIgnore: input.noIgnore,
-            ignoreFiles: input.ignoreFiles,
-            maxDepth: input.maxDepth,
-            maxFileSizeBytes: input.maxFileSizeBytes,
-            follow: input.follow,
-            embeddingConcurrency: input.embeddingConcurrency,
-            modifiedAfter: input.modifiedAfter,
-            modifiedBefore: input.modifiedBefore,
-            autoUpdate: false,
-          },
-          searchModelLoadRequest,
-        ),
+      }
+      const searchModelLoadRequest = searchInfo.indexed
+        ? this.searchModelLoadRequest(searchInfo, input)
+        : this.overrideActiveModelLoadRequest(defaultModelLoadRequest, input);
+      runtime.updateModelLoadRequest(defaultModelLoadRequest);
+      this.ensureWatcher(runtime);
+      await runtime.probeInitialFreshness(
+        async () => {
+          const info = await inspectRoot(
+            runtime.canonicalRoot,
+            this.options.serviceOptions,
+          );
+          this.statusCache.set(runtime.canonicalRoot, info);
+          return indexStatusIsFresh(info);
+        },
+        (initialFreshness) => {
+          this.options.logger?.event(
+            `runtime.initial_probe_${initialFreshness}`,
+            {
+              root_id: rootIdentity(runtime.canonicalRoot),
+            },
+          );
+        },
       );
-    let result;
-    if (input.freshness === "wait_for_fresh") {
-      while (true) {
-        updateJob =
-          (await this.waitForFresh(runtime, options.authorization, input)) ??
-          updateJob;
-        const beforeSearch = runtime.snapshot();
+      let updateJob: IndexJobSnapshot | undefined;
+      const executeSearch = () =>
+        withRemoteEmbeddingOperationPermit(options.authorization, () =>
+          runtime.search(
+            {
+              queries: input.queries,
+              routes: input.routes,
+              fuse: input.fuse,
+              limit: input.limit,
+              trace: input.trace,
+              preferSymbol: input.preferSymbol,
+              symbolTypes: input.symbolTypes,
+              globs: normalizePlainStringList(input.globs),
+              insensitiveGlobs: normalizePlainStringList(
+                input.insensitiveGlobs,
+              ),
+              fileTypes: normalizePlainStringList(input.fileTypes),
+              excludedFileTypes: normalizePlainStringList(
+                input.excludedFileTypes,
+              ),
+              hidden: input.hidden,
+              noIgnore: input.noIgnore,
+              ignoreFiles: input.ignoreFiles,
+              maxDepth: input.maxDepth,
+              maxFileSizeBytes: input.maxFileSizeBytes,
+              follow: input.follow,
+              embeddingConcurrency: input.embeddingConcurrency,
+              modifiedAfter: input.modifiedAfter,
+              modifiedBefore: input.modifiedBefore,
+              autoUpdate: false,
+            },
+            searchModelLoadRequest,
+          ),
+        );
+      let result;
+      if (input.freshness === "wait_for_fresh") {
+        while (true) {
+          updateJob =
+            (await this.waitForFresh(runtime, options.authorization, input)) ??
+            updateJob;
+          const beforeSearch = runtime.snapshot();
+          result = await executeSearch();
+          const afterSearch = runtime.snapshot();
+          if (
+            !afterSearch.watcherPending &&
+            afterSearch.watcherEpoch === beforeSearch.watcherEpoch &&
+            !runtime.needsReconciliation()
+          ) {
+            break;
+          }
+        }
+      } else {
         result = await executeSearch();
-        const afterSearch = runtime.snapshot();
+      }
+      if (
+        runtime.needsReconciliation() &&
+        input.autoUpdate &&
+        (runtime.requiresFullReconciliation() ||
+          !this.scheduler.hasActiveRoot(runtime.canonicalRoot))
+      ) {
         if (
-          !afterSearch.watcherPending &&
-          afterSearch.watcherEpoch === beforeSearch.watcherEpoch &&
-          !runtime.needsReconciliation()
+          !runtime.requiresFullReconciliation() ||
+          runtime.canProbeFullReconciliation()
         ) {
-          break;
+          await this.probeCurrentFreshness(runtime);
+        }
+        const currentJob = this.scheduler.getByRoot(runtime.canonicalRoot);
+        const terminalKnownPathJob =
+          !runtime.requiresFullReconciliation() &&
+          (currentJob?.state === "failed" || currentJob?.state === "cancelled");
+        if (runtime.needsReconciliation() && !terminalKnownPathJob) {
+          updateJob = await this.submitIndex(
+            runtime,
+            {
+              root: runtime.canonicalRoot,
+              apiKey: input.apiKey,
+              device: input.device,
+              runtimeOverridesAreEphemeral: true,
+            },
+            "background_reconcile",
+            false,
+            options.authorization,
+          );
         }
       }
-    } else {
-      result = await executeSearch();
+      const job = updateJob ?? this.scheduler.getByRoot(runtime.canonicalRoot);
+      const runtimeSnapshot = runtime.snapshot();
+      const freshness =
+        runtime.needsReconciliation() ||
+        runtimeSnapshot.watcherPending ||
+        job?.state === "queued" ||
+        job?.state === "running"
+          ? "possibly_stale"
+          : "fresh";
+      const response: ZvecGrepSearchResult = {
+        root: runtime.canonicalRoot,
+        freshness,
+        indexing:
+          freshness === "possibly_stale"
+            ? searchIndexingSnapshot(
+                job,
+                this.currentIndexCompletion(runtime.canonicalRoot),
+              )
+            : undefined,
+        result,
+      };
+      this.options.logger?.event("search.completed", {
+        root_id: rootIdentity(runtime.canonicalRoot),
+        duration_ms: Date.now() - startedAt,
+        freshness: response.freshness,
+        result_count: result.items.length,
+      });
+      return response;
+    } finally {
+      releaseRuntimeActivity();
     }
-    if (
-      runtime.needsReconciliation() &&
-      input.autoUpdate &&
-      (runtime.requiresFullReconciliation() ||
-        !this.scheduler.hasActiveRoot(runtime.canonicalRoot))
-    ) {
-      if (
-        !runtime.requiresFullReconciliation() ||
-        runtime.canProbeFullReconciliation()
-      ) {
-        await this.probeCurrentFreshness(runtime);
-      }
-      const currentJob = this.scheduler.getByRoot(runtime.canonicalRoot);
-      const terminalKnownPathJob =
-        !runtime.requiresFullReconciliation() &&
-        (currentJob?.state === "failed" || currentJob?.state === "cancelled");
-      if (runtime.needsReconciliation() && !terminalKnownPathJob) {
-        updateJob = await this.submitIndex(
-          runtime,
-          {
-            root: runtime.canonicalRoot,
-            apiKey: input.apiKey,
-            device: input.device,
-            runtimeOverridesAreEphemeral: true,
-          },
-          "background_reconcile",
-          false,
-          options.authorization,
-        );
-      }
-    }
-    const job = updateJob ?? this.scheduler.getByRoot(runtime.canonicalRoot);
-    const runtimeSnapshot = runtime.snapshot();
-    const freshness =
-      runtime.needsReconciliation() ||
-      runtimeSnapshot.watcherPending ||
-      job?.state === "queued" ||
-      job?.state === "running"
-        ? "possibly_stale"
-        : "fresh";
-    const response: ZvecGrepSearchResult = {
-      root: runtime.canonicalRoot,
-      freshness,
-      indexing:
-        freshness === "possibly_stale"
-          ? searchIndexingSnapshot(
-              job,
-              this.currentIndexCompletion(runtime.canonicalRoot),
-            )
-          : undefined,
-      result,
-    };
-    this.options.logger?.event("search.completed", {
-      root_id: rootIdentity(runtime.canonicalRoot),
-      duration_ms: Date.now() - startedAt,
-      freshness: response.freshness,
-      result_count: result.items.length,
-    });
-    return response;
   }
 
   private currentIndexCompletion(canonicalRoot: string) {
@@ -681,7 +692,7 @@ export class DaemonBackend implements ZvecGrepDaemonBackend {
     const before = await inspectRoot(
       runtime.canonicalRoot,
       this.options.serviceOptions,
-      true,
+      input.rebuild !== true,
     );
     this.statusCache.set(runtime.canonicalRoot, before);
     const modelLoadRequest = this.indexModelLoadRequest(before, input);

--- a/src/daemon/model-pool.ts
+++ b/src/daemon/model-pool.ts
@@ -5,10 +5,12 @@ import {
   type EmbeddingModelIdentity,
 } from "../engine/service/zvec-grep.js";
 import type { EmbeddingModel } from "../engine/models/index.js";
+import type { EmbeddingRuntimeConfig } from "../engine/config.js";
 import { opaqueIdentity, type DaemonLogger } from "./logger.js";
 
 export type EmbeddingModelLoadRequest = {
   model: EmbeddingModelIdentity;
+  runtime?: EmbeddingRuntimeConfig;
 };
 
 export type ModelLease = {
@@ -63,14 +65,17 @@ export class EmbeddingModelPool {
     this.createModel =
       options.createModel ??
       ((request) =>
-        createEmbeddingModelForIdentity(request.model, options.serviceOptions));
+        createEmbeddingModelForIdentity(request.model, {
+          ...options.serviceOptions,
+          ...request.runtime,
+        }));
     this.keyForRequest =
       options.keyForRequest ??
       ((request) =>
-        embeddingModelPoolKeyForIdentity(
-          request.model,
-          options.serviceOptions,
-        ));
+        embeddingModelPoolKeyForIdentity(request.model, {
+          ...options.serviceOptions,
+          ...request.runtime,
+        }));
     this.logger = options.logger;
   }
 

--- a/src/daemon/model-pool.ts
+++ b/src/daemon/model-pool.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import type { CreateZvecGrepOptions } from "../engine/service/types.js";
 import {
   createEmbeddingModelForIdentity,
@@ -6,7 +7,7 @@ import {
 } from "../engine/service/zvec-grep.js";
 import type { EmbeddingModel } from "../engine/models/index.js";
 import type { EmbeddingRuntimeConfig } from "../engine/config.js";
-import { opaqueIdentity, type DaemonLogger } from "./logger.js";
+import type { DaemonLogger } from "./logger.js";
 
 export type EmbeddingModelLoadRequest = {
   model: EmbeddingModelIdentity;
@@ -37,6 +38,7 @@ export type EmbeddingModelPoolOptions = {
 
 type ModelEntry = {
   key: string;
+  logIdentity: string;
   model?: EmbeddingModel;
   loading?: Promise<EmbeddingModel>;
   leases: number;
@@ -89,6 +91,7 @@ export class EmbeddingModelPool {
     if (!entry) {
       entry = {
         key,
+        logIdentity: randomUUID(),
         leases: 0,
         lastUsedAt: Date.now(),
         retired: false,
@@ -103,7 +106,7 @@ export class EmbeddingModelPool {
 
     if (!entry.model) {
       if (!entry.loading) {
-        this.logger?.event("model.load", { model_id: opaqueIdentity(key) });
+        this.logger?.event("model.load", { model_id: entry.logIdentity });
         entry.loading = Promise.resolve(this.createModel(request));
       }
       try {
@@ -115,7 +118,7 @@ export class EmbeddingModelPool {
         entry.loading = undefined;
       }
     } else {
-      this.logger?.event("model.cache_hit", { model_id: opaqueIdentity(key) });
+      this.logger?.event("model.cache_hit", { model_id: entry.logIdentity });
     }
 
     if (this.closed) {
@@ -247,7 +250,7 @@ export class EmbeddingModelPool {
     this.entries.delete(entry.key);
     await model.dispose();
     this.logger?.event("model.evicted", {
-      model_id: opaqueIdentity(entry.key),
+      model_id: entry.logIdentity,
     });
   }
 }

--- a/src/daemon/root-runtime.ts
+++ b/src/daemon/root-runtime.ts
@@ -56,6 +56,7 @@ export class RootRuntime {
   private activeWriterSearches = 0;
   private writerSearchesDrained?: Promise<void>;
   private writerSearchesDrainedResolve?: () => void;
+  private activeOperations = 0;
   private closed = false;
 
   constructor(private readonly options: RootRuntimeOptions) {
@@ -73,6 +74,23 @@ export class RootRuntime {
 
   currentModelLoadRequest(): EmbeddingModelLoadRequest | undefined {
     return this.modelLoadRequest;
+  }
+
+  beginActivity(): () => void {
+    if (this.closed) {
+      throw new Error("Root runtime is closed.");
+    }
+    this.activeOperations += 1;
+    this.options.onActivity?.();
+    let released = false;
+    return () => {
+      if (released) {
+        return;
+      }
+      released = true;
+      this.activeOperations = Math.max(0, this.activeOperations - 1);
+      this.options.onActivity?.();
+    };
   }
 
   async search(
@@ -276,6 +294,7 @@ export class RootRuntime {
   snapshot(): {
     readCollectionOpen: boolean;
     activeReaders: number;
+    activeOperations: number;
     writerPending: boolean;
     dirtyRevision: number;
     indexedRevision: number;
@@ -287,6 +306,7 @@ export class RootRuntime {
     return {
       readCollectionOpen: read?.open ?? false,
       activeReaders: read?.activeReaders ?? 0,
+      activeOperations: this.activeOperations,
       writerPending: this.writerPending,
       dirtyRevision: this.dirtyRevision,
       indexedRevision: this.indexedRevision,

--- a/src/daemon/root-runtime.ts
+++ b/src/daemon/root-runtime.ts
@@ -53,6 +53,7 @@ export class RootRuntime {
   private writerContext?: (
     options: ZvecGrepContextOptions,
   ) => Promise<ZvecGrepContextResult>;
+  private writerModelKey?: string;
   private activeWriterSearches = 0;
   private writerSearchesDrained?: Promise<void>;
   private writerSearchesDrainedResolve?: () => void;
@@ -106,12 +107,10 @@ export class RootRuntime {
       : undefined;
     while (true) {
       const writerContext = this.writerContext;
-      const writerModelKey = this.modelLoadRequest
-        ? this.options.modelPool.keyFor(this.modelLoadRequest)
-        : undefined;
       if (
         writerContext &&
-        (overrideModelKey === undefined || overrideModelKey === writerModelKey)
+        (overrideModelKey === undefined ||
+          overrideModelKey === this.writerModelKey)
       ) {
         return await this.withWriterContext(writerContext, options);
       }
@@ -168,8 +167,10 @@ export class RootRuntime {
     context: (
       options: ZvecGrepContextOptions,
     ) => Promise<ZvecGrepContextResult>,
+    modelKey: string,
   ): () => Promise<void> {
     this.writerContext = context;
+    this.writerModelKey = modelKey;
     this.notifyWriterStateChanged();
     this.armWriterReady();
     return async () => {
@@ -177,6 +178,7 @@ export class RootRuntime {
         return;
       }
       this.writerContext = undefined;
+      this.writerModelKey = undefined;
       this.notifyWriterStateChanged();
       this.armWriterReady();
       if (this.activeWriterSearches > 0) {

--- a/src/daemon/root-runtime.ts
+++ b/src/daemon/root-runtime.ts
@@ -71,16 +71,30 @@ export class RootRuntime {
     return this.modelLoadRequest?.model.provider;
   }
 
+  currentModelLoadRequest(): EmbeddingModelLoadRequest | undefined {
+    return this.modelLoadRequest;
+  }
+
   async search(
     options: ZvecGrepContextOptions,
+    modelLoadRequest?: EmbeddingModelLoadRequest,
   ): Promise<ZvecGrepContextResult> {
     this.options.onActivity?.();
     if (this.closed) {
       throw new Error("Root runtime is closed.");
     }
+    const overrideModelKey = modelLoadRequest
+      ? this.options.modelPool.keyFor(modelLoadRequest)
+      : undefined;
     while (true) {
       const writerContext = this.writerContext;
-      if (writerContext) {
+      const writerModelKey = this.modelLoadRequest
+        ? this.options.modelPool.keyFor(this.modelLoadRequest)
+        : undefined;
+      if (
+        writerContext &&
+        (overrideModelKey === undefined || overrideModelKey === writerModelKey)
+      ) {
         return await this.withWriterContext(writerContext, options);
       }
       if (!this.writerPending || !this.writerReady) {
@@ -93,7 +107,7 @@ export class RootRuntime {
       if (this.closed) {
         throw new Error("Root runtime is closed.");
       }
-      const request = this.modelLoadRequest;
+      const request = modelLoadRequest ?? this.modelLoadRequest;
       if (!request) {
         throw new Error("Root runtime does not have an embedding model.");
       }

--- a/src/daemon/runtime-manager.ts
+++ b/src/daemon/runtime-manager.ts
@@ -279,6 +279,7 @@ export class RuntimeManager {
     const snapshot = runtime.snapshot();
     if (
       snapshot.activeReaders > 0 ||
+      snapshot.activeOperations > 0 ||
       snapshot.writerPending ||
       snapshot.watcherPending
     ) {

--- a/src/engine/collection/index.ts
+++ b/src/engine/collection/index.ts
@@ -61,6 +61,7 @@ import type {
 } from "../types.js";
 import { CURRENT_INDEX_VERSION } from "../types.js";
 import { defaultHome, normalizePath } from "../utils/path.js";
+import type { EmbeddingDevice, EmbeddingRuntimeConfig } from "../config.js";
 
 const COLLECTIONS_ZVEC = "collections.zvec";
 const FILES_ZVEC = "files.zvec";
@@ -374,6 +375,30 @@ export class CollectionRegistry {
 
   get(name: string): CollectionInfo | null {
     return this.meta.getByName(name);
+  }
+
+  getEmbeddingRuntime(name: string): EmbeddingRuntimeConfig {
+    return this.meta.getRuntimeByName(name);
+  }
+
+  updateEmbeddingRuntime(name: string, runtime: EmbeddingRuntimeConfig): void {
+    if (this.readOnly) {
+      throw new EngineError(
+        "Cannot update embedding runtime in a read-only registry",
+        {
+          code: "ZVEC_GREP.ENGINE.COLLECTION.READ_ONLY",
+          context: collectionOperationDetails(name, "updateEmbeddingRuntime"),
+        },
+      );
+    }
+    const info = this.get(name);
+    if (!info) {
+      throw new EngineError("Collection not found", {
+        code: "ZVEC_GREP.ENGINE.COLLECTION.NOT_FOUND",
+        context: errorDetails([collectionDetail(name)]),
+      });
+    }
+    this.meta.upsert(info, runtime);
   }
 
   has(name: string): boolean {
@@ -798,16 +823,32 @@ class ZvecCollectionsMetaStore {
     return doc ? docToCollectionInfo(doc) : null;
   }
 
-  upsert(info: CollectionInfo): void {
+  getRuntimeByName(name: string): EmbeddingRuntimeConfig {
+    if (!this.collection) {
+      return {};
+    }
+    const [doc] = this.collection.querySync({
+      filter: `name = ${quoteFilterString(name)}`,
+      topk: 1,
+      includeVector: false,
+    });
+    return doc ? docToEmbeddingRuntime(doc) : {};
+  }
+
+  upsert(info: CollectionInfo, runtime?: EmbeddingRuntimeConfig): void {
     this.assertWritable("upsert");
     const collection = this.requireCollection();
+    const previousRuntime =
+      runtime === undefined ? this.getRuntimeByCollectionId(info.id) : runtime;
     const deleteStatus = collection.deleteSync(info.id);
     assertZvecStatusOrNotFound(
       deleteStatus,
       "collection metadata replace",
       info.name,
     );
-    const status = collection.upsertSync(collectionInfoToDoc(info));
+    const status = collection.upsertSync(
+      collectionInfoToDoc(info, previousRuntime),
+    );
     assertZvecStatus(status, "collection metadata upsert", info.name);
     this.needsOptimize = true;
   }
@@ -843,6 +884,20 @@ class ZvecCollectionsMetaStore {
     }
 
     return this.collection;
+  }
+
+  private getRuntimeByCollectionId(
+    collectionId: string,
+  ): EmbeddingRuntimeConfig {
+    if (!this.collection) {
+      return {};
+    }
+    const [doc] = this.collection.querySync({
+      filter: `collection_id = ${quoteFilterString(collectionId)}`,
+      topk: 1,
+      includeVector: false,
+    });
+    return doc ? docToEmbeddingRuntime(doc) : {};
   }
 
   private assertWritable(operation: string): void {
@@ -887,6 +942,9 @@ function createCollectionsSchema(): ZVecCollectionSchema {
         nullable: true,
       },
       indexedStringField("embedding_metric", true),
+      stringField("embedding_api_key", true),
+      stringField("embedding_endpoint", true),
+      stringField("embedding_device", true),
       {
         name: "index_version",
         dataType: ZVecDataType.INT32,
@@ -906,7 +964,10 @@ function createCollectionsSchema(): ZVecCollectionSchema {
   });
 }
 
-function collectionInfoToDoc(info: CollectionInfo): ZVecDocInput {
+function collectionInfoToDoc(
+  info: CollectionInfo,
+  runtime: EmbeddingRuntimeConfig = {},
+): ZVecDocInput {
   const fields: Record<string, string | number> = {
     collection_id: info.id,
     name: info.name,
@@ -930,11 +991,51 @@ function collectionInfoToDoc(info: CollectionInfo): ZVecDocInput {
   if (info.indexVersion !== null && info.indexVersion !== undefined) {
     fields.index_version = info.indexVersion;
   }
+  if (runtime.apiKey !== undefined) {
+    fields.embedding_api_key = runtime.apiKey;
+  }
+  if (runtime.endpoint !== undefined) {
+    fields.embedding_endpoint = runtime.endpoint;
+  }
+  if (runtime.device !== undefined) {
+    fields.embedding_device = runtime.device;
+  }
 
   return {
     id: info.id,
     fields,
   };
+}
+
+function docToEmbeddingRuntime(doc: ZVecDoc): EmbeddingRuntimeConfig {
+  const apiKey = readNullableStringFieldFromFields(
+    doc.fields,
+    "embedding_api_key",
+  );
+  const endpoint = readNullableStringFieldFromFields(
+    doc.fields,
+    "embedding_endpoint",
+  );
+  const device = embeddingDeviceFromField(
+    readNullableStringFieldFromFields(doc.fields, "embedding_device"),
+  );
+  return {
+    ...(apiKey ? { apiKey } : {}),
+    ...(endpoint ? { endpoint } : {}),
+    ...(device ? { device } : {}),
+  };
+}
+
+function embeddingDeviceFromField(
+  value: string | null,
+): EmbeddingDevice | undefined {
+  return value === "auto" ||
+    value === "cpu" ||
+    value === "metal" ||
+    value === "vulkan" ||
+    value === "cuda"
+    ? value
+    : undefined;
 }
 
 function docToCollectionInfo(doc: ZVecDoc): CollectionInfo {

--- a/src/engine/collection/index.ts
+++ b/src/engine/collection/index.ts
@@ -216,6 +216,10 @@ export class Collection {
           collectionDetail(this.name),
           detail("expected", CURRENT_INDEX_VERSION),
           detail("actual", this.info.indexVersion),
+          detail(
+            "hint",
+            'Recreate the index with the current zvec-grep version; run "zg index --rebuild" for a workspace index.',
+          ),
         ]),
       });
     }

--- a/src/engine/collection/index.ts
+++ b/src/engine/collection/index.ts
@@ -9,7 +9,7 @@ import {
   type ZVecDocInput,
 } from "@zvec/zvec";
 import { randomUUID } from "node:crypto";
-import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, rmSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
 import {
   collectionDetail,
@@ -65,6 +65,7 @@ import type { EmbeddingDevice, EmbeddingRuntimeConfig } from "../config.js";
 
 const COLLECTIONS_ZVEC = "collections.zvec";
 const FILES_ZVEC = "files.zvec";
+const COLLECTION_REGISTRY_HOME_MODE = 0o700;
 
 export class Collection {
   private readonly storage: CollectionStorage;
@@ -364,7 +365,13 @@ export class CollectionRegistry {
     private readonly readOnly = false,
   ) {
     if (!readOnly) {
-      mkdirSync(home, { recursive: true });
+      mkdirSync(home, {
+        recursive: true,
+        mode: COLLECTION_REGISTRY_HOME_MODE,
+      });
+    }
+    if (existsSync(home)) {
+      chmodSync(home, COLLECTION_REGISTRY_HOME_MODE);
     }
 
     this.meta = new ZvecCollectionsMetaStore(

--- a/src/engine/config.ts
+++ b/src/engine/config.ts
@@ -7,16 +7,29 @@ import { acquireReadWriteLock } from "./utils/lock.js";
 export type ZvecGrepGlobalDefaults = {
   embedding?: string;
   modelCacheDir?: string;
-  device?: "auto" | "cpu" | "metal" | "vulkan" | "cuda";
 };
 
 export type ZvecGrepProviderConfig = {
   apiKey?: string;
-  endpoint?: string;
 };
 
+export type EmbeddingDevice = "auto" | "cpu" | "metal" | "vulkan" | "cuda";
+
 export type ZvecGrepEmbeddingModelConfig = {
-  device?: "auto" | "cpu" | "metal" | "vulkan" | "cuda";
+  endpoint?: string;
+  device?: EmbeddingDevice;
+};
+
+export type EmbeddingRuntimeConfig = {
+  apiKey?: string;
+  endpoint?: string;
+  device?: EmbeddingDevice;
+};
+
+export type ResolvedEmbeddingRuntimeConfig = {
+  apiKey: string;
+  endpoint?: string;
+  device?: EmbeddingDevice;
 };
 
 export type ZvecGrepClientMode = "direct" | "server" | "auto";
@@ -48,24 +61,53 @@ export type ZvecGrepGlobalConfigUpdate = {
   server?: ZvecGrepServerConfig;
 };
 
-export type ZvecGrepExplicitGlobalOptions = ZvecGrepGlobalDefaults & {
-  apiKey?: string;
-  endpoint?: string;
-};
-
 export function resolveEmbeddingRuntimeOptions(
-  reference: string | undefined,
-  explicit: Pick<ZvecGrepEmbeddingModelConfig, "device">,
+  reference: string,
+  explicit: EmbeddingRuntimeConfig,
+  workspace: EmbeddingRuntimeConfig,
   config: ZvecGrepGlobalConfig,
-): ZvecGrepEmbeddingModelConfig {
-  if (!reference?.startsWith("local/")) return {};
+  environment: NodeJS.ProcessEnv = process.env,
+): ResolvedEmbeddingRuntimeConfig {
+  const provider = providerFromEmbedding(reference);
+  const local = provider === "local";
+  if (local && explicit.endpoint !== undefined) {
+    throw invalidRuntime(
+      reference,
+      "endpoint is only supported for remote embedding models",
+    );
+  }
+  if (!local && explicit.device !== undefined) {
+    throw invalidRuntime(
+      reference,
+      "device is only supported for local embedding models",
+    );
+  }
   const model = config.models?.[reference];
-  return {
-    device:
-      explicit.device ??
+  const providerConfig = provider ? config.providers?.[provider] : undefined;
+  const endpoint = !local
+    ? (explicit.endpoint ??
+      workspace.endpoint ??
+      model?.endpoint ??
+      nonEmptyEnvironmentValue(environment.ZVEC_GREP_ENDPOINT))
+    : undefined;
+  if (endpoint !== undefined && !isHttpEndpoint(endpoint)) {
+    throw invalidRuntime(reference, "endpoint must be a valid HTTP(S) URL");
+  }
+  const device = local
+    ? (explicit.device ??
+      workspace.device ??
       model?.device ??
-      config.defaults?.device ??
-      environmentDevice(),
+      environmentDevice(environment))
+    : undefined;
+  return {
+    apiKey:
+      explicit.apiKey ??
+      workspace.apiKey ??
+      providerConfig?.apiKey ??
+      environmentApiKey(provider, environment) ??
+      "",
+    ...(endpoint !== undefined ? { endpoint } : {}),
+    ...(device !== undefined ? { device } : {}),
   };
 }
 
@@ -126,65 +168,6 @@ export function updateGlobalConfig(
   }
 }
 
-export function updateGlobalConfigFromExplicitOptions(
-  options: ZvecGrepExplicitGlobalOptions,
-  indexedEmbedding?: string,
-  path = globalConfigPath(),
-): boolean {
-  const modelReference =
-    options.embedding ??
-    (indexedEmbedding?.includes("/") ? indexedEmbedding : undefined);
-  const localModel = modelReference?.startsWith("local/")
-    ? modelReference
-    : undefined;
-  const defaults: ZvecGrepGlobalDefaults = {
-    ...(options.embedding !== undefined
-      ? { embedding: options.embedding }
-      : {}),
-    ...(options.modelCacheDir !== undefined
-      ? { modelCacheDir: options.modelCacheDir }
-      : {}),
-    ...(!localModel && options.device !== undefined
-      ? { device: options.device }
-      : {}),
-  };
-  const provider =
-    providerFromEmbedding(options.embedding) ??
-    providerFromEmbedding(indexedEmbedding) ??
-    indexedEmbedding;
-  const providerConfig: ZvecGrepProviderConfig =
-    provider && provider !== "local"
-      ? {
-          ...(options.apiKey !== undefined ? { apiKey: options.apiKey } : {}),
-          ...(options.endpoint !== undefined
-            ? { endpoint: options.endpoint }
-            : {}),
-        }
-      : {};
-  const update: ZvecGrepGlobalConfigUpdate = {
-    ...(Object.keys(defaults).length > 0 ? { defaults } : {}),
-    ...(provider && Object.keys(providerConfig).length > 0
-      ? { providers: { [provider]: providerConfig } }
-      : {}),
-    ...(localModel && options.device !== undefined
-      ? {
-          models: {
-            [localModel]: {
-              device: options.device,
-            },
-          },
-        }
-      : {}),
-  };
-
-  if (!update.defaults && !update.providers && !update.models) {
-    return false;
-  }
-
-  updateGlobalConfig(update, path);
-  return true;
-}
-
 function emptyGlobalConfig(): ZvecGrepGlobalConfig {
   return { version: GLOBAL_CONFIG_VERSION };
 }
@@ -242,19 +225,42 @@ function parseModels(
         `models.${reference} must be an object with a valid embedding reference`,
       );
     }
-    if (!reference.startsWith("local/")) {
+    assertKnownFields(
+      modelValue,
+      ["endpoint", "device"],
+      path,
+      `models.${reference}`,
+    );
+    const endpoint = optionalNonEmptyString(
+      modelValue.endpoint,
+      path,
+      `models.${reference}.endpoint`,
+    );
+    if (endpoint !== undefined && !isHttpEndpoint(endpoint)) {
       throw invalidConfig(
         path,
-        `models.${reference} only supports local embedding models`,
+        `models.${reference}.endpoint must be a valid HTTP(S) URL`,
       );
     }
-    assertKnownFields(modelValue, ["device"], path, `models.${reference}`);
     const device = optionalDevice(
       modelValue.device,
       path,
       `models.${reference}.device`,
     );
+    if (reference.startsWith("local/") && endpoint !== undefined) {
+      throw invalidConfig(
+        path,
+        `models.${reference}.endpoint is only supported for remote models`,
+      );
+    }
+    if (!reference.startsWith("local/") && device !== undefined) {
+      throw invalidConfig(
+        path,
+        `models.${reference}.device is only supported for local models`,
+      );
+    }
     const config: ZvecGrepEmbeddingModelConfig = {
+      ...(endpoint !== undefined ? { endpoint } : {}),
       ...(device !== undefined ? { device } : {}),
     };
     if (Object.keys(config).length > 0) models[reference] = config;
@@ -317,12 +323,7 @@ function parseDefaults(
   if (!isRecord(value)) {
     throw invalidConfig(path, "defaults must be an object");
   }
-  assertKnownFields(
-    value,
-    ["embedding", "modelCacheDir", "device"],
-    path,
-    "defaults",
-  );
+  assertKnownFields(value, ["embedding", "modelCacheDir"], path, "defaults");
 
   const embedding = optionalNonEmptyString(
     value.embedding,
@@ -334,11 +335,9 @@ function parseDefaults(
     path,
     "defaults.modelCacheDir",
   );
-  const device = optionalDevice(value.device, path, "defaults.device");
   const defaults: ZvecGrepGlobalDefaults = {
     ...(embedding ? { embedding } : {}),
     ...(modelCacheDir ? { modelCacheDir } : {}),
-    ...(device !== undefined ? { device } : {}),
   };
   return Object.keys(defaults).length > 0 ? defaults : undefined;
 }
@@ -362,26 +361,15 @@ function parseProviders(
         `providers.${provider} must be an object with a valid provider name`,
       );
     }
-    assertKnownFields(
-      providerValue,
-      ["apiKey", "endpoint"],
-      path,
-      `providers.${provider}`,
-    );
+    assertKnownFields(providerValue, ["apiKey"], path, `providers.${provider}`);
 
     const apiKey = optionalNonEmptyString(
       providerValue.apiKey,
       path,
       `providers.${provider}.apiKey`,
     );
-    const endpoint = optionalNonEmptyString(
-      providerValue.endpoint,
-      path,
-      `providers.${provider}.endpoint`,
-    );
     const config: ZvecGrepProviderConfig = {
       ...(apiKey ? { apiKey } : {}),
-      ...(endpoint ? { endpoint } : {}),
     };
     if (Object.keys(config).length > 0) {
       providers[provider] = config;
@@ -472,11 +460,33 @@ function optionalDevice(
   );
 }
 
-function environmentDevice(): "auto" | "cpu" | "metal" | "vulkan" | "cuda" {
-  const normalized = process.env.ZVEC_GREP_DEVICE?.trim().toLowerCase() ?? "";
+function environmentApiKey(
+  provider: string | undefined,
+  environment: NodeJS.ProcessEnv,
+): string | undefined {
+  const values =
+    provider === "qwen"
+      ? [
+          environment.ZVEC_GREP_API_KEY,
+          environment.DASHSCOPE_API_KEY,
+          environment.QWEN_API_KEY,
+        ]
+      : [environment.ZVEC_GREP_API_KEY];
+  return values.map(nonEmptyEnvironmentValue).find(Boolean);
+}
+
+function nonEmptyEnvironmentValue(
+  value: string | undefined,
+): string | undefined {
+  const normalized = value?.trim();
+  return normalized ? normalized : undefined;
+}
+
+function environmentDevice(environment: NodeJS.ProcessEnv): EmbeddingDevice {
+  const normalized = environment.ZVEC_GREP_DEVICE?.trim().toLowerCase() ?? "";
   if (["auto", "cpu", "metal", "vulkan", "cuda"].includes(normalized))
-    return normalized as "auto" | "cpu" | "metal" | "vulkan" | "cuda";
-  return "cpu";
+    return normalized as EmbeddingDevice;
+  return "auto";
 }
 
 function assertKnownFields(
@@ -498,6 +508,22 @@ function invalidConfig(path: string, detail: string): EngineError {
     code: "ZVEC_GREP.ENGINE.CONFIG.INVALID",
     context: `path=${path}\ndetail=${detail}`,
   });
+}
+
+function invalidRuntime(reference: string, message: string): EngineError {
+  return new EngineError("Embedding runtime configuration is invalid", {
+    code: "ZVEC_GREP.ENGINE.CONFIG.INVALID_EMBEDDING_RUNTIME",
+    context: `reference=${reference}\ndetail=${message}`,
+  });
+}
+
+function isHttpEndpoint(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/engine/models/index.ts
+++ b/src/engine/models/index.ts
@@ -7,3 +7,7 @@ export {
   type EmbeddingResult,
 } from "./embeddings.js";
 export { createEmbeddingModel } from "./factory.js";
+export {
+  getEmbeddingModelCatalogEntry,
+  listEmbeddingModels,
+} from "./catalog.js";

--- a/src/engine/service/root.ts
+++ b/src/engine/service/root.ts
@@ -1,4 +1,4 @@
-import { existsSync } from "node:fs";
+import { existsSync, rmSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 
 export const ZVEC_GREP_DIR = ".zvec-grep";
@@ -6,6 +6,7 @@ export const ANONYMOUS_COLLECTION_NAME = "__anonymous__";
 export const ANONYMOUS_COLLECTION_DIR = "index";
 
 const COLLECTIONS_ZVEC = "collections.zvec";
+const FILES_ZVEC = "files.zvec";
 const ENTITIES_ZVEC = "index.zvec";
 
 export type AnonymousIndexLocation = {
@@ -36,6 +37,21 @@ export function anonymousIndexLocation(root: string): AnonymousIndexLocation {
     collectionName: ANONYMOUS_COLLECTION_NAME,
     collectionPath: anonymousCollectionPath(resolvedRoot),
   };
+}
+
+export function resetAnonymousIndexStorage(
+  location: AnonymousIndexLocation,
+): void {
+  if (dirname(location.collectionPath) !== location.home) {
+    throw new Error("Anonymous index path must be inside its workspace home");
+  }
+  for (const target of [
+    join(location.home, COLLECTIONS_ZVEC),
+    join(location.home, FILES_ZVEC),
+    location.collectionPath,
+  ]) {
+    rmSync(target, { recursive: true, force: true });
+  }
 }
 
 export function findNearestAnonymousIndex(

--- a/src/engine/service/zvec-grep.ts
+++ b/src/engine/service/zvec-grep.ts
@@ -1,5 +1,5 @@
 import { readFileSync, statSync } from "node:fs";
-import { createHash, createHmac, randomBytes } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
 import { dirname, join, relative, resolve } from "node:path";
 import {
   globalConfigPath,
@@ -78,7 +78,7 @@ import { RemoteEmbeddingAuthorizationStore } from "../../authorization/store.js"
 const DEFAULT_CONTEXT_LIMIT = 10;
 const DEFAULT_CONTEXT_TOTAL_LIMIT = 30;
 const DEFAULT_LOCAL_EMBEDDING = "local/embeddinggemma-300m";
-const PROVIDER_OPTIONS_FINGERPRINT_SECRET = randomBytes(32);
+const PROVIDER_API_KEY_IDENTITIES = new Map<string, string>();
 const MAX_RECOVERED_EMBEDDING_MODELS = 4;
 
 export type EmbeddingModelIdentity = Pick<
@@ -1789,16 +1789,22 @@ function providerOptionsFingerprint(options: {
   modelCacheDir?: string;
   device?: "auto" | "cpu" | "metal" | "vulkan" | "cuda";
 }): string {
-  return createHmac("sha256", PROVIDER_OPTIONS_FINGERPRINT_SECRET)
+  const publicOptionsFingerprint = createHash("sha256")
     .update(
-      JSON.stringify([
-        options.apiKey,
-        options.endpoint,
-        options.modelCacheDir,
-        options.device,
-      ]),
+      JSON.stringify([options.endpoint, options.modelCacheDir, options.device]),
     )
     .digest("hex");
+  return `${providerApiKeyIdentity(options.apiKey)}:${publicOptionsFingerprint}`;
+}
+
+function providerApiKeyIdentity(apiKey: string): string {
+  const existing = PROVIDER_API_KEY_IDENTITIES.get(apiKey);
+  if (existing) {
+    return existing;
+  }
+  const identity = randomBytes(32).toString("hex");
+  PROVIDER_API_KEY_IDENTITIES.set(apiKey, identity);
+  return identity;
 }
 
 function effectiveEmbeddingRuntime(

--- a/src/engine/service/zvec-grep.ts
+++ b/src/engine/service/zvec-grep.ts
@@ -1,5 +1,5 @@
 import { readFileSync, statSync } from "node:fs";
-import { createHash, randomBytes } from "node:crypto";
+import { createHash, createHmac, randomBytes } from "node:crypto";
 import { dirname, join, relative, resolve } from "node:path";
 import {
   globalConfigPath,
@@ -78,7 +78,7 @@ import { RemoteEmbeddingAuthorizationStore } from "../../authorization/store.js"
 const DEFAULT_CONTEXT_LIMIT = 10;
 const DEFAULT_CONTEXT_TOTAL_LIMIT = 30;
 const DEFAULT_LOCAL_EMBEDDING = "local/embeddinggemma-300m";
-const PROVIDER_API_KEY_IDENTITIES = new Map<string, string>();
+const PROVIDER_API_KEY_IDENTITY_SECRET = randomBytes(32);
 const MAX_RECOVERED_EMBEDDING_MODELS = 4;
 
 export type EmbeddingModelIdentity = Pick<
@@ -1798,13 +1798,9 @@ function providerOptionsFingerprint(options: {
 }
 
 function providerApiKeyIdentity(apiKey: string): string {
-  const existing = PROVIDER_API_KEY_IDENTITIES.get(apiKey);
-  if (existing) {
-    return existing;
-  }
-  const identity = randomBytes(32).toString("hex");
-  PROVIDER_API_KEY_IDENTITIES.set(apiKey, identity);
-  return identity;
+  return createHmac("sha256", PROVIDER_API_KEY_IDENTITY_SECRET)
+    .update(apiKey)
+    .digest("hex");
 }
 
 function effectiveEmbeddingRuntime(

--- a/src/engine/service/zvec-grep.ts
+++ b/src/engine/service/zvec-grep.ts
@@ -1,5 +1,5 @@
 import { readFileSync, statSync } from "node:fs";
-import { createHash } from "node:crypto";
+import { createHash, createHmac, randomBytes } from "node:crypto";
 import { dirname, join, relative, resolve } from "node:path";
 import {
   globalConfigPath,
@@ -38,6 +38,7 @@ import type {
   SearchPlan,
   SearchPlanResult,
 } from "../types.js";
+import { CURRENT_INDEX_VERSION } from "../types.js";
 import { indexStatusNeedsRefresh } from "../index-status.js";
 import {
   ANONYMOUS_COLLECTION_NAME,
@@ -45,6 +46,7 @@ import {
   anonymousHome,
   anonymousIndexLocation,
   findNearestAnonymousWorkspace,
+  resetAnonymousIndexStorage,
   resolveZvecGrepRoot,
   type AnonymousIndexLocation,
 } from "./root.js";
@@ -76,6 +78,7 @@ import { RemoteEmbeddingAuthorizationStore } from "../../authorization/store.js"
 const DEFAULT_CONTEXT_LIMIT = 10;
 const DEFAULT_CONTEXT_TOTAL_LIMIT = 30;
 const DEFAULT_LOCAL_EMBEDDING = "local/embeddinggemma-300m";
+const PROVIDER_OPTIONS_FINGERPRINT_SECRET = randomBytes(32);
 const MAX_RECOVERED_EMBEDDING_MODELS = 4;
 
 export type EmbeddingModelIdentity = Pick<
@@ -250,35 +253,43 @@ class ZvecGrepService implements ZvecGrep {
                 "zg index --endpoint <url> --rebuild",
               );
             }
+            const rootPaths = resolveIndexRootPaths(
+              existing,
+              options.rootPaths,
+              root,
+              {
+                resetPaths: options.resetPaths === true,
+                includePaths: options.includePaths,
+                excludePaths: options.excludePaths,
+                globs: options.globs,
+                insensitiveGlobs: options.insensitiveGlobs,
+                fileTypes: options.fileTypes,
+                excludedFileTypes: options.excludedFileTypes,
+                hidden: options.hidden,
+                noIgnore: options.noIgnore,
+                ignoreFiles: options.ignoreFiles,
+                maxDepth: options.maxDepth,
+                maxFileSizeBytes: options.maxFileSizeBytes,
+                follow: options.follow,
+              },
+            );
+            const resetUnsupportedStorage =
+              options.rebuild === true &&
+              isCollectionIndexed(existing) &&
+              existing.indexVersion !== CURRENT_INDEX_VERSION;
+            if (resetUnsupportedStorage) {
+              resetAnonymousIndexStorage(location);
+            }
             const registry = new CollectionRegistry(
               location.home,
               embeddingModel,
             );
 
             try {
-              const rootPaths = resolveIndexRootPaths(
-                existing,
-                options.rootPaths,
-                root,
-                {
-                  resetPaths: options.resetPaths === true,
-                  includePaths: options.includePaths,
-                  excludePaths: options.excludePaths,
-                  globs: options.globs,
-                  insensitiveGlobs: options.insensitiveGlobs,
-                  fileTypes: options.fileTypes,
-                  excludedFileTypes: options.excludedFileTypes,
-                  hidden: options.hidden,
-                  noIgnore: options.noIgnore,
-                  ignoreFiles: options.ignoreFiles,
-                  maxDepth: options.maxDepth,
-                  maxFileSizeBytes: options.maxFileSizeBytes,
-                  follow: options.follow,
-                },
-              );
-
               if (options.rebuild) {
-                registry.remove(ANONYMOUS_COLLECTION_NAME);
+                if (!resetUnsupportedStorage) {
+                  registry.remove(ANONYMOUS_COLLECTION_NAME);
+                }
               }
 
               const existingAfterRebuild = registry.get(
@@ -1778,7 +1789,7 @@ function providerOptionsFingerprint(options: {
   modelCacheDir?: string;
   device?: "auto" | "cpu" | "metal" | "vulkan" | "cuda";
 }): string {
-  return createHash("sha256")
+  return createHmac("sha256", PROVIDER_OPTIONS_FINGERPRINT_SECRET)
     .update(
       JSON.stringify([
         options.apiKey,

--- a/src/engine/service/zvec-grep.ts
+++ b/src/engine/service/zvec-grep.ts
@@ -5,6 +5,8 @@ import {
   globalConfigPath,
   readGlobalConfig,
   resolveEmbeddingRuntimeOptions,
+  type EmbeddingRuntimeConfig,
+  type ResolvedEmbeddingRuntimeConfig,
   type ZvecGrepGlobalConfig,
 } from "../config.js";
 import {
@@ -160,11 +162,12 @@ export function openAnonymousReadSession(
 export function createEmbeddingModelForIdentity(
   identity: EmbeddingModelIdentity,
   options: CreateZvecGrepOptions = {},
+  workspaceRuntime: EmbeddingRuntimeConfig = {},
 ): EmbeddingModel {
   const reference = embeddingModelReference(identity);
   return createServiceEmbeddingModel(
     reference,
-    providerOptions(options, identity),
+    providerOptions(options, identity, readGlobalConfig(), workspaceRuntime),
     options,
   );
 }
@@ -172,10 +175,11 @@ export function createEmbeddingModelForIdentity(
 export function embeddingModelPoolKeyForIdentity(
   identity: EmbeddingModelIdentity,
   options: CreateZvecGrepOptions = {},
+  workspaceRuntime: EmbeddingRuntimeConfig = {},
 ): string {
   const reference = embeddingModelReference(identity);
   const fingerprint = providerOptionsFingerprint(
-    providerOptions(options, identity),
+    providerOptions(options, identity, readGlobalConfig(), workspaceRuntime),
   );
   return [reference, fingerprint].join("/");
 }
@@ -220,10 +224,32 @@ class ZvecGrepService implements ZvecGrep {
               location.home,
               ANONYMOUS_COLLECTION_NAME,
             );
+            const existingRuntime = readCollectionEmbeddingRuntime(
+              location.home,
+              ANONYMOUS_COLLECTION_NAME,
+            );
             const embeddingModel = this.embeddingModelForIndex(
               existing,
               "index",
+              existingRuntime,
             );
+            const effectiveRuntime = effectiveEmbeddingRuntime(
+              this.options,
+              embeddingModel,
+              runtimeForModelProvider(
+                existing,
+                embeddingModel,
+                existingRuntime,
+              ),
+            );
+            if (!options.rebuild) {
+              assertCollectionEndpointMatchesCurrentRuntime(
+                existing,
+                existingRuntime,
+                effectiveRuntime,
+                "zg index --endpoint <url> --rebuild",
+              );
+            }
             const registry = new CollectionRegistry(
               location.home,
               embeddingModel,
@@ -281,13 +307,32 @@ class ZvecGrepService implements ZvecGrep {
                   ),
               );
               try {
-                return await collection.index({
+                const result = await collection.index({
                   rebuild: false,
                   embeddingConcurrency: options.embeddingConcurrency,
                   onProgress: options.onProgress,
                   changedPaths: options.changedPaths,
                   signal: options.signal,
                 });
+                registry.updateEmbeddingRuntime(
+                  ANONYMOUS_COLLECTION_NAME,
+                  embeddingRuntimeAfterSuccessfulIndex(
+                    existing,
+                    existingRuntime,
+                    embeddingModel,
+                    effectiveRuntime,
+                    this.options,
+                  ),
+                );
+                return result;
+              } catch (error) {
+                if (registry.get(ANONYMOUS_COLLECTION_NAME)) {
+                  registry.updateEmbeddingRuntime(
+                    ANONYMOUS_COLLECTION_NAME,
+                    existingRuntime,
+                  );
+                }
+                throw error;
               } finally {
                 await releaseWriterContext?.();
               }
@@ -544,6 +589,7 @@ class ZvecGrepService implements ZvecGrep {
     name: string,
     paths?: string | RootPath | readonly (string | RootPath)[],
     options: ZvecGrepCollectionIndexOptions = {},
+    persistRuntime = true,
   ): Promise<IndexResult> {
     this.ensureOpen();
     const home = serviceHome(this.options);
@@ -553,10 +599,25 @@ class ZvecGrepService implements ZvecGrep {
         options.rebuild ? "collections.index.rebuild" : "collections.index",
         async () => {
           const existing = readCollectionInfo(home, name);
+          const existingRuntime = readCollectionEmbeddingRuntime(home, name);
           const embeddingModel = this.embeddingModelForIndex(
             existing,
             "collections.index",
+            existingRuntime,
           );
+          const effectiveRuntime = effectiveEmbeddingRuntime(
+            this.options,
+            embeddingModel,
+            runtimeForModelProvider(existing, embeddingModel, existingRuntime),
+          );
+          if (!options.rebuild) {
+            assertCollectionEndpointMatchesCurrentRuntime(
+              existing,
+              existingRuntime,
+              effectiveRuntime,
+              "zg collections index <name> --endpoint <url> --rebuild",
+            );
+          }
           const registry = this.createRegistry(false, embeddingModel);
           try {
             const requestedRootPaths =
@@ -600,10 +661,30 @@ class ZvecGrepService implements ZvecGrep {
             }
             registry.prepareIndex(name, rootPaths);
 
-            return await registry.open(name).index({
-              embeddingConcurrency: options.embeddingConcurrency,
-              onProgress: options.onProgress,
-            });
+            try {
+              const result = await registry.open(name).index({
+                embeddingConcurrency: options.embeddingConcurrency,
+                onProgress: options.onProgress,
+              });
+              if (persistRuntime) {
+                registry.updateEmbeddingRuntime(
+                  name,
+                  embeddingRuntimeAfterSuccessfulIndex(
+                    existing,
+                    existingRuntime,
+                    embeddingModel,
+                    effectiveRuntime,
+                    this.options,
+                  ),
+                );
+              }
+              return result;
+            } catch (error) {
+              if (registry.get(name)) {
+                registry.updateEmbeddingRuntime(name, existingRuntime);
+              }
+              throw error;
+            }
           } finally {
             registry.close();
           }
@@ -647,6 +728,7 @@ class ZvecGrepService implements ZvecGrep {
         info,
         request,
         location.home,
+        registry.getEmbeddingRuntime(ANONYMOUS_COLLECTION_NAME),
       );
       try {
         return await this.contextFromCollection({
@@ -714,9 +796,24 @@ class ZvecGrepService implements ZvecGrep {
             return;
           }
 
+          const workspaceRuntime = readCollectionEmbeddingRuntime(
+            location.home,
+            ANONYMOUS_COLLECTION_NAME,
+          );
           const embeddingModel = this.embeddingModelForIndex(
             existing,
             "context.refresh",
+            workspaceRuntime,
+          );
+          assertCollectionEndpointMatchesCurrentRuntime(
+            existing,
+            workspaceRuntime,
+            effectiveEmbeddingRuntime(
+              this.options,
+              embeddingModel,
+              workspaceRuntime,
+            ),
+            "zg index --endpoint <url> --rebuild",
           );
           assertCollectionEmbeddingMatchesCurrentModel(
             existing,
@@ -757,10 +854,15 @@ class ZvecGrepService implements ZvecGrep {
     if (!indexStatusNeedsRefresh(status)) return;
 
     const result = await timings.time("auto_update", () =>
-      this.indexCollection(collectionName, undefined, {
-        embeddingConcurrency: options.embeddingConcurrency,
-        onProgress: options.onAutoUpdateProgress,
-      }),
+      this.indexCollection(
+        collectionName,
+        undefined,
+        {
+          embeddingConcurrency: options.embeddingConcurrency,
+          onProgress: options.onAutoUpdateProgress,
+        },
+        false,
+      ),
     );
     timings.addEntries(result.timings, "auto_update_");
   }
@@ -789,6 +891,7 @@ class ZvecGrepService implements ZvecGrep {
             info,
             request,
             registry.home,
+            registry.getEmbeddingRuntime(collectionName),
           );
           const root =
             collection.info.rootPaths[0]?.absolutePath ??
@@ -922,10 +1025,16 @@ class ZvecGrepService implements ZvecGrep {
     info: CollectionInfo,
     request: NormalizedContextRequest,
     registryHome: string,
+    workspaceRuntime: EmbeddingRuntimeConfig,
   ): Collection {
     return new Collection(
       info,
-      this.embeddingModelForSearch(indexedEmbeddingSchema(info), request),
+      this.embeddingModelForSearch(
+        indexedEmbeddingSchema(info),
+        request,
+        workspaceRuntime,
+        info,
+      ),
       true,
       join(registryHome, "files.zvec"),
     );
@@ -934,45 +1043,82 @@ class ZvecGrepService implements ZvecGrep {
   private embeddingModelForSearch(
     schema: CollectionEmbeddingSchema,
     request: NormalizedContextRequest,
+    workspaceRuntime: EmbeddingRuntimeConfig,
+    info: CollectionInfo,
   ): EmbeddingModel | undefined {
     if (!request.routes.some((route) => route.mode === "vector")) {
       return undefined;
     }
 
+    const identity = {
+      provider: schema.provider,
+      name: schema.model,
+    };
+    const effectiveRuntime = resolveEmbeddingRuntimeOptions(
+      embeddingModelReference(identity),
+      this.options,
+      workspaceRuntime,
+      readGlobalConfig(),
+    );
+    assertSearchEndpointMatchesWorkspace(
+      info,
+      workspaceRuntime,
+      effectiveRuntime,
+    );
+
     if (this.embeddingModel) {
       return this.embeddingModel;
     }
 
-    return this.recoverEmbeddingModel(schema);
+    return this.recoverEmbeddingModel(schema, workspaceRuntime);
   }
 
   private embeddingModelForIndex(
     existing: CollectionInfo | null,
     operation: string,
+    workspaceRuntime: EmbeddingRuntimeConfig = {},
   ): EmbeddingModel {
     if (
       isCollectionIndexed(existing) &&
       !this.embeddingModel &&
       !this.options.embedding
     ) {
-      return this.recoverEmbeddingModel(existing.embedding);
+      return this.recoverEmbeddingModel(existing.embedding, workspaceRuntime);
     }
 
+    const config = readGlobalConfig();
     const reference =
       this.options.embedding ??
+      config.defaults?.embedding ??
+      nonEmptyEnvironmentValue(process.env.ZVEC_GREP_EMBEDDING) ??
       (this.options.defaultEmbedding === true
         ? DEFAULT_LOCAL_EMBEDDING
         : undefined);
+    const referenceIdentity = reference
+      ? parseEmbeddingModelReference(reference)
+      : undefined;
+    const selectedWorkspaceRuntime =
+      isCollectionIndexed(existing) &&
+      referenceIdentity &&
+      existing.embedding.provider !== referenceIdentity.provider
+        ? {}
+        : workspaceRuntime;
     return (
       this.embeddingModel ??
-      (reference ? this.embeddingModelFromReference(reference) : undefined) ??
-      this.configuredEmbeddingModel() ??
+      (reference
+        ? this.embeddingModelFromReference(
+            reference,
+            config,
+            selectedWorkspaceRuntime,
+          )
+        : undefined) ??
       this.requireEmbeddingModel(operation)
     );
   }
 
   private recoverEmbeddingModel(
     schema: CollectionEmbeddingSchema,
+    workspaceRuntime: EmbeddingRuntimeConfig = {},
   ): EmbeddingModel {
     const config = readGlobalConfig();
     const identity = {
@@ -980,29 +1126,30 @@ class ZvecGrepService implements ZvecGrep {
       name: schema.model,
     };
     const reference = embeddingModelReference(identity);
-    const options = providerOptions(this.options, identity, config);
+    const options = providerOptions(
+      this.options,
+      identity,
+      config,
+      workspaceRuntime,
+    );
     const key = `${reference}/${providerOptionsFingerprint(options)}`;
     return this.cachedEmbeddingModel(key, () =>
       createServiceEmbeddingModel(reference, options, this.options),
     );
   }
 
-  private configuredEmbeddingModel(): EmbeddingModel | undefined {
-    const config = readGlobalConfig();
-    const reference = config.defaults?.embedding;
-    if (!reference) {
-      return undefined;
-    }
-
-    return this.embeddingModelFromReference(reference, config);
-  }
-
   private embeddingModelFromReference(
     reference: string,
     config: ZvecGrepGlobalConfig = readGlobalConfig(),
+    workspaceRuntime: EmbeddingRuntimeConfig = {},
   ): EmbeddingModel {
     const identity = parseEmbeddingModelReference(reference);
-    const options = providerOptions(this.options, identity, config);
+    const options = providerOptions(
+      this.options,
+      identity,
+      config,
+      workspaceRuntime,
+    );
     const key = `configured/${reference}/${providerOptionsFingerprint(options)}`;
     return this.cachedEmbeddingModel(key, () =>
       createServiceEmbeddingModel(reference, options, this.options),
@@ -1508,6 +1655,18 @@ function readCollectionInfo(home: string, name: string): CollectionInfo | null {
   }
 }
 
+function readCollectionEmbeddingRuntime(
+  home: string,
+  name: string,
+): EmbeddingRuntimeConfig {
+  const registry = new CollectionRegistry(home, undefined, true);
+  try {
+    return registry.getEmbeddingRuntime(name);
+  } finally {
+    registry.close();
+  }
+}
+
 function indexedEmbeddingSchema(
   info: CollectionInfo,
 ): CollectionEmbeddingSchema {
@@ -1528,17 +1687,22 @@ function providerOptions(
   options: CreateZvecGrepOptions,
   identity: EmbeddingModelIdentity,
   config: ZvecGrepGlobalConfig = readGlobalConfig(),
+  workspaceRuntime: EmbeddingRuntimeConfig = {},
 ): CreateEmbeddingModelOptions & { apiKey: string } {
-  const providerConfig = config.providers?.[identity.provider];
   const reference = embeddingModelReference(identity);
-  const runtime = resolveEmbeddingRuntimeOptions(reference, options, config);
+  const runtime = resolveEmbeddingRuntimeOptions(
+    reference,
+    options,
+    workspaceRuntime,
+    config,
+  );
   return {
-    apiKey: options.apiKey ?? providerConfig?.apiKey ?? "",
-    endpoint: options.endpoint ?? providerConfig?.endpoint,
+    apiKey: runtime.apiKey,
+    endpoint: runtime.endpoint,
     modelCacheDir:
       options.modelCacheDir ??
-      process.env.ZVEC_GREP_MODEL_CACHE ??
       config.defaults?.modelCacheDir ??
+      process.env.ZVEC_GREP_MODEL_CACHE ??
       join(options.home ?? defaultHome(), "models"),
     device: runtime.device,
   };
@@ -1624,6 +1788,123 @@ function providerOptionsFingerprint(options: {
       ]),
     )
     .digest("hex");
+}
+
+function effectiveEmbeddingRuntime(
+  options: CreateZvecGrepOptions,
+  model: EmbeddingModel,
+  workspaceRuntime: EmbeddingRuntimeConfig,
+): ResolvedEmbeddingRuntimeConfig {
+  const resolved = resolveEmbeddingRuntimeOptions(
+    model.info.reference,
+    options,
+    workspaceRuntime,
+    readGlobalConfig(),
+  );
+  return {
+    apiKey: resolved.apiKey,
+    ...((model.info.endpoint ?? resolved.endpoint)
+      ? { endpoint: model.info.endpoint ?? resolved.endpoint }
+      : {}),
+    ...(model.info.provider === "local"
+      ? { device: resolved.device ?? "auto" }
+      : {}),
+  };
+}
+
+function runtimeForModelProvider(
+  existing: CollectionInfo | null,
+  model: EmbeddingModel,
+  workspaceRuntime: EmbeddingRuntimeConfig,
+): EmbeddingRuntimeConfig {
+  return isCollectionIndexed(existing) &&
+    existing.embedding.provider !== model.info.provider
+    ? {}
+    : workspaceRuntime;
+}
+
+function embeddingRuntimeAfterSuccessfulIndex(
+  existing: CollectionInfo | null,
+  existingRuntime: EmbeddingRuntimeConfig,
+  model: EmbeddingModel,
+  effectiveRuntime: ResolvedEmbeddingRuntimeConfig,
+  explicit: CreateZvecGrepOptions,
+): EmbeddingRuntimeConfig {
+  const sameProvider =
+    isCollectionIndexed(existing) &&
+    existing.embedding.provider === model.info.provider;
+  const apiKey =
+    model.info.provider === "local"
+      ? undefined
+      : (explicit.apiKey ??
+        (sameProvider ? existingRuntime.apiKey : undefined));
+  return {
+    ...(apiKey !== undefined ? { apiKey } : {}),
+    ...(model.info.provider !== "local" &&
+    effectiveRuntime.endpoint !== undefined
+      ? { endpoint: effectiveRuntime.endpoint }
+      : {}),
+    ...(model.info.provider === "local"
+      ? { device: effectiveRuntime.device ?? "auto" }
+      : {}),
+  };
+}
+
+function assertCollectionEndpointMatchesCurrentRuntime(
+  info: CollectionInfo | null,
+  workspaceRuntime: EmbeddingRuntimeConfig,
+  effectiveRuntime: ResolvedEmbeddingRuntimeConfig,
+  rebuildCommand: string,
+): void {
+  if (
+    !isCollectionIndexed(info) ||
+    workspaceRuntime.endpoint === effectiveRuntime.endpoint
+  ) {
+    return;
+  }
+  throw new EngineError(
+    "Existing zvec-grep index uses a different embedding endpoint",
+    {
+      code: "ZVEC_GREP.ENGINE.SERVICE.EMBEDDING_ENDPOINT_CHANGE_REQUIRES_REBUILD",
+      context: errorDetails([
+        collectionDetail(info.name),
+        detail(
+          "hint",
+          `Run "${rebuildCommand}" to rebuild this index with the requested endpoint.`,
+        ),
+      ]),
+    },
+  );
+}
+
+function assertSearchEndpointMatchesWorkspace(
+  info: CollectionInfo,
+  workspaceRuntime: EmbeddingRuntimeConfig,
+  effectiveRuntime: ResolvedEmbeddingRuntimeConfig,
+): void {
+  if (workspaceRuntime.endpoint === effectiveRuntime.endpoint) {
+    return;
+  }
+  throw new EngineError(
+    "Search cannot override the embedding endpoint of an existing index",
+    {
+      code: "ZVEC_GREP.ENGINE.SERVICE.SEARCH_ENDPOINT_CHANGE_REQUIRES_REBUILD",
+      context: errorDetails([
+        collectionDetail(info.name),
+        detail(
+          "hint",
+          'Run "zg index --endpoint <url> --rebuild" before searching with this endpoint.',
+        ),
+      ]),
+    },
+  );
+}
+
+function nonEmptyEnvironmentValue(
+  value: string | undefined,
+): string | undefined {
+  const normalized = value?.trim();
+  return normalized ? normalized : undefined;
 }
 
 function assertCollectionEmbeddingMatchesCurrentModel(

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -178,7 +178,7 @@ export type EntityFragment = {
 // Collection types
 // -----------------------------------------------------------------------------
 
-export const CURRENT_INDEX_VERSION = 1;
+export const CURRENT_INDEX_VERSION = 2;
 
 export type CollectionEmbeddingSchema = {
   provider: string;

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -178,7 +178,7 @@ export type EntityFragment = {
 // Collection types
 // -----------------------------------------------------------------------------
 
-export const CURRENT_INDEX_VERSION = 2;
+export const CURRENT_INDEX_VERSION = 1;
 
 export type CollectionEmbeddingSchema = {
   provider: string;

--- a/src/mcp/input-normalization.ts
+++ b/src/mcp/input-normalization.ts
@@ -10,6 +10,8 @@ import type {
 
 export type NormalizedSearchInput = {
   root: string;
+  apiKey?: string;
+  device?: "auto" | "cpu" | "metal" | "vulkan" | "cuda";
   queries?: string[];
   routes: Array<{ mode: "fts" | "vector"; query: string }>;
   fuse?: boolean;
@@ -40,6 +42,8 @@ export function normalizeSearchInput(
   const common = normalizeSearchFields(input);
   return {
     root: input.root,
+    apiKey: input.apiKey,
+    device: input.device,
     ...common,
     freshness: input.freshness,
     autoUpdate: input.autoUpdate,

--- a/src/mcp/schemas.ts
+++ b/src/mcp/schemas.ts
@@ -51,7 +51,31 @@ export const absoluteRootSchema = z
   .refine((root) => isAbsolute(root), "root must be an absolute path.")
   .describe("Absolute repository path visible to the daemon.");
 
+const embeddingSearchRuntimeFields = {
+  apiKey: z
+    .string()
+    .min(1)
+    .max(8_192)
+    .optional()
+    .describe("One-request embedding provider API key override."),
+  device: z
+    .enum(["auto", "cpu", "metal", "vulkan", "cuda"])
+    .optional()
+    .describe("One-request local embedding device override."),
+};
+
+const embeddingIndexRuntimeFields = {
+  ...embeddingSearchRuntimeFields,
+  endpoint: z
+    .string()
+    .url()
+    .max(2_048)
+    .optional()
+    .describe("Remote embedding endpoint override."),
+};
+
 const searchFields = {
+  ...embeddingSearchRuntimeFields,
   query: boundedString("Natural-language or exact search query.").optional(),
   queries: boundedStringList(
     "Multiple query groups. Use this for related concepts.",
@@ -128,6 +152,7 @@ const searchFields = {
 
 export const zvecGrepIndexInputSchema = z.object({
   root: absoluteRootSchema,
+  ...embeddingIndexRuntimeFields,
   drop: z
     .boolean()
     .optional()

--- a/test/config-cli.test.mjs
+++ b/test/config-cli.test.mjs
@@ -24,6 +24,31 @@ test("config model set parses local runtime settings", () => {
   assert.deepEqual(parsed.positionals, ["local/embeddinggemma-300m"]);
 });
 
+test("config provider and default model settings parse", () => {
+  const provider = parseArgs([
+    "config",
+    "provider",
+    "set",
+    "qwen",
+    "--api-key",
+    "secret",
+  ]);
+  assert.equal(provider.options.configAction, "provider-set");
+  assert.equal(provider.options.apiKey, "secret");
+
+  const model = parseArgs([
+    "config",
+    "model",
+    "set",
+    "qwen/text-embedding-v4",
+    "--endpoint",
+    "https://example.test/embeddings",
+    "--default",
+  ]);
+  assert.equal(model.options.endpoint, "https://example.test/embeddings");
+  assert.equal(model.options.defaultModel, true);
+});
+
 test("config model set persists independent local model settings", async (t) => {
   const home = await mkdtemp(join(tmpdir(), "zvec-grep-config-cli-"));
   const workspace = join(home, "workspace");
@@ -72,6 +97,25 @@ test("config model set persists independent local model settings", async (t) => 
     ],
     { env, cwd: workspace },
   );
+  await execFileAsync(
+    process.execPath,
+    [cliPath, "config", "provider", "set", "qwen", "--api-key", "provider-key"],
+    { env, cwd: workspace },
+  );
+  await execFileAsync(
+    process.execPath,
+    [
+      cliPath,
+      "config",
+      "model",
+      "set",
+      "qwen/text-embedding-v4",
+      "--endpoint",
+      "https://example.test/embeddings",
+      "--default",
+    ],
+    { env, cwd: workspace },
+  );
 
   const config = JSON.parse(
     await readFile(join(home, ".zvec-grep", "config.json"), "utf8"),
@@ -79,13 +123,21 @@ test("config model set persists independent local model settings", async (t) => 
   assert.deepEqual(config.models, {
     "local/embeddinggemma-300m": { device: "cpu" },
     "local/qwen3-embedding-0.6b": { device: "cpu" },
+    "qwen/text-embedding-v4": {
+      endpoint: "https://example.test/embeddings",
+    },
   });
+  assert.deepEqual(config.providers, {
+    qwen: { apiKey: "provider-key" },
+  });
+  assert.equal(config.defaults.embedding, "qwen/text-embedding-v4");
+  assert.equal(config.version, 1);
   await assert.rejects(access(join(workspace, ".zvec-grep")), {
     code: "ENOENT",
   });
 });
 
-test("config model set rejects missing settings and remote models", async () => {
+test("config model set rejects missing and incompatible settings", async () => {
   await assert.rejects(
     execFileAsync(process.execPath, [
       cliPath,
@@ -94,7 +146,7 @@ test("config model set rejects missing settings and remote models", async () => 
       "set",
       "local/embeddinggemma-300m",
     ]),
-    /requires --device/,
+    /requires --endpoint, --device, or --default/,
   );
   await assert.rejects(
     execFileAsync(process.execPath, [
@@ -106,7 +158,7 @@ test("config model set rejects missing settings and remote models", async () => 
       "--device",
       "cpu",
     ]),
-    /only supports local embedding models/,
+    /only supported for local embedding models/,
   );
   await assert.rejects(
     execFileAsync(process.execPath, [
@@ -118,7 +170,31 @@ test("config model set rejects missing settings and remote models", async () => 
       "--device",
       "cpu",
     ]),
-    /not in the zvec-grep catalog/,
+    /Unsupported embedding model/,
+  );
+  await assert.rejects(
+    execFileAsync(process.execPath, [
+      cliPath,
+      "config",
+      "model",
+      "set",
+      "local/embeddinggemma-300m",
+      "--endpoint",
+      "https://example.test/embeddings",
+    ]),
+    /only supported for remote embedding models/,
+  );
+  await assert.rejects(
+    execFileAsync(process.execPath, [
+      cliPath,
+      "config",
+      "provider",
+      "set",
+      "unknown",
+      "--api-key",
+      "secret",
+    ]),
+    /Unsupported remote embedding provider/,
   );
   for (const option of ["--gpu", "--no-gpu", "--llama-gpu"]) {
     assert.throws(

--- a/test/config-cli.test.mjs
+++ b/test/config-cli.test.mjs
@@ -170,7 +170,12 @@ test("config model set rejects missing and incompatible settings", async () => {
       "--device",
       "cpu",
     ]),
-    /Unsupported embedding model/,
+    (error) => {
+      assert.match(error.stderr, /Unsupported embedding model/);
+      assert.match(error.stderr, /local\/embeddinggemma-300m/);
+      assert.match(error.stderr, /qwen\/text-embedding-v4/);
+      return true;
+    },
   );
   await assert.rejects(
     execFileAsync(process.execPath, [
@@ -194,7 +199,14 @@ test("config model set rejects missing and incompatible settings", async () => {
       "--api-key",
       "secret",
     ]),
-    /Unsupported remote embedding provider/,
+    (error) => {
+      assert.match(error.stderr, /Unsupported remote embedding provider/);
+      assert.match(
+        error.stderr,
+        /Supported remote embedding providers:\s+qwen/,
+      );
+      return true;
+    },
   );
   for (const option of ["--gpu", "--no-gpu", "--llama-gpu"]) {
     assert.throws(

--- a/test/config.test.mjs
+++ b/test/config.test.mjs
@@ -7,10 +7,9 @@ import {
   readGlobalConfig,
   resolveEmbeddingRuntimeOptions,
   updateGlobalConfig,
-  updateGlobalConfigFromExplicitOptions,
 } from "../dist/engine/config.js";
 
-test("global config is created securely and merged incrementally", async (t) => {
+test("global config v1 is created securely and merged incrementally", async (t) => {
   const temporaryDirectory = await mkdtemp(join(tmpdir(), "zvec-grep-config-"));
   const configPath = join(temporaryDirectory, ".zvec-grep", "config.json");
   t.after(async () => {
@@ -23,11 +22,19 @@ test("global config is created securely and merged incrementally", async (t) => 
     {
       defaults: {
         embedding: "qwen/text-embedding-v4",
-        device: "cpu",
+        modelCacheDir: "/tmp/models",
       },
       providers: {
         qwen: {
           apiKey: "first-key",
+        },
+      },
+      models: {
+        "qwen/text-embedding-v4": {
+          endpoint: "https://example.test/embeddings",
+        },
+        "local/embeddinggemma-300m": {
+          device: "metal",
         },
       },
       client: { mode: "server", serverUrl: "http://127.0.0.1:8123/mcp" },
@@ -39,7 +46,7 @@ test("global config is created securely and merged incrementally", async (t) => 
     {
       providers: {
         qwen: {
-          endpoint: "https://example.test/embeddings",
+          apiKey: "rotated-key",
         },
       },
       client: { mode: "auto" },
@@ -51,12 +58,19 @@ test("global config is created securely and merged incrementally", async (t) => 
     version: 1,
     defaults: {
       embedding: "qwen/text-embedding-v4",
-      device: "cpu",
+      modelCacheDir: "/tmp/models",
     },
     providers: {
       qwen: {
-        apiKey: "first-key",
+        apiKey: "rotated-key",
+      },
+    },
+    models: {
+      "qwen/text-embedding-v4": {
         endpoint: "https://example.test/embeddings",
+      },
+      "local/embeddinggemma-300m": {
+        device: "metal",
       },
     },
     client: { mode: "auto", serverUrl: "http://127.0.0.1:8123/mcp" },
@@ -73,148 +87,87 @@ test("global config is created securely and merged incrementally", async (t) => 
   }
 });
 
-test("explicit index options become provider-aware global config", async (t) => {
-  const temporaryDirectory = await mkdtemp(
-    join(tmpdir(), "zvec-grep-config-explicit-"),
-  );
-  const configPath = join(temporaryDirectory, ".zvec-grep", "config.json");
-  t.after(async () => {
-    await rm(temporaryDirectory, { recursive: true, force: true });
-  });
-
-  assert.equal(
-    updateGlobalConfigFromExplicitOptions(
-      {
-        embedding: "qwen/text-embedding-v4",
-        apiKey: "explicit-key",
-        endpoint: "https://example.test/embeddings",
-      },
-      undefined,
-      configPath,
-    ),
-    true,
-  );
-  assert.deepEqual(readGlobalConfig(configPath), {
-    version: 1,
-    defaults: {
-      embedding: "qwen/text-embedding-v4",
-    },
-    providers: {
-      qwen: {
-        apiKey: "explicit-key",
-        endpoint: "https://example.test/embeddings",
-      },
-    },
-  });
-  assert.equal(
-    updateGlobalConfigFromExplicitOptions({}, "qwen", configPath),
-    false,
-  );
-});
-
-test("local embedding options are persisted per model", async (t) => {
-  const temporaryDirectory = await mkdtemp(
-    join(tmpdir(), "zvec-grep-config-model-"),
-  );
-  const configPath = join(temporaryDirectory, ".zvec-grep", "config.json");
-  t.after(async () => {
-    await rm(temporaryDirectory, { recursive: true, force: true });
-  });
-
-  assert.equal(
-    updateGlobalConfigFromExplicitOptions(
-      {
-        embedding: "local/embeddinggemma-300m",
-        device: "metal",
-      },
-      undefined,
-      configPath,
-    ),
-    true,
-  );
-  assert.equal(
-    updateGlobalConfigFromExplicitOptions(
-      {
-        embedding: "local/qwen3-embedding-0.6b",
-        device: "cpu",
-      },
-      undefined,
-      configPath,
-    ),
-    true,
-  );
-
-  assert.deepEqual(readGlobalConfig(configPath), {
-    version: 1,
-    defaults: {
-      embedding: "local/qwen3-embedding-0.6b",
-    },
-    models: {
-      "local/embeddinggemma-300m": {
-        device: "metal",
-      },
-      "local/qwen3-embedding-0.6b": {
-        device: "cpu",
-      },
-    },
-  });
-});
-
-test("existing local index persists runtime options for its stored model", async (t) => {
-  const temporaryDirectory = await mkdtemp(
-    join(tmpdir(), "zvec-grep-config-existing-model-"),
-  );
-  const configPath = join(temporaryDirectory, ".zvec-grep", "config.json");
-  t.after(async () => {
-    await rm(temporaryDirectory, { recursive: true, force: true });
-  });
-
-  assert.equal(
-    updateGlobalConfigFromExplicitOptions(
-      { device: "metal" },
-      "local/embeddinggemma-300m",
-      configPath,
-    ),
-    true,
-  );
-  assert.deepEqual(readGlobalConfig(configPath), {
-    version: 1,
-    models: {
-      "local/embeddinggemma-300m": { device: "metal" },
-    },
-  });
-});
-
-test("model runtime settings override defaults and do not affect remote models", () => {
+test("embedding runtime resolver preserves every precedence layer", () => {
   const config = {
     version: 1,
-    defaults: { device: "cpu" },
+    providers: { qwen: { apiKey: "global-key" } },
     models: {
-      "local/embeddinggemma-300m": {
-        device: "metal",
+      "qwen/text-embedding-v4": {
+        endpoint: "https://global.test/embeddings",
       },
+      "local/embeddinggemma-300m": { device: "metal" },
     },
+  };
+  const environment = {
+    ZVEC_GREP_API_KEY: "env-key",
+    ZVEC_GREP_ENDPOINT: "https://env.test/embeddings",
+    ZVEC_GREP_DEVICE: "cpu",
   };
 
   assert.deepEqual(
-    resolveEmbeddingRuntimeOptions("local/embeddinggemma-300m", {}, config),
-    { device: "metal" },
+    resolveEmbeddingRuntimeOptions(
+      "qwen/text-embedding-v4",
+      {
+        apiKey: "request-key",
+        endpoint: "https://request.test/embeddings",
+      },
+      {
+        apiKey: "workspace-key",
+        endpoint: "https://workspace.test/embeddings",
+      },
+      config,
+      environment,
+    ),
+    {
+      apiKey: "request-key",
+      endpoint: "https://request.test/embeddings",
+    },
+  );
+  assert.deepEqual(
+    resolveEmbeddingRuntimeOptions(
+      "qwen/text-embedding-v4",
+      {},
+      {
+        apiKey: "workspace-key",
+        endpoint: "https://workspace.test/embeddings",
+      },
+      config,
+      environment,
+    ),
+    {
+      apiKey: "workspace-key",
+      endpoint: "https://workspace.test/embeddings",
+    },
+  );
+  assert.deepEqual(
+    resolveEmbeddingRuntimeOptions(
+      "qwen/text-embedding-v4",
+      {},
+      {},
+      config,
+      environment,
+    ),
+    {
+      apiKey: "global-key",
+      endpoint: "https://global.test/embeddings",
+    },
   );
   assert.deepEqual(
     resolveEmbeddingRuntimeOptions(
       "local/embeddinggemma-300m",
-      { device: "cpu" },
+      {},
+      {},
       config,
+      environment,
     ),
-    { device: "cpu" },
-  );
-  assert.deepEqual(
-    resolveEmbeddingRuntimeOptions("qwen/text-embedding-v4", {}, config),
-    {},
+    {
+      apiKey: "env-key",
+      device: "metal",
+    },
   );
 });
 
-test("global config rejects malformed fields without echoing secrets", async (t) => {
+test("global config v1 rejects malformed schemas without echoing secrets", async (t) => {
   const temporaryDirectory = await mkdtemp(
     join(tmpdir(), "zvec-grep-config-invalid-"),
   );
@@ -225,16 +178,23 @@ test("global config rejects malformed fields without echoing secrets", async (t)
 
   await writeFile(
     configPath,
-    JSON.stringify({
-      version: 1,
-      providers: {
-        qwen: {
-          apiKey: 12345,
-        },
-      },
-    }),
+    JSON.stringify({ version: 1, defaults: { device: "cpu" } }),
+  );
+  assert.throws(
+    () => readGlobalConfig(configPath),
+    (error) => {
+      assert.match(error.context, /defaults\.device is not supported/);
+      return true;
+    },
   );
 
+  await writeFile(
+    configPath,
+    JSON.stringify({
+      version: 1,
+      providers: { qwen: { apiKey: 12345 } },
+    }),
+  );
   assert.throws(
     () => readGlobalConfig(configPath),
     (error) => {
@@ -245,37 +205,16 @@ test("global config rejects malformed fields without echoing secrets", async (t)
     },
   );
 
-  await writeFile(
-    configPath,
-    JSON.stringify({
-      version: 1,
-      models: {
-        "qwen/text-embedding-v4": { device: "metal" },
+  for (const models of [
+    { "qwen/text-embedding-v4": { device: "metal" } },
+    {
+      "local/embeddinggemma-300m": {
+        endpoint: "https://example.test/embeddings",
       },
-    }),
-  );
-  assert.throws(
-    () => readGlobalConfig(configPath),
-    (error) => {
-      assert.match(error.context, /only supports local embedding models/);
-      return true;
     },
-  );
-
-  await writeFile(
-    configPath,
-    JSON.stringify({
-      version: 1,
-      defaults: {
-        llamaGpu: "metal",
-      },
-    }),
-  );
-  assert.throws(
-    () => readGlobalConfig(configPath),
-    (error) => {
-      assert.match(error.context, /defaults\.llamaGpu is not supported/);
-      return true;
-    },
-  );
+    { "qwen/text-embedding-v4": { endpoint: "not-a-url" } },
+  ]) {
+    await writeFile(configPath, JSON.stringify({ version: 1, models }));
+    assert.throws(() => readGlobalConfig(configPath));
+  }
 });

--- a/test/daemon-cache.test.mjs
+++ b/test/daemon-cache.test.mjs
@@ -247,11 +247,14 @@ test("root runtime searches the writer context as soon as it becomes available",
   await new Promise((resolve) => setImmediate(resolve));
   assert.equal(searchSettled, false);
 
-  const releaseWriterContext = runtime.setWriterContext(async (options) => {
-    assert.equal(options.root, "/tmp/repo");
-    assert.equal(options.autoUpdate, false);
-    return { ...emptyContextResult(), query: options.query };
-  });
+  const releaseWriterContext = runtime.setWriterContext(
+    async (options) => {
+      assert.equal(options.root, "/tmp/repo");
+      assert.equal(options.autoUpdate, false);
+      return { ...emptyContextResult(), query: options.query };
+    },
+    pool.keyFor(modelLoadRequest("model-a")),
+  );
 
   const result = await search;
   assert.equal(searchSettled, true);
@@ -261,6 +264,51 @@ test("root runtime searches the writer context as soon as it becomes available",
   runtime.setWriterPending(false);
   await runtime.close();
   await pool.close();
+});
+
+test("root runtime does not reuse a writer context with a different model runtime", async () => {
+  const pool = new EmbeddingModelPool({
+    keyForRequest: (request) => request.runtime.apiKey,
+    createModel: () => ({ dispose: async () => {} }),
+  });
+  const writerRequest = {
+    model: { provider: "qwen", name: "text-embedding-v4" },
+    runtime: { apiKey: "writer-key" },
+  };
+  const searchRequest = {
+    model: { provider: "qwen", name: "text-embedding-v4" },
+    runtime: { apiKey: "search-key" },
+  };
+  let writerSearches = 0;
+  const runtime = new RootRuntime({
+    canonicalRoot: "/tmp/repo",
+    modelPool: pool,
+    modelLoadRequest: writerRequest,
+    openSession: async (lease) => ({
+      root: "/tmp/repo",
+      context: async () => ({ ...emptyContextResult(), query: lease.key }),
+      close: async () => {},
+    }),
+  });
+
+  runtime.setWriterPending(true);
+  const releaseWriterContext = runtime.setWriterContext(async () => {
+    writerSearches += 1;
+    return { ...emptyContextResult(), query: "writer-key" };
+  }, pool.keyFor(writerRequest));
+  runtime.updateModelLoadRequest(searchRequest);
+  const search = runtime.search({ query: "query" }, searchRequest);
+  await new Promise((resolve) => setImmediate(resolve));
+  const writerSearchesBeforeRelease = writerSearches;
+
+  await releaseWriterContext();
+  runtime.setWriterPending(false);
+  const result = await search;
+  await runtime.close();
+  await pool.close();
+
+  assert.equal(writerSearchesBeforeRelease, 0);
+  assert.equal(result.query, "search-key");
 });
 
 test("root runtime releases its daemon lease when read cache close fails", async () => {

--- a/test/e2e/cli.test.mjs
+++ b/test/e2e/cli.test.mjs
@@ -292,6 +292,9 @@ test("CLI exposes stable help, version, and failure behavior", async () => {
   const indexHelp = await runCli(["index", "-h"]);
   assert.match(indexHelp.stdout, /qwen\/text-embedding-v4/);
   assert.doesNotMatch(indexHelp.stdout, /qwen3\.7-text-embedding/);
+  const configHelp = await runCli(["config", "--help"]);
+  assert.match(configHelp.stdout, /Default API key for the provider/);
+  assert.match(configHelp.stdout, /Existing indexes continue to use/);
   const version = await runCli(["version"]);
   assert.match(version.stdout.trim(), /^\d+\.\d+\.\d+/);
   const verboseVersion = await runCli(["version", "-v"]);

--- a/test/e2e/cli.test.mjs
+++ b/test/e2e/cli.test.mjs
@@ -28,6 +28,7 @@ test("server-mode index reports Workspace progress", async (t) => {
   const port = await availablePort();
   const env = {
     HOME: home,
+    USERPROFILE: home,
     NO_COLOR: "1",
     ZVEC_GREP_API_KEY: "test-key",
     ZVEC_GREP_ENDPOINT: endpoint,
@@ -90,7 +91,15 @@ test("CLI completes index, search, explicit refresh, status, and rg workflows", 
   );
 
   const endpoint = await createFakeEmbeddingServer(t);
-  const env = { HOME: home, NO_COLOR: "1" };
+  const env = { HOME: home, USERPROFILE: home, NO_COLOR: "1" };
+  await mkdir(join(home, ".zvec-grep"), { recursive: true });
+  await writeFile(
+    join(home, ".zvec-grep", "config.json"),
+    `${JSON.stringify({
+      version: 1,
+      defaults: { embedding: "qwen/text-embedding-v4" },
+    })}\n`,
+  );
 
   const indexed = await runCli(
     [

--- a/test/e2e/cli.test.mjs
+++ b/test/e2e/cli.test.mjs
@@ -305,6 +305,16 @@ test("CLI exposes stable help, version, and failure behavior", async () => {
     return true;
   });
   await assert.rejects(
+    runCli(["index", "--embedding", "unknown/model"]),
+    (error) => {
+      assert.equal(error.code, 1);
+      assert.match(error.stderr, /Unsupported embedding model: unknown\/model/);
+      assert.match(error.stderr, /local\/embeddinggemma-300m/);
+      assert.match(error.stderr, /qwen\/text-embedding-v4/);
+      return true;
+    },
+  );
+  await assert.rejects(
     runCli(["collections", "list", "extra"]),
     /does not accept/,
   );

--- a/test/embedding-runtime.test.mjs
+++ b/test/embedding-runtime.test.mjs
@@ -1,0 +1,147 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { CollectionRegistry } from "../dist/engine/collection/index.js";
+import { updateGlobalConfig } from "../dist/engine/config.js";
+import { createZvecGrep } from "../dist/index.js";
+import {
+  createRemoteEmbeddingOperationPermit,
+  createRemoteEmbeddingTarget,
+  withRemoteEmbeddingOperationPermit,
+} from "../dist/authorization/index.js";
+import { createFakeEmbeddingServer } from "./helpers/fake-embedding.mjs";
+
+test("workspace runtime persists explicit key and endpoint but search overrides stay one-shot", async (t) => {
+  const temporaryDirectory = await mkdtemp(
+    join(tmpdir(), "zvec-grep-workspace-runtime-"),
+  );
+  const root = join(temporaryDirectory, "repo");
+  const endpoint = await createFakeEmbeddingServer(t);
+  const replacementEndpoint = await createFakeEmbeddingServer(t);
+  t.after(async () => {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  });
+  await mkdir(root, { recursive: true });
+  await writeFile(join(root, "example.ts"), "export const answer = 42;\n");
+
+  let service = await createZvecGrep({
+    root,
+    embedding: "qwen/text-embedding-v4",
+    apiKey: "workspace-key",
+    endpoint,
+  });
+  await withPermit(root, endpoint, () => service.index());
+  await service.close();
+
+  assert.deepEqual(readRuntime(root), {
+    apiKey: "workspace-key",
+    endpoint,
+  });
+
+  service = await createZvecGrep({
+    root,
+    apiKey: "one-shot-key",
+  });
+  await withPermit(root, endpoint, () =>
+    service.context({
+      root,
+      query: "where is answer defined",
+      autoUpdate: false,
+    }),
+  );
+  await service.close();
+  assert.deepEqual(readRuntime(root), {
+    apiKey: "workspace-key",
+    endpoint,
+  });
+
+  service = await createZvecGrep({
+    root,
+    endpoint: replacementEndpoint,
+  });
+  await assert.rejects(
+    service.context({
+      root,
+      query: "where is answer defined",
+      autoUpdate: false,
+    }),
+    /cannot override.*endpoint/i,
+  );
+  await assert.rejects(service.index(), /different embedding endpoint/i);
+  await service.close();
+  assert.deepEqual(readRuntime(root), {
+    apiKey: "workspace-key",
+    endpoint,
+  });
+
+  service = await createZvecGrep({
+    root,
+    endpoint: replacementEndpoint,
+  });
+  await withPermit(root, replacementEndpoint, () =>
+    service.index({ rebuild: true }),
+  );
+  await service.close();
+  assert.deepEqual(readRuntime(root), {
+    apiKey: "workspace-key",
+    endpoint: replacementEndpoint,
+  });
+});
+
+test("inherited provider keys are not copied into workspace metadata", async (t) => {
+  const temporaryDirectory = await mkdtemp(
+    join(tmpdir(), "zvec-grep-inherited-runtime-"),
+  );
+  const root = join(temporaryDirectory, "repo");
+  const endpoint = await createFakeEmbeddingServer(t);
+  const originalHome = process.env.HOME;
+  process.env.HOME = temporaryDirectory;
+  t.after(async () => {
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  });
+  await mkdir(root, { recursive: true });
+  await writeFile(join(root, "example.ts"), "export const answer = 42;\n");
+  updateGlobalConfig({
+    defaults: { embedding: "qwen/text-embedding-v4" },
+    providers: { qwen: { apiKey: "global-key" } },
+    models: {
+      "qwen/text-embedding-v4": { endpoint },
+    },
+  });
+
+  const service = await createZvecGrep({ root });
+  await withPermit(root, endpoint, () => service.index());
+  await service.close();
+
+  assert.deepEqual(readRuntime(root), { endpoint });
+});
+
+function readRuntime(root) {
+  const registry = new CollectionRegistry(
+    join(root, ".zvec-grep"),
+    undefined,
+    true,
+  );
+  try {
+    return registry.getEmbeddingRuntime("__anonymous__");
+  } finally {
+    registry.close();
+  }
+}
+
+async function withPermit(root, endpoint, operation) {
+  const target = await createRemoteEmbeddingTarget({
+    roots: [root],
+    provider: "qwen",
+    model: "text-embedding-v4",
+    endpoint,
+  });
+  return await withRemoteEmbeddingOperationPermit(
+    createRemoteEmbeddingOperationPermit(target, "once"),
+    operation,
+  );
+}

--- a/test/integration/collection-registry.test.mjs
+++ b/test/integration/collection-registry.test.mjs
@@ -48,6 +48,16 @@ test("collection registry covers lifecycle, caching, rename, roots, disable, rea
   assert.equal(registry.has("docs"), true);
   assert.equal(registry.get("docs")?.id, created.id);
   assert.equal(registry.list().length, 1);
+  assert.deepEqual(registry.getEmbeddingRuntime("docs"), {});
+  registry.updateEmbeddingRuntime("docs", {
+    apiKey: "workspace-key",
+    endpoint: "https://example.test/embeddings",
+  });
+  assert.deepEqual(registry.getEmbeddingRuntime("docs"), {
+    apiKey: "workspace-key",
+    endpoint: "https://example.test/embeddings",
+  });
+  assert.equal("apiKey" in registry.get("docs"), false);
   assert.throws(() => registry.create("docs", [root]), /already exists/);
 
   const collection = registry.open("docs");
@@ -87,6 +97,10 @@ test("collection registry covers lifecycle, caching, rename, roots, disable, rea
   assert.equal(renamed?.name, "renamed");
   assert.equal(registry.has("docs"), false);
   assert.equal(registry.has("renamed"), true);
+  assert.deepEqual(registry.getEmbeddingRuntime("renamed"), {
+    apiKey: "workspace-key",
+    endpoint: "https://example.test/embeddings",
+  });
 
   const unchanged = registry.updateRootPaths("renamed", [root]);
   assert.equal(unchanged?.updatedTime, renamed?.updatedTime);
@@ -159,6 +173,7 @@ test("collection registry covers lifecycle, caching, rename, roots, disable, rea
     () => readOnly.prepareIndex("renamed", [root]),
     () => readOnly.disableIndex("renamed", [root]),
     () => readOnly.updateRootPaths("renamed", [root]),
+    () => readOnly.updateEmbeddingRuntime("renamed", { apiKey: "other" }),
   ]) {
     assert.throws(operation, /read-only/);
   }

--- a/test/integration/collection-registry.test.mjs
+++ b/test/integration/collection-registry.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdir, writeFile } from "node:fs/promises";
+import { chmod, mkdir, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import test from "node:test";
 import {
@@ -31,6 +31,9 @@ test("collection registry covers lifecycle, caching, rename, roots, disable, rea
 
   const withoutModelHome = join(temporaryDirectory, "without-model");
   const withoutModel = new CollectionRegistry(withoutModelHome);
+  if (process.platform !== "win32") {
+    assert.equal((await stat(withoutModelHome)).mode & 0o777, 0o700);
+  }
   assert.throws(
     () => withoutModel.create("missing-model", [root]),
     /requires an embedding model/,
@@ -164,7 +167,13 @@ test("collection registry covers lifecycle, caching, rename, roots, disable, rea
   registry.close();
   assert.doesNotThrow(() => registry.close());
   registry = undefined;
+  if (process.platform !== "win32") {
+    await chmod(home, 0o755);
+  }
   readOnly = new CollectionRegistry(home, embedding, true);
+  if (process.platform !== "win32") {
+    assert.equal((await stat(home)).mode & 0o777, 0o700);
+  }
   assert.ok(readOnly.list().length > 0);
   for (const operation of [
     () => readOnly.create("readonly", [root]),

--- a/test/integration/service.test.mjs
+++ b/test/integration/service.test.mjs
@@ -168,7 +168,7 @@ test("workspace rebuild recreates unsupported index metadata", async (t) => {
   const registry = new CollectionRegistry(workspaceHome);
   const info = registry.get("__anonymous__");
   assert.ok(info);
-  registry.meta.upsert({ ...info, indexVersion: 1 });
+  registry.meta.upsert({ ...info, indexVersion: 999 });
   registry.close();
 
   const collectionsMarker = join(

--- a/test/integration/service.test.mjs
+++ b/test/integration/service.test.mjs
@@ -1,7 +1,9 @@
 import assert from "node:assert/strict";
-import { mkdir, rm, writeFile } from "node:fs/promises";
+import { access, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import test from "node:test";
+import { CollectionRegistry } from "../../dist/engine/collection/index.js";
+import { CURRENT_INDEX_VERSION } from "../../dist/engine/types.js";
 import { createZvecGrep } from "../../dist/index.js";
 import { createTemporaryDirectory } from "../helpers/fixtures.mjs";
 import { FakeEmbeddingModel } from "../helpers/fake-embedding.mjs";
@@ -141,6 +143,68 @@ test("service optionally fuses independent query groups into one result list", a
   assert.equal(grouped.items.length, 2);
   assert.equal(fused.items.length, 1);
   assert.equal(fused.diagnostics.index?.routes.length, 2);
+});
+
+test("workspace rebuild recreates unsupported index metadata", async (t) => {
+  const temporaryDirectory = await createTemporaryDirectory(
+    t,
+    "zvec-grep-version-rebuild-",
+  );
+  const root = join(temporaryDirectory, "repo");
+  const workspaceHome = join(root, ".zvec-grep");
+  await mkdir(root, { recursive: true });
+  await writeFile(join(root, "legacy.ts"), "export const LegacyNeedle = 42;\n");
+
+  let service = await createZvecGrep({
+    root,
+    embeddingModel: new FakeEmbeddingModel(),
+  });
+  t.after(async () => {
+    await service.close();
+  });
+  await service.index();
+  await service.close();
+
+  const registry = new CollectionRegistry(workspaceHome);
+  const info = registry.get("__anonymous__");
+  assert.ok(info);
+  registry.meta.upsert({ ...info, indexVersion: 1 });
+  registry.close();
+
+  const collectionsMarker = join(
+    workspaceHome,
+    "collections.zvec",
+    "legacy-marker",
+  );
+  const filesMarker = join(workspaceHome, "files.zvec", "legacy-marker");
+  const authorizationPath = join(workspaceHome, "authorization.json");
+  await writeFile(collectionsMarker, "legacy");
+  await writeFile(filesMarker, "legacy");
+  await writeFile(authorizationPath, "preserve");
+
+  service = await createZvecGrep({
+    root,
+    embeddingModel: new FakeEmbeddingModel(),
+  });
+  await assert.rejects(
+    service.info(),
+    (error) =>
+      error.code === "ZVEC_GREP.ENGINE.COLLECTION.INDEX_VERSION_MISMATCH" &&
+      error.context.includes("zg index --rebuild"),
+  );
+
+  await service.index({ rebuild: true });
+  const rebuilt = await service.info();
+  assert.equal(rebuilt.collection?.indexVersion, CURRENT_INDEX_VERSION);
+  await assert.rejects(access(collectionsMarker), { code: "ENOENT" });
+  await assert.rejects(access(filesMarker), { code: "ENOENT" });
+  assert.equal(await readFile(authorizationPath, "utf8"), "preserve");
+
+  const result = await service.context({
+    routes: [{ mode: "fts", query: "LegacyNeedle" }],
+    autoUpdate: false,
+  });
+  assert.ok(result.items.length > 0);
 });
 
 test("service records failed files, retries them, deletes stale records, and rebuilds", async (t) => {

--- a/test/mcp.test.mjs
+++ b/test/mcp.test.mjs
@@ -1,8 +1,38 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { parseArgs } from "../dist/cli/args.js";
+import {
+  zvecGrepIndexInputSchema,
+  zvecGrepSearchInputSchema,
+} from "../dist/mcp/schemas.js";
 
 test("stdio MCP entry points are not public CLI commands", () => {
   assert.throws(() => parseArgs(["serve", "--mcp"]), /removed/i);
   assert.throws(() => parseArgs(["--mcp"]), /Unknown command/i);
+});
+
+test("MCP index and search expose only supported runtime overrides", () => {
+  const searchRuntime = {
+    apiKey: "request-key",
+    device: "auto",
+  };
+  const indexRuntime = {
+    ...searchRuntime,
+    endpoint: "https://example.test/embeddings",
+  };
+  assert.deepEqual(
+    zvecGrepIndexInputSchema.parse({ root: "/repo", ...indexRuntime }),
+    { root: "/repo", ...indexRuntime },
+  );
+  assert.deepEqual(
+    zvecGrepSearchInputSchema.parse({ root: "/repo", ...searchRuntime }),
+    {
+      root: "/repo",
+      ...searchRuntime,
+      symbolTypes: [],
+      freshness: "eventual",
+      autoUpdate: true,
+    },
+  );
+  assert.equal("endpoint" in zvecGrepSearchInputSchema.shape, false);
 });

--- a/test/service-config-reload.test.mjs
+++ b/test/service-config-reload.test.mjs
@@ -53,6 +53,10 @@ test("explicit embedding reference reloads provider config before refresh and qu
       providers: {
         qwen: {
           apiKey: "key-a",
+        },
+      },
+      models: {
+        "qwen/text-embedding-v4": {
           endpoint: "https://endpoint-a.test/embeddings",
         },
       },
@@ -80,6 +84,10 @@ test("explicit embedding reference reloads provider config before refresh and qu
       providers: {
         qwen: {
           apiKey: "key-b",
+        },
+      },
+      models: {
+        "qwen/text-embedding-v4": {
           endpoint: "https://endpoint-b.test/embeddings",
         },
       },
@@ -89,7 +97,7 @@ test("explicit embedding reference reloads provider config before refresh and qu
       "export const answer = 43;\n",
     );
 
-    await withPermit(root, "https://endpoint-b.test/embeddings", () =>
+    await withPermit(root, "https://endpoint-a.test/embeddings", () =>
       service.context({
         root,
         query: "where is the answer defined",
@@ -99,7 +107,7 @@ test("explicit embedding reference reloads provider config before refresh and qu
     assert.ok(requests.length > 0);
     assert.ok(
       requests.every(
-        (request) => request.url === "https://endpoint-b.test/embeddings",
+        (request) => request.url === "https://endpoint-a.test/embeddings",
       ),
     );
     assert.ok(

--- a/test/service-model-cache.test.mjs
+++ b/test/service-model-cache.test.mjs
@@ -26,8 +26,8 @@ test("recovered embedding model cache is bounded and defers disposal until activ
   let blockedContext;
 
   const blockedRequestStarted = new Promise((resolve) => {
-    globalThis.fetch = async (input, init) => {
-      if (String(input) === "https://blocked.test/embeddings") {
+    globalThis.fetch = async (_input, init) => {
+      if (init?.headers?.Authorization === "Bearer blocked") {
         resolve();
         await new Promise((release) => {
           releaseBlockedRequest = release;
@@ -49,7 +49,7 @@ test("recovered embedding model cache is bounded and defers disposal until activ
       join(root, "src", "example.ts"),
       "export const answer = 42;\n",
     );
-    configureQwen("https://initial.test/embeddings");
+    configureQwen("initial");
 
     service = await createZvecGrep({
       root,
@@ -59,8 +59,8 @@ test("recovered embedding model cache is bounded and defers disposal until activ
       service.index(),
     );
 
-    configureQwen("https://blocked.test/embeddings");
-    blockedContext = withPermit(root, "https://blocked.test/embeddings", () =>
+    configureQwen("blocked");
+    blockedContext = withPermit(root, "https://initial.test/embeddings", () =>
       service.context({
         root,
         query: "where is the answer defined",
@@ -71,8 +71,8 @@ test("recovered embedding model cache is bounded and defers disposal until activ
     await blockedRequestStarted;
 
     for (const name of ["third", "fourth", "fifth", "sixth"]) {
-      configureQwen(`https://${name}.test/embeddings`);
-      await withPermit(root, `https://${name}.test/embeddings`, () =>
+      configureQwen(name);
+      await withPermit(root, "https://initial.test/embeddings", () =>
         service.context({
           root,
           query: "where is the answer defined",
@@ -106,12 +106,16 @@ test("recovered embedding model cache is bounded and defers disposal until activ
   }
 });
 
-function configureQwen(endpoint) {
+function configureQwen(apiKey) {
   updateGlobalConfig({
     providers: {
       qwen: {
-        apiKey: "test-key",
-        endpoint,
+        apiKey,
+      },
+    },
+    models: {
+      "qwen/text-embedding-v4": {
+        endpoint: "https://initial.test/embeddings",
       },
     },
   });

--- a/test/service-model-cache.test.mjs
+++ b/test/service-model-cache.test.mjs
@@ -5,12 +5,32 @@ import { join } from "node:path";
 import test from "node:test";
 import { updateGlobalConfig } from "../dist/engine/config.js";
 import { BaseEmbeddingModel } from "../dist/engine/models/embeddings.js";
+import { embeddingModelPoolKeyForIdentity } from "../dist/engine/service/index.js";
 import { createZvecGrep } from "../dist/index.js";
 import {
   createRemoteEmbeddingOperationPermit,
   createRemoteEmbeddingTarget,
   withRemoteEmbeddingOperationPermit,
 } from "../dist/authorization/index.js";
+
+test("embedding model cache identities are stable without exposing API keys", () => {
+  const identity = { provider: "qwen", name: "text-embedding-v4" };
+  const options = {
+    apiKey: "first-secret-key",
+    endpoint: "https://example.test/embeddings",
+  };
+  const first = embeddingModelPoolKeyForIdentity(identity, options);
+  const repeated = embeddingModelPoolKeyForIdentity(identity, options);
+  const differentKey = embeddingModelPoolKeyForIdentity(identity, {
+    ...options,
+    apiKey: "second-secret-key",
+  });
+
+  assert.equal(repeated, first);
+  assert.notEqual(differentKey, first);
+  assert.doesNotMatch(first, /first-secret-key/);
+  assert.doesNotMatch(differentKey, /second-secret-key/);
+});
 
 test("recovered embedding model cache is bounded and defers disposal until active queries finish", async () => {
   const temporaryDirectory = await mkdtemp(

--- a/test/unit/core.test.mjs
+++ b/test/unit/core.test.mjs
@@ -101,8 +101,6 @@ test("CLI argument parser handles command, provider, path, and rg options", () =
     "query",
     "--api-key",
     "secret",
-    "--endpoint",
-    "https://example.test/embeddings",
     "--model-cache",
     "/tmp/models",
     "--device",
@@ -110,10 +108,6 @@ test("CLI argument parser handles command, provider, path, and rg options", () =
     "query text",
   ]);
   assert.equal(queryRuntime.options.apiKey, "secret");
-  assert.equal(
-    queryRuntime.options.endpoint,
-    "https://example.test/embeddings",
-  );
   assert.equal(queryRuntime.options.modelCacheDir, "/tmp/models");
   assert.equal(queryRuntime.options.device, "cpu");
 
@@ -138,6 +132,16 @@ test("CLI argument parser handles command, provider, path, and rg options", () =
 });
 
 test("CLI parsers reject invalid values and normalize supported values", () => {
+  assert.throws(
+    () =>
+      parseArgs([
+        "query",
+        "--endpoint",
+        "https://example.test/embeddings",
+        "query text",
+      ]),
+    /--endpoint is not supported with zg query/,
+  );
   assert.equal(parseDevice("cpu"), "cpu");
   assert.equal(parseDevice("CUDA"), "cuda");
   assert.deepEqual(splitPathFilters("src/**, test/**, docs/**"), [


### PR DESCRIPTION
## Summary

- add provider- and model-level global embedding configuration
- resolve runtime values consistently across request, workspace, global config, and environment sources
- persist workspace API key overrides and endpoint/device snapshots after successful indexing
- align direct, server, and MCP index/search behavior
- remove endpoint overrides from search while keeping endpoint changes behind index rebuilds

## Motivation

Embedding configuration was previously split across CLI preprocessing, global settings, and runtime model loading. Server and direct modes could resolve or persist the same inputs differently. This change centralizes resolution and gives existing workspaces stable runtime snapshots while allowing provider keys to be managed globally or per workspace.

## User impact

- `zg config provider set` stores provider API keys
- `zg config model set` stores model endpoint/device settings and the default model
- indexing updates workspace runtime metadata without mutating global configuration
- searches allow one-shot API key/device overrides but no endpoint override
- model or endpoint changes require `--rebuild`

## Validation

- lint
- typecheck
- build
- configuration, runtime persistence, MCP contract, daemon freshness, and HTTP server tests
