### PR TITLE
feat(cli): add model and file type help

### DIFF
--- a/docs/02-cli.md
+++ b/docs/02-cli.md
@@ -12,6 +12,8 @@ installed CLI for version-specific help:
 ```bash
 zg help
 zg help query
+zg help models
+zg help file-types
 zg help environment
 zg <command> --help
 ```

--- a/src/cli/auth.ts
+++ b/src/cli/auth.ts
@@ -268,10 +268,7 @@ export function requireEmbeddingModelCatalogEntry(reference: string) {
   throw new Error(
     [
       `Unsupported embedding model: ${reference}`,
-      "Supported embedding models:",
-      ...[...listEmbeddingModels()]
-        .sort((left, right) => left.provider.localeCompare(right.provider))
-        .map((model) => `  ${model.reference}`),
+      "Run `zg help models` to list supported models.",
     ].join("\n"),
   );
 }

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -39,6 +39,7 @@ import {
   printIndexPathFilterTip,
   printIndexResult,
   printIndexScanDiagnostics,
+  printNoIndexableFilesTip,
   printServerIndexInfo,
 } from "./format/status.js";
 import {
@@ -220,12 +221,13 @@ async function runIndex(parsed: ParsedArgs): Promise<void> {
     mode,
     serverAvailable: () => daemonIsReady(parsed.options.home),
     server: async () => {
+      const client = daemonClient(parsed.options);
       const progress = createIndexProgressReporter({
         color: parsed.options.color,
       });
       let result: Record<string, unknown>;
       try {
-        result = await daemonClient(parsed.options).callTool(
+        result = await client.callTool(
           "zvec_grep_index",
           {
             root: rootPath.absolutePath,
@@ -272,6 +274,17 @@ async function runIndex(parsed: ParsedArgs): Promise<void> {
       }
       if (result.state === "failed") {
         throw new Error(serverIndexFailureMessage(result));
+      }
+      if (result.state === "succeeded") {
+        const status = (await client
+          .callTool("zvec_grep_index_status", {
+            root: rootPath.absolutePath,
+          })
+          .catch(() => undefined)) as
+          Parameters<typeof printServerIndexInfo>[0] | undefined;
+        if (status?.persistent.files?.scanned === 0) {
+          printNoIndexableFilesTip(parsed.options);
+        }
       }
     },
     direct: () => runDirectIndex(parsed, rootPath, explicitRoot),

--- a/src/cli/format/status.ts
+++ b/src/cli/format/status.ts
@@ -641,6 +641,9 @@ export function printIndexResult(
   if (options.debug) {
     printIndexScanDiagnostics(result.scanDiagnostics);
   }
+  if (result.filesScanned === 0) {
+    printNoIndexableFilesTip(options);
+  }
 }
 
 export function printIndexScanDiagnostics(
@@ -671,6 +674,17 @@ export function printIndexScanDiagnostics(
     ];
     console.error(`skipped_file ${details.join(" ")}`);
   }
+}
+
+export function printNoIndexableFilesTip(options: CliOptions): void {
+  const theme = createStatusTheme(options);
+  printField(
+    theme,
+    "tip",
+    theme.warning(
+      "No indexable files were found. Run `zg help file-types` to review supported file types and indexing rules.",
+    ),
+  );
 }
 
 export function printIndexPathFilterTip(options: CliOptions): void {

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -1,3 +1,17 @@
+import {
+  COMPONENT_CODE_FORMATS,
+  STRUCTURED_CODE_FORMATS,
+} from "../engine/code-formats.js";
+import {
+  listKnownBinaryExtensionGroups,
+  listRecognizedFileTypes,
+  type RecognizedFileType,
+} from "../engine/file-type.js";
+import { resolveMaxFileSizeBytes } from "../engine/file-size-policy.js";
+import { listEmbeddingModels } from "../engine/models/index.js";
+
+type EmbeddingCatalogEntry = ReturnType<typeof listEmbeddingModels>[number];
+
 export function printHelp(version: string, topic?: string): void {
   if (!topic) {
     console.log(mainHelp(version));
@@ -83,6 +97,7 @@ Examples:
 Environment:
 ${formatEnvironmentVariables(MAIN_ENVIRONMENT_VARIABLES)}
 
+Run zg help models or zg help file-types for supported indexing capabilities.
 Run zg help environment for all variables, scopes, aliases, and precedence.
 Run zg help <command> or zg <command> --help for command-specific help.
 Use zg -h/--help for this page and zg -v/--version for the version.`;
@@ -302,7 +317,13 @@ Removes zvec-grep-managed MCP configuration, trust, and guidance.`;
   zg --help
 
 Topics:
+  models                             Supported embedding models
+  file-types                         Supported file types and structural parsing
   environment, env                   Environment variables and precedence`;
+    case "models":
+      return modelsHelp();
+    case "file-types":
+      return fileTypesHelp();
     case "environment":
     case "env":
       return environmentHelp();
@@ -315,6 +336,160 @@ Topics:
     default:
       return undefined;
   }
+}
+
+function modelsHelp(): string {
+  const models = listEmbeddingModels().sort((left, right) => {
+    const leftRuntime = left.provider === "local" ? 0 : 1;
+    const rightRuntime = right.provider === "local" ? 0 : 1;
+    return (
+      leftRuntime - rightRuntime ||
+      left.reference.localeCompare(right.reference)
+    );
+  });
+
+  return `Usage:
+  zg help models
+
+Supported embedding models:
+${formatEmbeddingModels(models)}
+
+Local models are downloaded to the model cache on first use. Remote models
+require provider credentials plus --allow-remote or a Workspace authorization.
+Only qwen/qwen3-vl-embedding accepts image input.
+
+Existing indexes keep their stored model. See zg help environment for
+new-index model selection and runtime precedence.`;
+}
+
+function fileTypesHelp(): string {
+  const types = listRecognizedFileTypes();
+  const structuredFormats: ReadonlySet<string> = new Set(
+    STRUCTURED_CODE_FORMATS,
+  );
+  const componentFormats: ReadonlySet<string> = new Set(COMPONENT_CODE_FORMATS);
+  const codeTypes = types.filter((type) => type.kind === "code");
+  const structuredCode = codeTypes.filter((type) =>
+    structuredFormats.has(type.format),
+  );
+  const componentCode = codeTypes.filter((type) =>
+    componentFormats.has(type.format),
+  );
+  const plainCode = codeTypes.filter(
+    (type) =>
+      !structuredFormats.has(type.format) && !componentFormats.has(type.format),
+  );
+  const documentsAndData = types.filter(
+    (type) => type.kind === "text" || type.kind === "data",
+  );
+  const images = types.filter((type) => type.kind === "image");
+  const skipped = listKnownBinaryExtensionGroups().map((group) => [
+    group.label,
+    group.extensions.join(", "),
+  ]);
+  const sizeLimits = (
+    [
+      ["Code", "code"],
+      ["Text", "text"],
+      ["Data", "data"],
+      ["Image", "image"],
+    ] as const
+  ).map(([label, kind]) => [
+    label,
+    `${resolveMaxFileSizeBytes(kind) / (1024 * 1024)} MiB`,
+  ]);
+
+  return `Usage:
+  zg help file-types
+
+Structured code (symbols and scopes):
+${formatFileTypeTable(structuredCode)}
+
+Component code (JavaScript and TypeScript script blocks):
+${formatFileTypeTable(componentCode)}
+
+Other code (plain-text chunks):
+${formatFileTypeTable(plainCode)}
+
+Documents and data:
+${formatFileTypeTable(documentsAndData)}
+  Markdown preserves heading structure; other formats use text chunks.
+
+Images (multimodal embedding required):
+${formatFileTypeTable(images)}
+  Images are ignored by default and must be explicitly selected.
+
+Other text:
+  Unknown non-binary extensions and extensionless files use text chunks.
+
+Skipped binary types:
+${formatTable(["GROUP", "EXTENSIONS"], skipped)}
+  Files detected as binary by content are also skipped.
+
+Indexing rules:
+  Default size limits:
+${formatTable(["KIND", "MAX SIZE"], sizeLimits)}
+  Empty files are skipped. Use --max-filesize to override the size limit.
+  Common dependencies, build output, generated files, and lock files are
+  ignored by default. .git and .zvec-grep are always skipped.`;
+}
+
+function formatEmbeddingModels(
+  models: readonly EmbeddingCatalogEntry[],
+): string {
+  const rows = models.map((model) => {
+    const runtime = model.provider === "local" ? "local" : "remote";
+    const input =
+      "kind" in model && model.kind === "multimodal" ? "text,image" : "text";
+    const inputLimit =
+      "maxInputTokens" in model ? model.maxInputTokens : model.contextSize;
+    return [
+      model.reference,
+      runtime,
+      input,
+      String(model.dimension),
+      String(inputLimit),
+      model.backend,
+    ];
+  });
+  return formatTable(
+    ["MODEL", "RUNTIME", "INPUT", "DIMS", "TOKENS", "BACKEND"],
+    rows,
+    new Set([3, 4]),
+  );
+}
+
+function formatFileTypeTable(types: readonly RecognizedFileType[]): string {
+  const rows = [...types]
+    .sort((left, right) => left.format.localeCompare(right.format))
+    .map((type) => [type.format, type.patterns.join(", ")]);
+  return formatTable(["TYPE", "FILES"], rows);
+}
+
+function formatTable(
+  header: readonly string[],
+  rows: readonly (readonly string[])[],
+  rightAlignedColumns: ReadonlySet<number> = new Set(),
+): string {
+  const widths = header.map((label, index) =>
+    Math.max(label.length, ...rows.map((row) => row[index]!.length)),
+  );
+  const separator = widths.map((width) => "-".repeat(width));
+
+  return [header, separator, ...rows]
+    .map(
+      (row) =>
+        `  ${row
+          .map((value, index) =>
+            index === row.length - 1
+              ? value
+              : rightAlignedColumns.has(index)
+                ? value.padStart(widths[index]!)
+                : value.padEnd(widths[index]!),
+          )
+          .join("  ")}`,
+    )
+    .join("\n");
 }
 
 function environmentHelp(): string {

--- a/src/engine/code-formats.ts
+++ b/src/engine/code-formats.ts
@@ -1,0 +1,16 @@
+export const STRUCTURED_CODE_FORMATS = [
+  "c",
+  "cpp",
+  "go",
+  "java",
+  "javascript",
+  "jsx",
+  "python",
+  "rust",
+  "tsx",
+  "typescript",
+] as const;
+
+export type StructuredCodeFormat = (typeof STRUCTURED_CODE_FORMATS)[number];
+
+export const COMPONENT_CODE_FORMATS = ["vue", "svelte"] as const;

--- a/src/engine/extraction/code/adapter.ts
+++ b/src/engine/extraction/code/adapter.ts
@@ -1,4 +1,5 @@
 import type { CodeEntityModifier, CodeSymbolType } from "../../types.js";
+import type { StructuredCodeFormat } from "../../code-formats.js";
 import type { TSNode } from "./tree-sitter/nodes.js";
 import { C_ADAPTER } from "./languages/c.js";
 import { CPP_ADAPTER } from "./languages/cpp.js";
@@ -32,7 +33,7 @@ export type LanguageAdapter = {
   extractModifiers?(node: TSNode): readonly CodeEntityModifier[];
 };
 
-const ADAPTERS: Record<string, LanguageAdapter> = {
+const ADAPTERS = {
   c: C_ADAPTER,
   cpp: CPP_ADAPTER,
   go: GO_ADAPTER,
@@ -43,8 +44,8 @@ const ADAPTERS: Record<string, LanguageAdapter> = {
   rust: RUST_ADAPTER,
   tsx: TYPESCRIPT_ADAPTER,
   typescript: TYPESCRIPT_ADAPTER,
-};
+} satisfies Record<StructuredCodeFormat, LanguageAdapter>;
 
 export function resolveAdapter(format: string): LanguageAdapter | null {
-  return ADAPTERS[format] ?? null;
+  return format in ADAPTERS ? ADAPTERS[format as StructuredCodeFormat] : null;
 }

--- a/src/engine/extraction/code/extractor.ts
+++ b/src/engine/extraction/code/extractor.ts
@@ -1,4 +1,5 @@
 import { EngineError } from "../../errors.js";
+import { COMPONENT_CODE_FORMATS } from "../../code-formats.js";
 import type {
   CodeEntityMetadata,
   CodeEntityModifier,
@@ -18,6 +19,9 @@ import { hasJavascriptTypescriptFunctionValue } from "./families/js-ts.js";
 
 const DEFAULT_CODE_CHUNK_CHARS = 3600;
 const DEFAULT_CODE_CHUNK_OVERLAP_CHARS = 540;
+const COMPONENT_CODE_FORMAT_SET: ReadonlySet<string> = new Set(
+  COMPONENT_CODE_FORMATS,
+);
 
 export class CodeExtractor {
   async extract(
@@ -946,7 +950,7 @@ function truncateInline(value: string, maxChars: number): string {
 }
 
 function isScriptBlockFormat(format: string): boolean {
-  return format === "vue" || format === "svelte";
+  return COMPONENT_CODE_FORMAT_SET.has(format);
 }
 
 function findScriptBlocks(text: string): ScriptBlock[] {

--- a/src/engine/file-type.ts
+++ b/src/engine/file-type.ts
@@ -63,51 +63,109 @@ const IMAGE_FORMATS: Record<string, ImageFormat> = {
   ".webp": "webp",
 };
 
-const BINARY_EXTENSIONS = new Set([
-  ".zip",
-  ".tar",
-  ".gz",
-  ".bz2",
-  ".xz",
-  ".7z",
-  ".rar",
-  ".exe",
-  ".dll",
-  ".dylib",
-  ".so",
-  ".a",
-  ".o",
-  ".obj",
-  ".wasm",
-  ".class",
-  ".jar",
-  ".pdf",
-  ".doc",
-  ".docx",
-  ".ppt",
-  ".pptx",
-  ".xls",
-  ".xlsx",
-  ".mp3",
-  ".mp4",
-  ".mov",
-  ".avi",
-  ".mkv",
-  ".db",
-  ".sqlite",
-]);
+const NAMED_FILE_FORMATS: Record<
+  string,
+  { kind: FileKind; format: FileFormat }
+> = {
+  Dockerfile: { kind: "code", format: "dockerfile" },
+  Makefile: { kind: "code", format: "makefile" },
+};
+
+const FILE_FORMATS_BY_KIND = {
+  code: CODE_FORMATS,
+  data: DATA_FORMATS,
+  text: TEXT_FORMATS,
+  image: IMAGE_FORMATS,
+} satisfies Record<FileKind, Record<string, string>>;
+
+const BINARY_EXTENSION_GROUPS = [
+  {
+    label: "Archives",
+    extensions: [".zip", ".tar", ".gz", ".bz2", ".xz", ".7z", ".rar"],
+  },
+  {
+    label: "Compiled",
+    extensions: [
+      ".exe",
+      ".dll",
+      ".dylib",
+      ".so",
+      ".a",
+      ".o",
+      ".obj",
+      ".wasm",
+      ".class",
+      ".jar",
+    ],
+  },
+  {
+    label: "Documents",
+    extensions: [".pdf", ".doc", ".docx", ".ppt", ".pptx", ".xls", ".xlsx"],
+  },
+  {
+    label: "Media",
+    extensions: [".mp3", ".mp4", ".mov", ".avi", ".mkv"],
+  },
+  { label: "Databases", extensions: [".db", ".sqlite"] },
+] as const;
+
+const BINARY_EXTENSIONS = new Set<string>(
+  BINARY_EXTENSION_GROUPS.flatMap((group) => group.extensions),
+);
+
+export type RecognizedFileType = {
+  kind: FileKind;
+  format: FileFormat;
+  patterns: string[];
+};
+
+export function listRecognizedFileTypes(): RecognizedFileType[] {
+  const recognized = new Map<string, RecognizedFileType>();
+  const append = (
+    kind: FileKind,
+    format: FileFormat,
+    pattern: string,
+  ): void => {
+    const key = `${kind}:${format}`;
+    const existing = recognized.get(key);
+    if (existing) {
+      existing.patterns.push(pattern);
+      return;
+    }
+    recognized.set(key, { kind, format, patterns: [pattern] });
+  };
+
+  for (const kind of Object.keys(FILE_FORMATS_BY_KIND) as FileKind[]) {
+    for (const [extension, format] of Object.entries(
+      FILE_FORMATS_BY_KIND[kind],
+    )) {
+      append(kind, format, extension);
+    }
+  }
+  for (const [name, type] of Object.entries(NAMED_FILE_FORMATS)) {
+    append(type.kind, type.format, name);
+  }
+
+  return [...recognized.values()];
+}
+
+export function listKnownBinaryExtensionGroups(): {
+  label: string;
+  extensions: string[];
+}[] {
+  return BINARY_EXTENSION_GROUPS.map((group) => ({
+    label: group.label,
+    extensions: [...group.extensions],
+  }));
+}
 
 export function detectFileType(
   path: string,
 ): { kind: FileKind; format: FileFormat } | null {
   const name = basename(path);
-
-  if (name === "Dockerfile") {
-    return { kind: "code", format: "dockerfile" };
-  }
-
-  if (name === "Makefile") {
-    return { kind: "code", format: "makefile" };
+  const namedType = NAMED_FILE_FORMATS[name];
+  if (namedType) {
+    return { ...namedType };
   }
 
   const extension = extname(name).toLowerCase();

--- a/src/engine/models/resolution.ts
+++ b/src/engine/models/resolution.ts
@@ -23,7 +23,7 @@ export function resolveEmbeddingReference(
     !getEmbeddingModelCatalogEntry(environmentReference)
   ) {
     throw new EngineError(
-      `Invalid ZVEC_GREP_EMBEDDING: unsupported model ${environmentReference}`,
+      `Invalid ZVEC_GREP_EMBEDDING: unsupported model ${environmentReference}. Run \`zg help models\` to list supported models.`,
       {
         code: "ZVEC_GREP.ENGINE.CONFIG.EMBEDDING_ENVIRONMENT_INVALID",
         context: "source=ZVEC_GREP_EMBEDDING",

--- a/test/config-cli.test.mjs
+++ b/test/config-cli.test.mjs
@@ -172,8 +172,7 @@ test("config model set rejects missing and incompatible settings", async () => {
     ]),
     (error) => {
       assert.match(error.stderr, /Unsupported embedding model/);
-      assert.match(error.stderr, /local\/embeddinggemma-300m/);
-      assert.match(error.stderr, /qwen\/text-embedding-v4/);
+      assert.match(error.stderr, /zg help models/);
       return true;
     },
   );

--- a/test/config.test.mjs
+++ b/test/config.test.mjs
@@ -213,6 +213,13 @@ test("embedding reference resolver validates only a selected environment model",
       }),
     /Invalid ZVEC_GREP_EMBEDDING: unsupported model unknown\/model/,
   );
+  assert.throws(
+    () =>
+      resolveEmbeddingReference({
+        environment: { ZVEC_GREP_EMBEDDING: "unknown/model" },
+      }),
+    /zg help models/,
+  );
   assert.equal(
     resolveEmbeddingReference({
       existing: "local/embeddinggemma-300m",

--- a/test/e2e/cli.test.mjs
+++ b/test/e2e/cli.test.mjs
@@ -498,11 +498,59 @@ test("auth grant uses the environment model before the global default", async (t
   assert.doesNotMatch(granted.stdout, /qwen\/text-embedding-v4/);
 });
 
+test("direct index points an empty workspace to file type help", async (t) => {
+  const temporaryDirectory = await createTemporaryDirectory(
+    t,
+    "zvec-grep-empty-index-",
+  );
+  const root = join(temporaryDirectory, "repo");
+  const home = join(temporaryDirectory, "home");
+  await mkdir(root, { recursive: true });
+
+  const indexed = await runCli(
+    ["index", "--mode", "direct", "--embedding", "local/potion-base-8m", root],
+    {
+      cwd: root,
+      env: {
+        HOME: home,
+        USERPROFILE: home,
+        NO_COLOR: "1",
+        ZVEC_GREP_HOME: home,
+      },
+    },
+  );
+
+  assert.match(indexed.stdout, /0 scanned/);
+  assert.match(indexed.stdout, /zg help file-types/);
+});
+
 test("CLI exposes stable help, version, and failure behavior", async (t) => {
   const help = await runCli(["help"]);
   assert.match(help.stdout, /Usage:/);
+  assert.match(help.stdout, /zg help models or zg help file-types/);
   assert.match(help.stdout, /zg help environment/);
   assert.match(help.stdout, /ZVEC_GREP_MODE/);
+  const helpTopics = await runCli(["help", "help"]);
+  assert.match(helpTopics.stdout, /models\s+Supported embedding models/);
+  assert.match(helpTopics.stdout, /file-types\s+Supported file types/);
+  const modelsHelp = await runCli(["help", "models"]);
+  assert.match(modelsHelp.stdout, /local\/potion-code-16m-v2/);
+  assert.match(modelsHelp.stdout, /qwen\/qwen3-vl-embedding/);
+  assert.match(modelsHelp.stdout, /Local models are downloaded/);
+  assert.match(modelsHelp.stdout, /Workspace authorization/);
+  const fileTypesHelp = await runCli(["help", "file-types"]);
+  assert.match(fileTypesHelp.stdout, /Structured code \(symbols and scopes\)/);
+  assert.match(fileTypesHelp.stdout, /typescript\s+\.ts/);
+  assert.match(fileTypesHelp.stdout, /Other code \(plain-text chunks\)/);
+  assert.match(fileTypesHelp.stdout, /dockerfile\s+Dockerfile/);
+  assert.match(fileTypesHelp.stdout, /Documents and data/);
+  assert.match(
+    fileTypesHelp.stdout,
+    /Images \(multimodal embedding required\)/,
+  );
+  assert.match(fileTypesHelp.stdout, /\.pdf/);
+  assert.match(fileTypesHelp.stdout, /Code\s+1 MiB/);
+  assert.match(fileTypesHelp.stdout, /Text\s+256 MiB/);
   const indexHelp = await runCli(["index", "-h"]);
   assert.match(indexHelp.stdout, /qwen\/text-embedding-v4/);
   assert.doesNotMatch(indexHelp.stdout, /qwen3\.7-text-embedding/);
@@ -550,8 +598,7 @@ test("CLI exposes stable help, version, and failure behavior", async (t) => {
     (error) => {
       assert.equal(error.code, 1);
       assert.match(error.stderr, /Unsupported embedding model: unknown\/model/);
-      assert.match(error.stderr, /local\/embeddinggemma-300m/);
-      assert.match(error.stderr, /qwen\/text-embedding-v4/);
+      assert.match(error.stderr, /zg help models/);
       return true;
     },
   );
@@ -560,7 +607,7 @@ test("CLI exposes stable help, version, and failure behavior", async (t) => {
     "zvec-grep-invalid-embedding-environment-",
   );
   await assert.rejects(
-    runCli(["index", invalidEnvironmentRoot], {
+    runCli(["index", invalidEnvironmentRoot, "--mode", "direct"], {
       cwd: invalidEnvironmentRoot,
       env: { ZVEC_GREP_EMBEDDING: "unknown/model" },
     }),
@@ -569,6 +616,7 @@ test("CLI exposes stable help, version, and failure behavior", async (t) => {
         error.stderr,
         /Invalid ZVEC_GREP_EMBEDDING: unsupported model unknown\/model/,
       );
+      assert.match(error.stderr, /zg help models/);
       return true;
     },
   );

--- a/test/unit/cli-format.test.mjs
+++ b/test/unit/cli-format.test.mjs
@@ -822,6 +822,7 @@ test("status formatters cover workspace states, failures, filters, and color", a
   assert.match(output.logs.join("\n"), /1m 5s/);
   assert.match(output.logs.join("\n"), /ignore-file=\.rgignore/);
   assert.match(output.logs.join("\n"), /Default indexing skips/);
+  assert.match(output.logs.join("\n"), /zg help file-types/);
   assert.match(
     output.logs.join("\n"),
     new RegExp(

--- a/test/unit/scanner-utils.test.mjs
+++ b/test/unit/scanner-utils.test.mjs
@@ -10,7 +10,11 @@ import {
 import { hostname } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
-import { detectFileType } from "../../dist/engine/file-type.js";
+import {
+  detectFileType,
+  listKnownBinaryExtensionGroups,
+  listRecognizedFileTypes,
+} from "../../dist/engine/file-type.js";
 import { resolveMaxFileSizeBytes } from "../../dist/engine/file-size-policy.js";
 import {
   fileBelongsToRootPath,
@@ -67,6 +71,22 @@ test("file detection covers special, code, data, text, image, binary, and unknow
     kind: "text",
     format: "text",
   });
+  assert.deepEqual(
+    listRecognizedFileTypes().find(
+      (type) => type.kind === "code" && type.format === "typescript",
+    ),
+    { kind: "code", format: "typescript", patterns: [".ts"] },
+  );
+  assert.deepEqual(
+    listRecognizedFileTypes().find((type) => type.format === "dockerfile"),
+    { kind: "code", format: "dockerfile", patterns: ["Dockerfile"] },
+  );
+  assert.ok(
+    listKnownBinaryExtensionGroups().some(
+      (group) =>
+        group.label === "Documents" && group.extensions.includes(".pdf"),
+    ),
+  );
 });
 
 test("file-size policy uses type-aware defaults and honors explicit overrides", () => {


### PR DESCRIPTION
## What changed

- Add `zg help models` with aligned model capability output.
- Add `zg help file-types` with grouped supported formats, skipped binary types, and size limits.
- Guide invalid model and zero-file indexing results to the relevant help topic.
- Share file-format capability metadata with detection and extraction logic without expanding engine facade exports.

## Why

Users currently cannot discover supported embedding models or indexable file types directly from the CLI, and related failures do not provide an actionable next step.

## Impact

This improves CLI discoverability and diagnostics without changing existing indexing or search behavior.

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `node --test --test-concurrency=1 test/unit/scanner-utils.test.mjs`
- Targeted CLI help E2E test
- `git diff --check`