### PR TITLE
refactor: simplify workspace index storage boundary

### DIFF
--- a/src/engine/manifest.ts
+++ b/src/engine/manifest.ts
@@ -1,3 +1,4 @@
+import { rmSync } from "node:fs";
 import { join } from "node:path";
 import type { EmbeddingRuntimeConfig } from "./config.js";
 import { EngineError } from "./errors.js";
@@ -44,6 +45,10 @@ export function writeWorkspaceManifest(
     directoryMode: WORKSPACE_DIRECTORY_MODE,
     fileMode: WORKSPACE_MANIFEST_MODE,
   });
+}
+
+export function deleteWorkspaceManifest(home: string): void {
+  rmSync(workspaceManifestPath(home), { force: true });
 }
 
 export function workspaceIndexInfoFromManifest(

--- a/src/engine/pipeline/indexing/index.ts
+++ b/src/engine/pipeline/indexing/index.ts
@@ -564,7 +564,7 @@ function buildIndexResult(
 
 async function optimizeStorage(ctx: IndexContext): Promise<void> {
   try {
-    await ctx.storage.optimize();
+    await ctx.storage.finalizeWrites();
   } catch (error) {
     throw toEngineError(error, "Indexing failed to finalize storage", {
       code: "ZVEC_GREP.ENGINE.INDEXING.OPTIMIZE_FAILED",
@@ -940,9 +940,25 @@ function commitFile(
 ): boolean {
   try {
     throwIfIndexCancelled(ctx);
-    ctx.storage.upsertFile(file.file, file.fragments, vectors, {
-      truncatedFragmentCount,
-    });
+    if (file.fragments.length !== vectors.length) {
+      throw new EngineError(
+        "Embedding returned mismatched entity/vector counts",
+        {
+          code: "ZVEC_GREP.ENGINE.STORAGE.ENTITY_VECTOR_COUNT_MISMATCH",
+          context: `fileId=${file.file.id} fragmentCount=${file.fragments.length} vectorCount=${vectors.length}`,
+        },
+      );
+    }
+    ctx.storage.replaceFile(
+      file.file,
+      file.fragments.map((fragment, index) => ({
+        fragment,
+        vector: vectors[index],
+      })),
+      {
+        truncatedFragmentCount,
+      },
+    );
     stats.filesIndexed++;
     stats.entitiesCreated += countPublicEntities(file.fragments);
     return true;

--- a/src/engine/pipeline/search/index.ts
+++ b/src/engine/pipeline/search/index.ts
@@ -5,11 +5,7 @@ import {
   errorDetails,
 } from "../../errors.js";
 import type { EmbeddingModel } from "../../models/index.js";
-import type {
-  WorkspaceIndexStorage,
-  StorageSearchFilter,
-  StorageSearchHit,
-} from "../../storage/index.js";
+import type { WorkspaceIndexStorage } from "../../storage/index.js";
 import type {
   WorkspaceIndexInfo,
   Entity,
@@ -46,6 +42,12 @@ type SearchContext = {
   storage: WorkspaceIndexStorage;
   embeddingModel?: EmbeddingModel;
 };
+
+type StorageSearchFilter = NonNullable<
+  Parameters<WorkspaceIndexStorage["searchFts"]>[2]
+>;
+
+type StorageSearchHit = ReturnType<WorkspaceIndexStorage["searchFts"]>[number];
 
 type Candidate = {
   id: string;

--- a/src/engine/service/root.ts
+++ b/src/engine/service/root.ts
@@ -1,16 +1,17 @@
-import { existsSync, rmSync } from "node:fs";
+import { existsSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
-import { workspaceManifestPath } from "../manifest.js";
+import { deleteWorkspaceManifest, workspaceManifestPath } from "../manifest.js";
+import {
+  deleteWorkspaceIndexStorage,
+  hasWorkspaceIndexStorage,
+} from "../storage/index.js";
+import { workspaceIndexPath } from "../storage/layout.js";
 
 export const ZVEC_GREP_DIR = ".zvec-grep";
-export const FILES_ZVEC = "files.zvec";
-export const ENTITIES_ZVEC = "index.zvec";
-
 export type WorkspaceIndexLocation = {
   root: string;
   home: string;
   manifestPath: string;
-  filesPath: string;
   indexPath: string;
 };
 
@@ -30,24 +31,13 @@ export function workspaceIndexLocation(root: string): WorkspaceIndexLocation {
     root: resolvedRoot,
     home,
     manifestPath: workspaceManifestPath(home),
-    filesPath: join(home, FILES_ZVEC),
-    indexPath: join(home, ENTITIES_ZVEC),
+    indexPath: workspaceIndexPath(home),
   };
 }
 
-export function resetWorkspaceIndexStorage(
-  location: WorkspaceIndexLocation,
-): void {
-  for (const target of [
-    location.manifestPath,
-    location.filesPath,
-    location.indexPath,
-  ]) {
-    if (dirname(target) !== location.home) {
-      throw new Error("Workspace index data must be inside its workspace home");
-    }
-    rmSync(target, { recursive: true, force: true });
-  }
+export function resetWorkspaceIndex(location: WorkspaceIndexLocation): void {
+  deleteWorkspaceManifest(location.home);
+  deleteWorkspaceIndexStorage(location.home);
 }
 
 export function findNearestWorkspaceIndex(
@@ -91,8 +81,6 @@ export function hasWorkspaceManifest(
 
 export function hasWorkspaceIndex(location: WorkspaceIndexLocation): boolean {
   return (
-    hasWorkspaceManifest(location) &&
-    existsSync(location.filesPath) &&
-    existsSync(location.indexPath)
+    hasWorkspaceManifest(location) && hasWorkspaceIndexStorage(location.home)
   );
 }

--- a/src/engine/service/workspace-index.ts
+++ b/src/engine/service/workspace-index.ts
@@ -1,4 +1,3 @@
-import { join } from "node:path";
 import {
   workspaceIndexDetail,
   detail,
@@ -12,8 +11,10 @@ import {
   indexWorkspacePaths,
 } from "../pipeline/indexing/index.js";
 import { searchWorkspaceIndex } from "../pipeline/search/index.js";
-import type { WorkspaceIndexStorage } from "../storage/index.js";
-import { ZvecWorkspaceIndexStorage } from "../storage/zvec.js";
+import {
+  createWorkspaceIndexStorage,
+  type WorkspaceIndexStorage,
+} from "../storage/index.js";
 import type {
   WorkspaceIndexEmbeddingSchema,
   WorkspaceIndexStatus,
@@ -25,31 +26,40 @@ import type {
 } from "../types.js";
 import { CURRENT_INDEX_VERSION } from "../types.js";
 
-const FILES_ZVEC = "files.zvec";
+export type WorkspaceIndexOptions = {
+  mode: "read" | "write";
+  embeddingModel?: EmbeddingModel;
+};
 
 export class WorkspaceIndex {
   private readonly storage: WorkspaceIndexStorage;
   private readonly embedding: WorkspaceIndexEmbeddingSchema;
+  private readonly embeddingModel?: EmbeddingModel;
   private closed = false;
 
   constructor(
     readonly info: WorkspaceIndexInfo,
-    private readonly embeddingModel?: EmbeddingModel,
-    private readonly readOnly = false,
-    private readonly fileStorePath = join(info.path, FILES_ZVEC),
+    options: WorkspaceIndexOptions,
   ) {
+    this.embeddingModel = options.embeddingModel;
     this.embedding = requireWorkspaceIndexEmbedding(info, "open");
     this.validateIndexVersion();
     if (this.embeddingModel) {
       this.validateEmbeddingSchema(this.embeddingModel);
     }
 
-    this.storage = new ZvecWorkspaceIndexStorage(
-      info.path,
-      this.embedding,
-      this.fileStorePath,
-      readOnly,
-    );
+    if (options.mode === "write") {
+      this.storage = createWorkspaceIndexStorage({
+        storagePath: info.path,
+        readOnly: false,
+        embedding: this.embedding,
+      });
+    } else {
+      this.storage = createWorkspaceIndexStorage({
+        storagePath: info.path,
+        readOnly: true,
+      });
+    }
   }
 
   get name(): string {
@@ -57,7 +67,7 @@ export class WorkspaceIndex {
   }
 
   index(options: IndexOptions = {}): Promise<IndexResult> {
-    if (this.readOnly) {
+    if (this.storage.readOnly) {
       throw new EngineError("Cannot update a read-only workspace index", {
         code: "ZVEC_GREP.ENGINE.WORKSPACE_INDEX.READ_ONLY",
         context: workspaceIndexOperationDetails(this.name, "index"),

--- a/src/engine/service/zvec-grep.ts
+++ b/src/engine/service/zvec-grep.ts
@@ -48,7 +48,7 @@ import { validateRootPaths } from "../pipeline/indexing/root-paths.js";
 import {
   findNearestWorkspace,
   hasWorkspaceIndex,
-  resetWorkspaceIndexStorage,
+  resetWorkspaceIndex,
   resolveZvecGrepRoot,
   workspaceHome,
   workspaceIndexLocation,
@@ -122,12 +122,10 @@ export function openWorkspaceReadSession(
     );
   }
 
-  const workspaceIndex = new WorkspaceIndex(
-    info,
+  const workspaceIndex = new WorkspaceIndex(info, {
+    mode: "read",
     embeddingModel,
-    true,
-    location.filesPath,
-  );
+  });
   let closed = false;
 
   return {
@@ -260,7 +258,7 @@ class ZvecGrepService implements ZvecGrep {
               },
             );
             if (options.rebuild || !isWorkspaceIndexed(existing)) {
-              resetWorkspaceIndexStorage(location);
+              resetWorkspaceIndex(location);
             }
 
             const existingAfterRebuild = options.rebuild ? null : existing;
@@ -279,12 +277,10 @@ class ZvecGrepService implements ZvecGrep {
               embeddingModel,
               existingRuntime,
             );
-            const workspaceIndex = new WorkspaceIndex(
-              manifest,
+            const workspaceIndex = new WorkspaceIndex(manifest, {
+              mode: "write",
               embeddingModel,
-              false,
-              location.filesPath,
-            );
+            });
             writeWorkspaceManifest(location.home, manifest);
 
             try {
@@ -351,7 +347,7 @@ class ZvecGrepService implements ZvecGrep {
       }
 
       return await withHomeWriteLock(location.home, "index.drop", async () => {
-        resetWorkspaceIndexStorage(location);
+        resetWorkspaceIndex(location);
         return true;
       });
     } finally {
@@ -527,7 +523,6 @@ class ZvecGrepService implements ZvecGrep {
     const workspaceIndex = this.openWorkspaceIndexForSearch(
       info,
       request,
-      location,
       info.embeddingRuntime,
     );
     try {
@@ -604,12 +599,10 @@ class ZvecGrepService implements ZvecGrep {
             "zg index --rebuild",
           );
 
-          const workspaceIndex = new WorkspaceIndex(
-            existing,
+          const workspaceIndex = new WorkspaceIndex(existing, {
+            mode: "write",
             embeddingModel,
-            false,
-            location.filesPath,
-          );
+          });
           try {
             const result = await workspaceIndex.index({
               embeddingConcurrency: options.embeddingConcurrency,
@@ -713,20 +706,17 @@ class ZvecGrepService implements ZvecGrep {
   private openWorkspaceIndexForSearch(
     info: WorkspaceIndexInfo,
     request: NormalizedContextRequest,
-    location: WorkspaceIndexLocation,
     workspaceRuntime: EmbeddingRuntimeConfig,
   ): WorkspaceIndex {
-    return new WorkspaceIndex(
-      info,
-      this.embeddingModelForSearch(
+    return new WorkspaceIndex(info, {
+      mode: "read",
+      embeddingModel: this.embeddingModelForSearch(
         indexedEmbeddingSchema(info),
         request,
         workspaceRuntime,
         info,
       ),
-      true,
-      location.filesPath,
-    );
+    });
   }
 
   private embeddingModelForSearch(
@@ -1371,12 +1361,7 @@ async function workspaceIndexStatus(
     return null;
   }
 
-  const workspaceIndex = new WorkspaceIndex(
-    info,
-    undefined,
-    true,
-    location.filesPath,
-  );
+  const workspaceIndex = new WorkspaceIndex(info, { mode: "read" });
   try {
     return await workspaceIndex.status();
   } finally {

--- a/src/engine/storage/index.ts
+++ b/src/engine/storage/index.ts
@@ -3,38 +3,50 @@ import type {
   Entity,
   EntityFragment,
   FileInfo,
+  WorkspaceIndexEmbeddingSchema,
 } from "../types.js";
 
-export type StoredEntity = {
+type StoredEntity = {
   entity: Entity;
   file: FileInfo;
 };
 
-export type StoredEntityFragment = {
+type IndexedFragment = {
   fragment: EntityFragment;
-  file: FileInfo;
+  vector: readonly number[];
 };
 
-export type StorageSearchPath = "fts" | "vector";
+type FileIndexDiagnostics = {
+  truncatedFragmentCount?: number;
+};
 
-export type StorageSearchFilter = {
+type StorageSearchFilter = {
   fileIds?: readonly string[];
   groupIds?: readonly string[];
   symbolNames?: readonly string[];
   symbolTypes?: readonly CodeSymbolType[];
 };
 
-export type StorageSearchHit = StoredEntityFragment & {
-  path: StorageSearchPath;
+type StorageSearchHit = {
+  fragment: EntityFragment;
+  file: FileInfo;
+  path: "fts" | "vector";
   score: number;
 };
 
-export type FileIndexDiagnostics = {
-  truncatedFragmentCount?: number;
-};
+export type WorkspaceIndexStorageOptions =
+  | {
+      storagePath: string;
+      readOnly: true;
+    }
+  | {
+      storagePath: string;
+      readOnly: false;
+      embedding: WorkspaceIndexEmbeddingSchema;
+    };
 
 export interface WorkspaceIndexStorage {
-  getFileById(fileId: string): FileInfo | null;
+  readonly readOnly: boolean;
   getFileByPath(absolutePath: string): FileInfo | null;
   listFilesByPathPrefix(absolutePath: string): FileInfo[];
   listFiles(): FileInfo[];
@@ -42,18 +54,7 @@ export interface WorkspaceIndexStorage {
     fileId: string,
     options?: { limit?: number; offset?: number },
   ): StoredEntity[];
-  getEntity(
-    entityId: string,
-    options?: { includeVector?: boolean },
-  ): (StoredEntity & { vector?: number[] }) | null;
-  upsertFile(
-    file: FileInfo,
-    fragments: readonly EntityFragment[],
-    vectors: readonly number[][],
-    diagnostics?: FileIndexDiagnostics,
-  ): void;
-  markFileFailed(file: FileInfo, error: string): void;
-  deleteFile(fileId: string): void;
+  getEntity(entityId: string): StoredEntity | null;
   searchFts(
     query: string,
     limit: number,
@@ -64,8 +65,19 @@ export interface WorkspaceIndexStorage {
     limit: number,
     filter?: StorageSearchFilter,
   ): StorageSearchHit[];
-  optimize(): Promise<void>;
+  replaceFile(
+    file: FileInfo,
+    entries: readonly IndexedFragment[],
+    diagnostics?: FileIndexDiagnostics,
+  ): void;
+  markFileFailed(file: FileInfo, error: string): void;
+  deleteFile(fileId: string): void;
+  finalizeWrites(): Promise<void>;
   close(): void;
 }
 
-export { ZvecWorkspaceIndexStorage } from "./zvec.js";
+export { createWorkspaceIndexStorage } from "./zvec.js";
+export {
+  deleteWorkspaceIndexStorage,
+  hasWorkspaceIndexStorage,
+} from "./layout.js";

--- a/src/engine/storage/layout.ts
+++ b/src/engine/storage/layout.ts
@@ -1,0 +1,41 @@
+import { existsSync, rmSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+
+const FILES_ZVEC = "files.zvec";
+const ENTITIES_ZVEC = "index.zvec";
+
+type WorkspaceIndexStoragePaths = {
+  storagePath: string;
+  filesPath: string;
+  indexPath: string;
+};
+
+export function resolveWorkspaceIndexStoragePaths(
+  storagePath: string,
+): WorkspaceIndexStoragePaths {
+  const resolvedStoragePath = resolve(storagePath);
+  return {
+    storagePath: resolvedStoragePath,
+    filesPath: join(resolvedStoragePath, FILES_ZVEC),
+    indexPath: join(resolvedStoragePath, ENTITIES_ZVEC),
+  };
+}
+
+export function hasWorkspaceIndexStorage(storagePath: string): boolean {
+  const paths = resolveWorkspaceIndexStoragePaths(storagePath);
+  return existsSync(paths.filesPath) && existsSync(paths.indexPath);
+}
+
+export function deleteWorkspaceIndexStorage(storagePath: string): void {
+  const paths = resolveWorkspaceIndexStoragePaths(storagePath);
+  for (const target of [paths.filesPath, paths.indexPath]) {
+    if (dirname(target) !== paths.storagePath) {
+      throw new Error("Workspace index data must be inside its storage path");
+    }
+    rmSync(target, { recursive: true, force: true });
+  }
+}
+
+export function workspaceIndexPath(storagePath: string): string {
+  return resolveWorkspaceIndexStoragePaths(storagePath).indexPath;
+}

--- a/src/engine/storage/zvec.ts
+++ b/src/engine/storage/zvec.ts
@@ -11,7 +11,6 @@ import {
   type ZVecDoc,
   type ZVecDocInput,
   type ZVecStatus,
-  type ZVecVector,
 } from "@zvec/zvec";
 import { closeSync, existsSync, mkdirSync, openSync } from "node:fs";
 import { dirname, join, sep } from "node:path";
@@ -30,21 +29,45 @@ import type {
 } from "../types.js";
 import { normalizePath } from "../utils/path.js";
 import type {
-  FileIndexDiagnostics,
   WorkspaceIndexStorage,
-  StorageSearchFilter,
-  StorageSearchHit,
-  StoredEntity,
-  StoredEntityFragment,
+  WorkspaceIndexStorageOptions,
 } from "./index.js";
+import { resolveWorkspaceIndexStoragePaths } from "./layout.js";
 
 type FileRecord = FileInfo & {
   entityIds: string[];
 };
 
+type StoredEntity = {
+  entity: Entity;
+  file: FileInfo;
+};
+
+type IndexedFragment = {
+  fragment: EntityFragment;
+  vector: readonly number[];
+};
+
+type FileIndexDiagnostics = {
+  truncatedFragmentCount?: number;
+};
+
+type StorageSearchFilter = {
+  fileIds?: readonly string[];
+  groupIds?: readonly string[];
+  symbolNames?: readonly string[];
+  symbolTypes?: readonly CodeSymbolType[];
+};
+
+type StorageSearchHit = {
+  fragment: EntityFragment;
+  file: FileInfo;
+  path: "fts" | "vector";
+  score: number;
+};
+
 const ENTITY_VECTOR_FIELD = "embedding";
 const ENTITY_TEXT_FIELD = "text";
-const ZVEC_PATH = "index.zvec";
 const ZVEC_LOCK_FILE = "LOCK";
 const NO_MATCH_FILTER = "file_id = '__zvec_grep_no_match__'";
 const ZVEC_UPSERT_BATCH_SIZE = 1024;
@@ -56,30 +79,40 @@ const ZVEC_OPEN_RETRY_MAX_DELAY_MS = 1000;
 
 let zvecInitialized = false;
 
-export class ZvecWorkspaceIndexStorage implements WorkspaceIndexStorage {
+export function createWorkspaceIndexStorage(
+  options: WorkspaceIndexStorageOptions,
+): WorkspaceIndexStorage {
+  return new ZvecWorkspaceIndexStorage(options);
+}
+
+type StoredEntityFragment = {
+  fragment: EntityFragment;
+  file: FileInfo;
+};
+
+class ZvecWorkspaceIndexStorage implements WorkspaceIndexStorage {
+  readonly readOnly: boolean;
   private readonly collection: ZVecCollection;
   private readonly files: ZvecFileMetaStore;
   private readonly filesById = new Map<string, FileRecord>();
   private readonly filesByAbsolutePath = new Map<string, FileRecord>();
   private needsOptimize = false;
 
-  constructor(
-    private readonly workspaceIndexPath: string,
-    private readonly embedding: WorkspaceIndexEmbeddingSchema,
-    fileStorePath: string,
-    private readonly readOnly = false,
-  ) {
+  constructor(options: WorkspaceIndexStorageOptions) {
+    const paths = resolveWorkspaceIndexStoragePaths(options.storagePath);
+    const { readOnly } = options;
+    this.readOnly = readOnly;
     initializeZvec();
     if (!readOnly) {
-      mkdirSync(workspaceIndexPath, { recursive: true });
+      mkdirSync(paths.storagePath, { recursive: true });
     }
 
-    this.files = new ZvecFileMetaStore(fileStorePath, readOnly);
+    this.files = new ZvecFileMetaStore(paths.filesPath, readOnly);
     for (const file of this.files.list()) {
       this.rememberFile(file);
     }
 
-    const zvecPath = join(workspaceIndexPath, ZVEC_PATH);
+    const zvecPath = paths.indexPath;
     if (existsSync(zvecPath)) {
       this.collection = openZvecCollection(zvecPath, readOnly, "open", () =>
         ZVecOpen(zvecPath, { readOnly }),
@@ -91,15 +124,9 @@ export class ZvecWorkspaceIndexStorage implements WorkspaceIndexStorage {
       });
     } else {
       this.collection = openZvecCollection(zvecPath, readOnly, "create", () =>
-        ZVecCreateAndOpen(zvecPath, createSchema(embedding)),
+        ZVecCreateAndOpen(zvecPath, createSchema(options.embedding)),
       );
     }
-  }
-
-  getFileById(fileId: string): FileInfo | null {
-    const file = this.filesById.get(fileId);
-
-    return file ? fileRecordToInfo(file) : null;
   }
 
   getFileByPath(absolutePath: string): FileInfo | null {
@@ -136,11 +163,8 @@ export class ZvecWorkspaceIndexStorage implements WorkspaceIndexStorage {
     return this.fetchStoredEntities(ids);
   }
 
-  getEntity(
-    entityId: string,
-    options: { includeVector?: boolean } = {},
-  ): (StoredEntity & { vector?: number[] }) | null {
-    const fragment = this.getFragment(entityId, options);
+  getEntity(entityId: string): StoredEntity | null {
+    const fragment = this.getFragment(entityId);
 
     if (!fragment) {
       return null;
@@ -150,23 +174,19 @@ export class ZvecWorkspaceIndexStorage implements WorkspaceIndexStorage {
       fragment.fragment.group &&
       fragment.fragment.group !== fragment.fragment.id
     ) {
-      return this.getEntity(fragment.fragment.group, options);
+      return this.getEntity(fragment.fragment.group);
     }
 
-    const entity = fragmentToEntity(fragment.fragment);
-
-    return fragment.vector
-      ? { file: fragment.file, entity, vector: fragment.vector }
-      : { file: fragment.file, entity };
+    return {
+      file: fragment.file,
+      entity: fragmentToEntity(fragment.fragment),
+    };
   }
 
-  private getFragment(
-    fragmentId: string,
-    options: { includeVector?: boolean } = {},
-  ): (StoredEntityFragment & { vector?: number[] }) | null {
+  private getFragment(fragmentId: string): StoredEntityFragment | null {
     const docs = this.collection.fetchSync({
       ids: fragmentId,
-      includeVector: options.includeVector ?? false,
+      includeVector: false,
     });
     const doc = docs[fragmentId];
 
@@ -174,34 +194,16 @@ export class ZvecWorkspaceIndexStorage implements WorkspaceIndexStorage {
       return null;
     }
 
-    const stored = this.docToStoredFragment(doc);
-    if (!stored) {
-      return null;
-    }
-
-    const vector = options.includeVector
-      ? readVector(doc.vectors[ENTITY_VECTOR_FIELD])
-      : undefined;
-
-    return vector ? { ...stored, vector } : stored;
+    return this.docToStoredFragment(doc);
   }
 
-  upsertFile(
+  replaceFile(
     file: FileInfo,
-    fragments: readonly EntityFragment[],
-    vectors: readonly number[][],
+    entries: readonly IndexedFragment[],
     diagnostics: FileIndexDiagnostics = {},
   ): void {
-    if (fragments.length !== vectors.length) {
-      throw new EngineError(
-        "Storage received mismatched entity/vector counts",
-        {
-          code: "ZVEC_GREP.ENGINE.STORAGE.ENTITY_VECTOR_COUNT_MISMATCH",
-          context: `fileId=${file.id} fragmentCount=${fragments.length} vectorCount=${vectors.length}`,
-        },
-      );
-    }
-
+    this.assertWritable("replaceFile");
+    const fragments = entries.map(({ fragment }) => fragment);
     validateFragmentGroups(file.id, fragments);
     this.markFileDirty(file);
     this.deleteFileDocuments(file.id);
@@ -219,11 +221,11 @@ export class ZvecWorkspaceIndexStorage implements WorkspaceIndexStorage {
       entityIds,
     };
 
-    if (fragments.length > 0) {
-      const docs = fragments.map((fragment, index): ZVecDocInput => ({
+    if (entries.length > 0) {
+      const docs = entries.map(({ fragment, vector }, index): ZVecDocInput => ({
         id: fragment.id,
         vectors: {
-          [ENTITY_VECTOR_FIELD]: vectors[index],
+          [ENTITY_VECTOR_FIELD]: [...vector],
         },
         fields: fragmentToFields(indexedFile, fragment, index),
       }));
@@ -253,6 +255,7 @@ export class ZvecWorkspaceIndexStorage implements WorkspaceIndexStorage {
   }
 
   markFileFailed(file: FileInfo, error: string): void {
+    this.assertWritable("markFileFailed");
     this.deleteFileDocuments(file.id);
 
     this.rememberFile({
@@ -269,6 +272,7 @@ export class ZvecWorkspaceIndexStorage implements WorkspaceIndexStorage {
   }
 
   deleteFile(fileId: string): void {
+    this.assertWritable("deleteFile");
     const existing = this.filesById.get(fileId);
 
     this.deleteFileDocuments(fileId);
@@ -314,7 +318,8 @@ export class ZvecWorkspaceIndexStorage implements WorkspaceIndexStorage {
     return docsToHits(docs, "vector", this);
   }
 
-  async optimize(): Promise<void> {
+  async finalizeWrites(): Promise<void> {
+    this.assertWritable("finalizeWrites");
     if (this.needsOptimize) {
       await this.collection.optimize();
       this.needsOptimize = false;
@@ -425,6 +430,15 @@ export class ZvecWorkspaceIndexStorage implements WorkspaceIndexStorage {
 
   private persistFile(file: FileRecord): void {
     this.files.upsertFile(file);
+  }
+
+  private assertWritable(operation: string): void {
+    if (this.readOnly) {
+      throw new EngineError("Cannot update read-only workspace index storage", {
+        code: "ZVEC_GREP.ENGINE.STORAGE.READ_ONLY",
+        context: `operation=${operation}`,
+      });
+    }
   }
 }
 
@@ -1248,22 +1262,6 @@ function readNullableNumberFieldFromFields(
   }
 
   return null;
-}
-
-function readVector(vector: ZVecVector | undefined): number[] | undefined {
-  if (!vector) {
-    return undefined;
-  }
-
-  if (Array.isArray(vector)) {
-    return vector;
-  }
-
-  if (ArrayBuffer.isView(vector)) {
-    return [...(vector as Float32Array | Int8Array)];
-  }
-
-  return undefined;
 }
 
 function parseStringArray(value: string): string[] {

--- a/test/e2e/cli.test.mjs
+++ b/test/e2e/cli.test.mjs
@@ -15,6 +15,7 @@ test("direct and server indexes report aggregate local model download progress",
   const temporaryDirectory = await createTemporaryDirectory(
     t,
     "zvec-grep-local-download-progress-",
+    { cleanup: false },
   );
   const root = join(temporaryDirectory, "repo");
   const home = join(temporaryDirectory, "home");
@@ -70,6 +71,7 @@ test("direct and server indexes report aggregate local model download progress",
       cwd: root,
       env: serverEnv,
     }).catch(() => undefined);
+    await removeTemporaryDirectory(temporaryDirectory);
   });
   await runCli(
     ["server", "on", "--listen", `127.0.0.1:${port}`, "--home", home],


### PR DESCRIPTION
## Summary

- expose a single `WorkspaceIndexStorage` contract and factory while keeping the ZVec implementation private
- centralize workspace index file layout, existence checks, and deletion in the storage module
- make read-only/write opening explicit and align whole-file replacement and write finalization APIs

## Impact

This is an Engine-internal boundary refactor. It does not change the workspace storage schema, file locations, query/index behavior, CLI/MCP surface, or require data migration.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm run test:all`
- `npm run test:package`
