### PR TITLE
ci: add automatic SWE-QA benchmark gate

### DIFF
--- a/.github/workflows/swe-qa-bench.yml
+++ b/.github/workflows/swe-qa-bench.yml
@@ -1,16 +1,22 @@
-name: SWE-QA Bench (manual)
+name: SWE-QA Bench
 
 on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       scope:
-        description: Run the smoke pair or all twenty benchmark pairs
+        description: Run the smoke pair or the 20-task All-Full benchmark
         required: true
         default: smoke
         type: choice
         options:
           - smoke
-          - gate-20
+          - all-full
 
 permissions: {}
 
@@ -52,7 +58,7 @@ jobs:
       - name: Build this run's task matrix from the locked selection
         id: task-matrix
         env:
-          SCOPE: ${{ inputs.scope || 'smoke' }}
+          SCOPE: ${{ github.event_name == 'workflow_dispatch' && inputs.scope || 'auto' }}
         run: |
           python - <<'PY'
           import json
@@ -65,20 +71,28 @@ jobs:
               ).read_text(encoding="utf-8")
           )
           tasks = selection["tasks"]
+          tasks_by_id = {task["task_id"]: task for task in tasks}
           scope = os.environ["SCOPE"]
           if scope == "smoke":
-              smoke_task = selection["gate"]["smoke_task"]
-              selected = [
-                  task for task in tasks if task["task_id"] == smoke_task
-              ]
-          elif scope == "gate-20":
-              selected = tasks
+              task_ids = [selection["gate"]["smoke_task"]]
+          elif scope == "auto":
+              task_ids = selection["gate"]["auto_tasks"]
+          elif scope in {"all-full", "gate-20"}:
+              # gate-20 remains accepted for legacy API/CLI dispatches.
+              task_ids = [task["task_id"] for task in tasks]
           else:
               raise SystemExit(f"unsupported SWE-QA scope: {scope}")
-          if not selected:
+          if not task_ids:
               raise SystemExit(f"SWE-QA scope {scope} selected no tasks")
+          if len(task_ids) != len(set(task_ids)):
+              raise SystemExit(f"SWE-QA scope {scope} selected duplicate tasks")
+          missing = sorted(set(task_ids) - tasks_by_id.keys())
+          if missing:
+              raise SystemExit(
+                  f"SWE-QA scope {scope} selected unknown tasks: {missing}"
+              )
+          selected = [tasks_by_id[task_id] for task_id in task_ids]
           slugs = [task["task_slug"] for task in selected]
-          task_ids = [task["task_id"] for task in selected]
           with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as output:
               output.write(f"tasks={json.dumps(slugs, separators=(',', ':'))}\n")
               output.write(f"count={len(slugs)}\n")
@@ -108,6 +122,12 @@ jobs:
   run-pair:
     name: Pair + judge / ${{ matrix.task }}
     needs: validate
+    if: >-
+      github.event_name != 'pull_request' ||
+      (
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        github.actor != 'dependabot[bot]'
+      )
     runs-on: ubuntu-24.04
     timeout-minutes: 240
     permissions:

--- a/benchmarks/coding/SWE_QA_CI.md
+++ b/benchmarks/coding/SWE_QA_CI.md
@@ -1,6 +1,6 @@
-# SWE-QA-Bench 手工 CI 设计
+# SWE-QA-Bench CI 设计
 
-本流程接入的是 [`peng-weihan/SWE-QA-Bench`](https://github.com/peng-weihan/SWE-QA-Bench)，不是 SWE-QA-Pro。题目锁定在上游 commit `c13deac7a0d99b0ca2e593e004c4739475785b08`，只允许通过 GitHub `workflow_dispatch` 人工触发，不参与 PR 或分支保护。
+本流程接入的是 [`peng-weihan/SWE-QA-Bench`](https://github.com/peng-weihan/SWE-QA-Bench)，不是 SWE-QA-Pro。题目锁定在上游 commit `c13deac7a0d99b0ca2e593e004c4739475785b08`。20 题 **All-Full** 只允许通过 GitHub `workflow_dispatch` 人工触发；同仓 pull request 和合并完成后推送到 `main` 时自动运行 5 题精选集。fork/Dependabot PR 仍执行不需要凭证的 validation，但跳过需要 `GLM_API_KEY` 的 benchmark job，因此不会向不受信任代码暴露 Secret。
 
 ## 固定任务集
 
@@ -31,22 +31,32 @@
 
 `selection.json` 同时锁定完整 question、question SHA-256、目标仓库完整 commit SHA 和题型。`validate` 在任何模型调用前验证这些字段、Harbor instruction 与 reference 的一致性，并检查 reference answer 没有进入 Harbor dataset。workflow 的 matrix、Aggregate 期望报告数和精确 task ID 集合均从通过校验的 selection 动态生成，YAML 不再维护第二份任务列表。
 
+### 自动精选集
+
+`selection.json` 的 `gate.auto_tasks` 按顺序锁定 `reflex:6`（Smoke）、`pylint:9`（What）、`matplotlib:37`（Where）、`streamlink:14`（How）和 `xarray:32`（Why）。validation 要求它正好包含 1 个 smoke，以及依次覆盖 What、Where、How、Why 的 4 个 category task，防止自动矩阵与设计意外漂移。
+
+这 4 个分类代表题来自本轮 All-Full 结果中各题型在 profile-mean 口径下表现较好的样本，同时保留原 smoke 作为快速链路检查：`reflex:6` 的 Judge 为 `+0.33`，input/tool/time 分别改善约 `20.01% / 38.52% / 12.71%`；`pylint:9` 为 `+42.33` 和约 `40.24% / 34.28% / 40.46%`；`matplotlib:37` 为 `+3.33` 和约 `20.88% / 29.28% / 41.82%`；`streamlink:14` 为 `+11.33` 和约 `7.22% / 27.83% / 40.43%`；`xarray:32` 为 `+1.33`，tool/time 改善约 `6.81% / 6.33%`，但 input 约回退 `16.29%`，有意保留一个不完全偏向效率胜出的样本。精选依据用于控制自动 CI 成本并覆盖四种问题类型；workflow 始终采用 completion-only 门禁，不把这些数值设为合并阈值。
+
 ## 执行拓扑
 
 ```mermaid
 flowchart LR
-    D["workflow_dispatch<br/>smoke / gate-20"] --> V["无密钥预检<br/>selection + tests + dry-run"]
-    V --> P1["case 1 同一 runner<br/>baseline ×3 → zvec-grep ×3 → Judge ×6"]
-    V --> P2["其余 19 个 case 各运行 3 组 pair<br/>gate-20 时 max-parallel=5"]
+    D["workflow_dispatch<br/>smoke / all-full"] --> V["无密钥预检<br/>selection + tests + dry-run"]
+    E["同仓 PR / 合并后 push main<br/>auto 5题"] --> V
+    F["fork / Dependabot PR"] --> V
+    V --> C{"允许读取 GLM Secret?"}
+    C -->|"否"| S["validation-only"]
+    C -->|"是"| P1["case 1 同一 runner<br/>baseline ×3 → zvec-grep ×3 → Judge ×6"]
+    C -->|"是"| P2["其余 case 各运行 3 组 pair<br/>max-parallel=5"]
     P1 --> R1["case 1 独立报告<br/>Job Summary + artifact"]
     P2 --> RN["每个 case 独立报告<br/>Job Summary + artifact"]
     R1 --> A["无模型调用的 Aggregate"]
     RN --> A
 ```
 
-矩阵维度是 case，不是 profile。每个 case 的 baseline 和 zvec-grep 在同一台 GitHub-hosted Ubuntu runner 上各执行 3 个独立 Harbor trial（`--n-attempts 3`，`--n-concurrent 1`），随后对 6 个答案分别执行 Judge，并生成该 case 自己的 Job Summary 与报告 artifact。单任务表中的 baseline/zvec-grep 原始指标是各自 3 次 trial 的算术平均；两侧 trial 分别按实际启动时间恢复第 1/2/3 轮，第三个 delta/reduction 值是这 3 组同轮比较值的等权平均，不依赖 Harbor 的随机 trial 名。所有成功的单任务报告最后由一个不调用模型的 job 合并。这样既保留重复实验的波动证据，也不会把失败 trial 当成 0 分或静默剔除。
+矩阵维度是 case，不是 profile。每个 case 的 baseline 和 zvec-grep 在同一台 GitHub-hosted Ubuntu runner 上各执行 3 个独立 Harbor trial（`--n-attempts 3`，`--n-concurrent 1`），随后对 6 个答案分别执行 Judge，并生成该 case 自己的 Job Summary 与报告 artifact。单任务表中的 baseline/zvec-grep 原始指标是各自 3 次 trial 的算术平均，第三个 delta/reduction 直接由表中展示的这两个 profile mean 计算。两侧 trial 仍按实际启动时间恢复第 1/2/3 轮，同轮 comparison 仅作为诊断证据，不参与单任务或 Aggregate 主指标。所有成功的单任务报告最后由一个不调用模型的 job 合并。这样既保留重复实验的波动证据，也不会把失败 trial 当成 0 分或静默剔除。
 
-`gate-20` 的 20 个 case 以 `max-parallel: 5` 分批占用 runner。每个 matrix task 在 Harbor 启动前从 Actions cache 恢复自己的 zvec index seed 到 `$RUNNER_TEMP/swe-qa-index-seed`，并通过 `ZG_BENCH_INDEX_SEED_DIR` 交给 benchmark/Harbor。cache miss 时，第 1 个 zvec-grep trial 冷建 seed，后两个 trial 从 seed 独立初始化；cache hit 时直接使用此前成功 workflow 保存的同任务 seed。seed 只表示可复用的初始索引快照，不共享 Agent 会话或可写运行状态，因此 3 个 trial 仍分别拥有独立的模型调用、trajectory、指标和 Judge 结果。host seed 不会 bind mount 到受评容器；Harbor 的可信 setup 代码只在模型 Agent 启动前通过 `upload_dir`/`download_dir` 传输快照，所以 Agent 无法回写 seed 或污染后续 trial。
+All-Full 的 20 个 case 以 `max-parallel: 5` 分批占用 runner；自动精选的 5 个 case 可在一个 wave 内完成。每个 matrix task 在 Harbor 启动前从 Actions cache 恢复自己的 zvec index seed 到 `$RUNNER_TEMP/swe-qa-index-seed`，并通过 `ZG_BENCH_INDEX_SEED_DIR` 交给 benchmark/Harbor。cache miss 时，第 1 个 zvec-grep trial 冷建 seed，后两个 trial 从 seed 独立初始化；cache hit 时直接使用此前成功 workflow 保存的同任务 seed。seed 只表示可复用的初始索引快照，不共享 Agent 会话或可写运行状态，因此 3 个 trial 仍分别拥有独立的模型调用、trajectory、指标和 Judge 结果。host seed 不会 bind mount 到受评容器；Harbor 的可信 setup 代码只在模型 Agent 启动前通过 `upload_dir`/`download_dir` 传输快照，所以 Agent 无法回写 seed 或污染后续 trial。
 
 缓存严格按 runner OS/arch 和 task 隔离。key 还分别包含锁定的 `selection.json`、`references.json`、该 task 的 dataset Dockerfile、`package-lock.json`，以及 zvec-grep TypeScript 源码、构建配置、benchmark adapter/依赖锁和 skill 的哈希；不使用 fallback `restore-keys`，任一输入变化都会冷建新 seed。key 不包含 API key 等凭证，seed 目录也会和报告 artifact 一起接受精确 secret 扫描；只有 cache miss 且 matrix task 完整成功时才保存。
 
@@ -73,15 +83,16 @@ Job Summary 对每个 case 和 Aggregate 展示：
 3. `toolcall`：Agent trajectory 的工具调用数；
 4. `time`：Agent execution wall time，索引 setup 仍保留在原始证据中。
 
-input_token、toolcall 和 time 同时给出 baseline/zvec-grep 的 3-trial 均值及降低比例。单任务第三个值先对 3 组 trial 的 delta/reduction 取均值；跨任务 Aggregate 再对各 case 的 delta/reduction 等权平均，而不是由总量反推比例。Judge 原始结构化结果、pair JSON、Harbor result、日志与 ATIF trajectory 均作为 artifact 保存。
+input_token、toolcall 和 time 同时给出 baseline/zvec-grep 的 3-trial 均值及降低比例。单任务第三个值由展示的 baseline 与 zvec-grep profile means 直接计算；跨任务 Aggregate 再对各 case 的 comparison 等权平均，而不是先加总所有任务的数据再反推比例。逐 trial comparison 只用于诊断。Judge 原始结构化结果、pair JSON、Harbor result、日志与 ATIF trajectory 均作为 artifact 保存。
 
 ## 当前门禁语义
 
-当前是影子运行（report-only），没有数值质量或效率阈值，也不会成为代码审核卡点。唯一硬门禁是运行完整性：所选 scope 的每个 case 都必须生成有效的 baseline/zvec-grep pair、非空答案和可解析 Judge 结果。
+当前是影子运行（report-only），没有数值质量或效率阈值。自动 workflow 可以作为运行完整性检查，但分数本身不会阻止合并；唯一硬门禁是所选 scope 的每个 case 都必须生成有效的 baseline/zvec-grep pair、非空答案和可解析 Judge 结果。
 
 - `smoke`：只跑 `reflex-6`，即 3 次 baseline + 3 次 zvec-grep，共 6 次 Agent 执行和 6 次 Judge；
-- `gate-20`：每个 case 各跑 3 组 pair，共 120 次 Agent 执行和 120 次 Judge；
-- `gate-20` 的 20 个 case 允许 `max-parallel: 5` 分批运行，但每个 case 内仍以 `--n-concurrent 1` 顺序运行；
+- 自动精选：5 个 case 各跑 3 组 pair，共 30 次 Agent 执行和 30 次 Judge，相比 All-Full 减少 75%；
+- `all-full`：20 个 case 各跑 3 组 pair，共 120 次 Agent 执行和 120 次 Judge；历史 API 调用中的 `gate-20` 仍作为隐藏同义值兼容；
+- 所有 scope 都允许 `max-parallel: 5`，但每个 case 内仍以 `--n-concurrent 1` 顺序运行；
 - `fail-fast: false`，便于一次收集所有 case 的失败证据；
 - 每个 Agent trial 最多 30 分钟，包含 6 个 trial 与 Judge 的单任务 job 最多 240 分钟，纯聚合 job 最多 15 分钟；
 - 付费 workflow 不自动取消；原始证据保留 30 天，单任务和聚合报告保留 90 天。
@@ -92,7 +103,7 @@ input_token、toolcall 和 time 同时给出 baseline/zvec-grep 的 3-trial 均�
 
 ## 触发方式
 
-在 GitHub Actions 中选择 **SWE-QA Bench (manual)**，点击 **Run workflow**，选择 `smoke` 或 `gate-20`。CLI 等价命令为：
+同仓 pull request 或合并完成后的 push 到 `main` 会自动选择 `gate.auto_tasks` 的 5 题；fork/Dependabot PR 只运行 validation 并跳过 Secret-backed benchmark。merge queue 不在候选合并 ref 上运行需要 Secret 的 benchmark，避免不受信任候选代码接触 `GLM_API_KEY`。手工运行时，在 GitHub Actions 中选择 **SWE-QA Bench**，点击 **Run workflow**，选择 `smoke` 或 `all-full`。CLI 等价命令为：
 
 ```bash
 uv run --project benchmarks/coding zg-bench run \

--- a/benchmarks/coding/tests/test_swe_qa_reporting.py
+++ b/benchmarks/coding/tests/test_swe_qa_reporting.py
@@ -194,6 +194,64 @@ def _judged_task_report(task_id: str, index: int = 0) -> dict[str, Any]:
     }
 
 
+def _set_report_trial_metrics(
+    report: dict[str, Any],
+    *,
+    baseline: list[tuple[int, int, float, float | None]],
+    zvec: list[tuple[int, int, float, float | None]],
+) -> None:
+    case = report["cases"][0]
+    for profile_name, rows in (("baseline", baseline), ("zvec-grep", zvec)):
+        profile = case["profiles"][profile_name]
+        for trial, (input_tokens, tool_calls, wall_seconds, cost_usd) in zip(
+            profile["trials"], rows, strict=True
+        ):
+            trial["metrics"].update(
+                {
+                    "input_tokens": input_tokens,
+                    "tool_calls": tool_calls,
+                    "agent_wall_seconds": wall_seconds,
+                    "cost_usd": cost_usd,
+                }
+            )
+        profile["metrics"].update(
+            {
+                "input_tokens": sum(row[0] for row in rows) / len(rows),
+                "tool_calls": sum(row[1] for row in rows) / len(rows),
+                "agent_wall_seconds": sum(row[2] for row in rows) / len(rows),
+                "cost_usd": (
+                    None
+                    if any(row[3] is None for row in rows)
+                    else sum(float(row[3]) for row in rows if row[3] is not None)
+                    / len(rows)
+                ),
+            }
+        )
+
+    baseline_summary = case["profiles"]["baseline"]
+    zvec_summary = case["profiles"]["zvec-grep"]
+
+    def reduction(key: str) -> float | None:
+        baseline_value = baseline_summary["metrics"][key]
+        zvec_value = zvec_summary["metrics"][key]
+        if baseline_value is None or zvec_value is None or baseline_value == 0:
+            return None
+        return (baseline_value - zvec_value) / baseline_value * 100
+
+    # Keep the serialized task summary aligned with its displayed profile means.
+    # Individual tests may overwrite it to simulate a stale source artifact.
+    case["comparison"] = {
+        "judge_delta": (
+            zvec_summary["judge"]["total"]
+            - baseline_summary["judge"]["total"]
+        ),
+        "input_token_reduction_pct": reduction("input_tokens"),
+        "toolcall_reduction_pct": reduction("tool_calls"),
+        "time_reduction_pct": reduction("agent_wall_seconds"),
+        "cost_reduction_pct": reduction("cost_usd"),
+    }
+
+
 def _write_harbor_job(
     root: Path,
     *,
@@ -635,22 +693,28 @@ class JudgeTests(unittest.TestCase):
                 [trial["trial_index"] for trial in comparison["trials"]],
                 [1, 2, 3],
             )
-            self.assertAlmostEqual(
-                comparison["input_token_reduction_pct"], 140 / 3
-            )
-            self.assertAlmostEqual(
-                comparison["toolcall_reduction_pct"], 140 / 3
-            )
-            self.assertAlmostEqual(comparison["time_reduction_pct"], 140 / 3)
             profile_mean_ratio = (1100 / 3 - 320) / (1100 / 3) * 100
-            self.assertNotAlmostEqual(
+            self.assertAlmostEqual(
                 comparison["input_token_reduction_pct"], profile_mean_ratio
+            )
+            self.assertAlmostEqual(
+                comparison["toolcall_reduction_pct"], profile_mean_ratio
+            )
+            self.assertAlmostEqual(
+                comparison["time_reduction_pct"], (120 - 101) / 120 * 100
+            )
+            self.assertEqual(
+                [
+                    trial["input_token_reduction_pct"]
+                    for trial in comparison["trials"]
+                ],
+                [90.0, 0.0, 50.0],
             )
             markdown = (output_dir / "report.md").read_text()
             self.assertIn("Aggregate", markdown)
             self.assertIn("input_token", markdown)
             self.assertIn("60.00 / 80.00 / +20.00", markdown)
-            self.assertIn("366.67 / 320.00 / +46.67%", markdown)
+            self.assertIn("366.67 / 320.00 / +12.73%", markdown)
             self.assertIn("equal-weight arithmetic mean", markdown)
             self.assertIn("not a ratio of totals", markdown)
             self.assertNotIn("cost", markdown.lower())
@@ -816,7 +880,7 @@ class JudgeTests(unittest.TestCase):
                     )
             self.assertFalse((root / "report" / "report.json").exists())
 
-    def test_aggregate_averages_per_case_reductions_without_weighting(self) -> None:
+    def test_aggregate_averages_task_comparisons_without_total_weighting(self) -> None:
         def case(
             *,
             baseline: dict[str, int | float],
@@ -901,8 +965,18 @@ class JudgeTests(unittest.TestCase):
             aggregate["comparison"]["input_token_reduction_pct"], totals_ratio
         )
 
-        cases[1]["comparison"]["cost_reduction_pct"] = None
-        self.assertIsNone(_aggregate(cases)["comparison"]["cost_reduction_pct"])
+        cases[1]["profiles"]["baseline"]["metrics"]["cost_usd"] = None
+        aggregate = _aggregate(cases)
+        self.assertEqual(aggregate["comparison"]["cost_reduction_pct"], 90.0)
+        self.assertEqual(
+            aggregate["comparison_samples"]["cost_reduction_pct"], 1
+        )
+        cases[0]["profiles"]["baseline"]["metrics"]["cost_usd"] = None
+        aggregate = _aggregate(cases)
+        self.assertIsNone(aggregate["comparison"]["cost_reduction_pct"])
+        self.assertEqual(
+            aggregate["comparison_samples"]["cost_reduction_pct"], 0
+        )
 
     def test_missing_expected_pair_fails_before_model_call(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -1005,6 +1079,163 @@ class AggregateReportTests(unittest.TestCase):
                     output_dir=output_dir,
                 )
             self.assertEqual(len(retried["cases"]), 1)
+
+    def test_offline_aggregate_uses_task_means_then_equal_weights_tasks(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            reports_root = root / "reports"
+            first = _judged_task_report("reflex:6")
+            _set_report_trial_metrics(
+                first,
+                baseline=[
+                    (100, 10, 10.0, 1.0),
+                    (900, 90, 90.0, 9.0),
+                    (100, 10, 20.0, 2.0),
+                ],
+                zvec=[
+                    (10, 1, 1.0, 0.1),
+                    (900, 90, 90.0, 9.0),
+                    (50, 5, 10.0, 1.0),
+                ],
+            )
+            first["cases"][0]["comparison"][
+                "input_token_reduction_pct"
+            ] = 140 / 3
+            # Pair by trial_index, not incidental array order in the artifact.
+            first["cases"][0]["profiles"]["zvec-grep"]["trials"].reverse()
+
+            second = _judged_task_report("sqlfluff:2", 1)
+            _set_report_trial_metrics(
+                second,
+                baseline=[
+                    (1000, 100, 100.0, 10.0),
+                    (1000, 100, 100.0, 10.0),
+                    (1000, 100, 100.0, 10.0),
+                ],
+                zvec=[
+                    (500, 50, 50.0, 5.0),
+                    (500, 50, 50.0, 5.0),
+                    (500, 50, 50.0, 5.0),
+                ],
+            )
+            _write_json(reports_root / "first" / "report.json", first)
+            _write_json(reports_root / "second" / "report.json", second)
+
+            report = aggregate_reports(
+                reports_root=reports_root,
+                output_dir=root / "combined",
+                expected=["reflex:6", "sqlfluff:2"],
+            )
+
+            first_comparison = report["cases"][0]["comparison"]
+            self.assertAlmostEqual(
+                first_comparison["input_token_reduction_pct"],
+                (1100 - 960) / 1100 * 100,
+            )
+            self.assertEqual(
+                [row["trial_index"] for row in first_comparison["trials"]],
+                [1, 2, 3],
+            )
+            self.assertEqual(
+                [
+                    row["input_token_reduction_pct"]
+                    for row in first_comparison["trials"]
+                ],
+                [90.0, 0.0, 50.0],
+            )
+
+            aggregate = report["aggregate"]
+            self.assertAlmostEqual(
+                aggregate["comparison"]["input_token_reduction_pct"],
+                ((1100 - 960) / 1100 * 100 + 50) / 2,
+            )
+            self.assertEqual(
+                aggregate["comparison_samples"][
+                    "input_token_reduction_pct"
+                ],
+                2,
+            )
+            self.assertAlmostEqual(
+                aggregate["profiles"]["baseline"]["input_tokens"],
+                1100 / 3 + 1000,
+            )
+            self.assertEqual(
+                aggregate["profiles"]["zvec-grep"]["input_tokens"], 820.0
+            )
+            grand_totals_ratio = (
+                aggregate["profiles"]["baseline"]["input_tokens"]
+                - aggregate["profiles"]["zvec-grep"]["input_tokens"]
+            ) / aggregate["profiles"]["baseline"]["input_tokens"] * 100
+            self.assertAlmostEqual(grand_totals_ratio, 40.0)
+            self.assertNotAlmostEqual(
+                aggregate["comparison"]["input_token_reduction_pct"],
+                grand_totals_ratio,
+            )
+            markdown = (root / "combined" / "report.md").read_text()
+            self.assertIn("1,366.67 / 820.00 / +31.36%", markdown)
+
+    def test_na_task_is_excluded_from_only_that_aggregate_metric(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            source = _judged_task_report("reflex:6")
+            _set_report_trial_metrics(
+                source,
+                baseline=[
+                    (100, 0, 10.0, 0.0),
+                    (100, 0, 10.0, 1.0),
+                    (100, 0, 10.0, None),
+                ],
+                zvec=[
+                    (50, 1, 5.0, 0.1),
+                    (50, 1, 5.0, 0.5),
+                    (50, 1, 5.0, None),
+                ],
+            )
+            _write_json(root / "reports" / "source" / "report.json", source)
+            _write_json(
+                root / "reports" / "valid" / "report.json",
+                _judged_task_report("sqlfluff:2", 1),
+            )
+
+            report = aggregate_reports(
+                reports_root=root / "reports",
+                output_dir=root / "combined",
+                expected=["reflex:6", "sqlfluff:2"],
+            )
+
+            comparison = report["cases"][0]["comparison"]
+            self.assertIsNone(
+                comparison["trials"][0]["toolcall_reduction_pct"]
+            )
+            self.assertIsNone(comparison["toolcall_reduction_pct"])
+            self.assertIsNone(comparison["cost_reduction_pct"])
+            self.assertEqual(
+                report["aggregate"]["comparison"]["toolcall_reduction_pct"],
+                60.0,
+            )
+            self.assertEqual(
+                report["aggregate"]["comparison"]["cost_reduction_pct"],
+                50.0,
+            )
+            self.assertEqual(
+                report["aggregate"]["profiles"]["baseline"]["tool_calls"],
+                20.0,
+            )
+            self.assertEqual(
+                report["aggregate"]["comparison_samples"][
+                    "toolcall_reduction_pct"
+                ],
+                1,
+            )
+            self.assertEqual(
+                report["aggregate"]["comparison_samples"][
+                    "cost_reduction_pct"
+                ],
+                1,
+            )
+            markdown = (root / "combined" / "report.md").read_text()
+            self.assertIn("0.00 / 1.00 / N/A", markdown)
+            self.assertIn("toolcall n=1/2", markdown)
 
     def test_aggregates_twenty_present_reports(self) -> None:
         tasks = list(EXPECTED_TASK_IDS)

--- a/benchmarks/coding/tests/test_swe_qa_validation.py
+++ b/benchmarks/coding/tests/test_swe_qa_validation.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any
+
+from zg_bench.swe_qa import SweQaError
+from zg_bench.swe_qa.validation import validate_assets
+
+CODING_DIR = Path(__file__).resolve().parents[1]
+SELECTION_PATH = CODING_DIR / "zg_bench" / "swe_qa" / "data" / "selection.json"
+REFERENCES_PATH = CODING_DIR / "zg_bench" / "swe_qa" / "data" / "references.json"
+DATASET_PATH = CODING_DIR / "datasets" / "swe-qa-bench-manual"
+EXPECTED_AUTO_TASK_IDS = (
+    "reflex:6",
+    "pylint:9",
+    "matplotlib:37",
+    "streamlink:14",
+    "xarray:32",
+)
+
+
+class AutoSelectionValidationTests(unittest.TestCase):
+    def _validate_selection(self, selection: dict[str, Any]) -> dict[str, Any]:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            selection_path = Path(temp_dir) / "selection.json"
+            selection_path.write_text(json.dumps(selection), encoding="utf-8")
+            return validate_assets(
+                selection_path=selection_path,
+                references_path=REFERENCES_PATH,
+                dataset_path=DATASET_PATH,
+            )
+
+    def test_checked_in_auto_selection_is_exact_and_valid(self) -> None:
+        result = validate_assets(
+            selection_path=SELECTION_PATH,
+            references_path=REFERENCES_PATH,
+            dataset_path=DATASET_PATH,
+        )
+
+        self.assertEqual(result["auto_task_count"], 5)
+        self.assertEqual(tuple(result["auto_task_ids"]), EXPECTED_AUTO_TASK_IDS)
+
+    def test_auto_selection_requires_exact_task_count(self) -> None:
+        selection = json.loads(SELECTION_PATH.read_text(encoding="utf-8"))
+        selection["gate"]["auto_tasks"].pop()
+
+        with self.assertRaisesRegex(SweQaError, "exactly 5 tasks"):
+            self._validate_selection(selection)
+
+    def test_auto_selection_must_start_with_smoke(self) -> None:
+        selection = json.loads(SELECTION_PATH.read_text(encoding="utf-8"))
+        auto_tasks = selection["gate"]["auto_tasks"]
+        auto_tasks[0], auto_tasks[1] = auto_tasks[1], auto_tasks[0]
+
+        with self.assertRaisesRegex(SweQaError, "start with the configured smoke"):
+            self._validate_selection(selection)
+
+    def test_auto_selection_requires_all_four_categories_in_order(self) -> None:
+        selection = json.loads(SELECTION_PATH.read_text(encoding="utf-8"))
+        selection["gate"]["auto_tasks"][-1] = "sqlfluff:2"
+
+        with self.assertRaisesRegex(SweQaError, "what/where/how/why order"):
+            self._validate_selection(selection)
+
+    def test_auto_selection_rejects_unknown_task(self) -> None:
+        selection = json.loads(SELECTION_PATH.read_text(encoding="utf-8"))
+        selection["gate"]["auto_tasks"][-1] = "unknown:0"
+
+        with self.assertRaisesRegex(SweQaError, "unknown task IDs"):
+            self._validate_selection(selection)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/benchmarks/coding/zg_bench/swe_qa/data/selection.json
+++ b/benchmarks/coding/zg_bench/swe_qa/data/selection.json
@@ -7,6 +7,13 @@
   "gate": {
     "required_tasks": 20,
     "smoke_task": "reflex:6",
+    "auto_tasks": [
+      "reflex:6",
+      "pylint:9",
+      "matplotlib:37",
+      "streamlink:14",
+      "xarray:32"
+    ],
     "category_tasks": [
       "sqlfluff:2",
       "conan:1",

--- a/benchmarks/coding/zg_bench/swe_qa/judge.py
+++ b/benchmarks/coding/zg_bench/swe_qa/judge.py
@@ -16,6 +16,13 @@ from . import SELF_JUDGE_LABEL, SweQaError
 SCORE_KEYS = ("correctness", "completeness", "relevance", "clarity", "coherence")
 JUDGE_MODEL = "openai/glm-5.2"
 PROFILE_NAMES = ("baseline", "zvec-grep")
+COMPARISON_KEYS = (
+    "judge_delta",
+    "input_token_reduction_pct",
+    "toolcall_reduction_pct",
+    "time_reduction_pct",
+    "cost_reduction_pct",
+)
 DEFAULT_JUDGE_CONCURRENCY = 3
 MAX_JUDGE_CONCURRENCY = 8
 JUDGE_CONCURRENCY_ENV = "SWE_QA_JUDGE_CONCURRENCY"
@@ -472,6 +479,15 @@ def _mean_or_none(values: Sequence[int | float | None]) -> float | None:
     return sum(float(value) for value in values if value is not None) / len(values)
 
 
+def _mean_available(
+    values: Sequence[int | float | None],
+) -> tuple[float | None, int]:
+    available = [float(value) for value in values if value is not None]
+    if not available:
+        return None, 0
+    return sum(available) / len(available), len(available)
+
+
 def _summarize_profile(trials: Sequence[dict[str, Any]]) -> dict[str, Any]:
     count = len(trials)
     scores = {
@@ -524,15 +540,22 @@ def _paired_comparison(
 ) -> dict[str, Any]:
     if len(baseline_trials) != len(zvec_trials):
         raise SweQaError("profile trial counts do not match")
+    baseline_by_index = {trial["trial_index"]: trial for trial in baseline_trials}
+    zvec_by_index = {trial["trial_index"]: trial for trial in zvec_trials}
+    if (
+        len(baseline_by_index) != len(baseline_trials)
+        or len(zvec_by_index) != len(zvec_trials)
+        or set(baseline_by_index) != set(zvec_by_index)
+    ):
+        raise SweQaError("profile trial_index values do not match")
+
     trial_rows: list[dict[str, Any]] = []
-    for baseline, zvec in zip(baseline_trials, zvec_trials, strict=True):
-        baseline_index = baseline["trial_index"]
-        zvec_index = zvec["trial_index"]
-        if baseline_index != zvec_index:
-            raise SweQaError("profile trial_index values do not match")
+    for trial_index in sorted(baseline_by_index):
+        baseline = baseline_by_index[trial_index]
+        zvec = zvec_by_index[trial_index]
         trial_rows.append(
             {
-                "trial_index": baseline_index,
+                "trial_index": trial_index,
                 **_comparison(
                     baseline["metrics"],
                     zvec["metrics"],
@@ -541,20 +564,39 @@ def _paired_comparison(
                 ),
             }
         )
-    comparison_keys = (
-        "judge_delta",
-        "input_token_reduction_pct",
-        "toolcall_reduction_pct",
-        "time_reduction_pct",
-        "cost_reduction_pct",
-    )
     return {
         **{
             key: _mean_or_none([row[key] for row in trial_rows])
-            for key in comparison_keys
+            for key in COMPARISON_KEYS
         },
         "trials": trial_rows,
     }
+
+
+def _case_comparison(case: dict[str, Any]) -> dict[str, Any]:
+    """Compare the baseline/zvec profile means displayed for one task."""
+    profiles = case["profiles"]
+    baseline = profiles["baseline"]
+    zvec = profiles["zvec-grep"]
+    comparison = _comparison(
+        baseline["metrics"],
+        zvec["metrics"],
+        baseline["judge"]["total"],
+        zvec["judge"]["total"],
+    )
+
+    baseline_trials = profiles["baseline"].get("trials")
+    zvec_trials = profiles["zvec-grep"].get("trials")
+    if baseline_trials is None and zvec_trials is None:
+        return comparison
+    if not isinstance(baseline_trials, list) or not isinstance(zvec_trials, list):
+        raise SweQaError("profile trial evidence does not match")
+    # Keep paired trial comparisons as diagnostic evidence only. The task-level
+    # values above are calculated from the displayed profile means.
+    comparison["trials"] = _paired_comparison(
+        baseline_trials, zvec_trials
+    )["trials"]
+    return comparison
 
 
 def _aggregate(cases: Sequence[dict[str, Any]]) -> dict[str, Any]:
@@ -573,18 +615,20 @@ def _aggregate(cases: Sequence[dict[str, Any]]) -> dict[str, Any]:
                 [row["metrics"]["cost_usd"] for row in profile_rows]
             ),
         }
-    comparison_keys = (
-        "judge_delta",
-        "input_token_reduction_pct",
-        "toolcall_reduction_pct",
-        "time_reduction_pct",
-        "cost_reduction_pct",
-    )
-    comparison = {
-        key: _mean_or_none([case["comparison"][key] for case in cases])
-        for key in comparison_keys
+    task_comparisons = [_case_comparison(case) for case in cases]
+    comparison: dict[str, float | None] = {}
+    comparison_samples: dict[str, int] = {}
+    for key in COMPARISON_KEYS:
+        value, sample_count = _mean_available(
+            [task_comparison[key] for task_comparison in task_comparisons]
+        )
+        comparison[key] = value
+        comparison_samples[key] = sample_count
+    return {
+        "profiles": profiles,
+        "comparison": comparison,
+        "comparison_samples": comparison_samples,
     }
-    return {"profiles": profiles, "comparison": comparison}
 
 
 def _fmt_number(value: int | float, *, decimals: int = 2) -> str:
@@ -613,7 +657,7 @@ def _metric_cell(
 
 def _render_report(report: dict[str, Any]) -> str:
     lines = [
-        "# SWE-QA-Bench manual CI report",
+        "# SWE-QA-Bench CI report",
         "",
         f"Judge: **{SELF_JUDGE_LABEL}** (GLM-5.2 self-judge).",
         "",
@@ -621,9 +665,9 @@ def _render_report(report: dict[str, Any]) -> str:
         "",
         "All cells use `baseline / zvec-grep / delta-or-reduction`. Positive reduction means zvec-grep used less.",
         "",
-        "Each case's baseline and zvec-grep values are arithmetic means across that profile's trials. Its third value is the equal-weight arithmetic mean of deltas or reductions after pairing sorted `trial_index` values; it is not a ratio of profile means.",
+        "Each task's baseline and zvec-grep values are arithmetic means across that profile's trials. Its third value is calculated directly from those two displayed profile means.",
         "",
-        "In the Aggregate row, baseline and zvec-grep efficiency values are sums of the per-case trial means (Judge is the equal-weight per-case mean), while the third value is the equal-weight arithmetic mean of the per-case deltas or reductions, not a ratio of totals.",
+        "In the Aggregate row, baseline and zvec-grep efficiency values are sums of the per-task profile means (Judge is the equal-weight task mean), while the third value is the equal-weight arithmetic mean of task comparisons, not a ratio of totals. A task whose baseline denominator is zero has an N/A reduction and is excluded only from that Aggregate metric.",
         "",
         "| Case | Judge self-judge | input_token | toolcall | time (s) |",
         "|---|---:|---:|---:|---:|",
@@ -702,6 +746,19 @@ def _render_report(report: dict[str, Any]) -> str:
         + " |"
     )
     lines.append("")
+    samples = aggregate.get("comparison_samples")
+    if isinstance(samples, dict):
+        task_count = len(report["cases"])
+        lines.extend(
+            (
+                "Aggregate comparison sample counts: "
+                f"Judge n={samples.get('judge_delta', 0)}/{task_count}, "
+                f"input_token n={samples.get('input_token_reduction_pct', 0)}/{task_count}, "
+                f"toolcall n={samples.get('toolcall_reduction_pct', 0)}/{task_count}, "
+                f"time n={samples.get('time_reduction_pct', 0)}/{task_count}.",
+                "",
+            )
+        )
     return "\n".join(lines)
 
 
@@ -907,18 +964,14 @@ def _validate_task_report(report: dict[str, Any], path: Path) -> dict[str, Any]:
         raise SweQaError(f"{prefix}: gate count does not match trial evidence")
 
     comparison = case.get("comparison")
-    comparison_keys = (
-        "judge_delta",
-        "input_token_reduction_pct",
-        "toolcall_reduction_pct",
-        "time_reduction_pct",
-        "cost_reduction_pct",
-    )
     if not isinstance(comparison, dict) or any(
         not _valid_number(comparison.get(key), allow_none=key != "judge_delta")
-        for key in comparison_keys
+        for key in COMPARISON_KEYS
     ):
         raise SweQaError(f"{prefix}: invalid case comparison")
+    # Recompute instead of trusting a potentially stale task summary produced
+    # with a different trial-to-task comparison rule.
+    case["comparison"] = _case_comparison(case)
     return case
 
 
@@ -1085,21 +1138,15 @@ def judge_pairs(
                 else:
                     judge_usage["cost_usd"] += usage["cost_usd"]
             profile_results[profile_name] = _summarize_profile(trial_results)
-        baseline_trials = profile_results["baseline"]["trials"]
-        zvec_trials = profile_results["zvec-grep"]["trials"]
-        cases.append(
-            {
-                "task_id": str(reference["task_id"]),
-                "role": reference.get("role"),
-                "category": reference.get("category"),
-                "trial_count": pair["actual_trials"],
-                "profiles": profile_results,
-                "comparison": _paired_comparison(
-                    baseline_trials,
-                    zvec_trials,
-                ),
-            }
-        )
+        case = {
+            "task_id": str(reference["task_id"]),
+            "role": reference.get("role"),
+            "category": reference.get("category"),
+            "trial_count": pair["actual_trials"],
+            "profiles": profile_results,
+        }
+        case["comparison"] = _case_comparison(case)
+        cases.append(case)
 
     if not judge_usage.pop("cost_complete"):
         judge_usage["cost_usd"] = None

--- a/benchmarks/coding/zg_bench/swe_qa/validation.py
+++ b/benchmarks/coding/zg_bench/swe_qa/validation.py
@@ -16,6 +16,7 @@ FULL_COMMIT_RE = re.compile(r"^[0-9a-fA-F]{40}$")
 EXPECTED_TASK_COUNT = 20
 EXPECTED_CATEGORIES = ("what", "where", "how", "why")
 EXPECTED_TASKS_PER_CATEGORY = 5
+EXPECTED_AUTO_TASK_COUNT = 1 + len(EXPECTED_CATEGORIES)
 
 
 def _object(path: Path, *, label: str) -> dict[str, Any]:
@@ -123,16 +124,6 @@ def validate_assets(
     categories = [task for task in tasks if task.get("role") == "category"]
     if len(smoke) != 1 or len(categories) != EXPECTED_TASK_COUNT - 1:
         raise SweQaError("selection must contain 1 smoke and 19 category tasks")
-    smoke_task_id = str(smoke[0]["task_id"])
-    if gate.get("smoke_task") != smoke_task_id:
-        raise SweQaError("selection gate.smoke_task does not match the smoke task")
-    expected_category_tasks = [
-        str(task["task_id"]) for task in tasks if task.get("role") == "category"
-    ]
-    if gate.get("category_tasks") != expected_category_tasks:
-        raise SweQaError(
-            "selection gate.category_tasks must list all non-smoke tasks in order"
-        )
 
     category_counts: Counter[str] = Counter()
     for task in tasks:
@@ -149,6 +140,50 @@ def validate_assets(
     }
     if dict(category_counts) != expected_counts:
         raise SweQaError("selection must contain 5 tasks in each question category")
+
+    smoke_task_id = str(smoke[0]["task_id"])
+    if gate.get("smoke_task") != smoke_task_id:
+        raise SweQaError("selection gate.smoke_task does not match the smoke task")
+    auto_tasks = gate.get("auto_tasks")
+    if not isinstance(auto_tasks, list) or any(
+        not isinstance(task_id, str) or not task_id for task_id in auto_tasks
+    ):
+        raise SweQaError("selection gate.auto_tasks must be an array of task IDs")
+    if len(auto_tasks) != EXPECTED_AUTO_TASK_COUNT:
+        raise SweQaError(
+            "selection gate.auto_tasks must contain exactly "
+            f"{EXPECTED_AUTO_TASK_COUNT} tasks"
+        )
+    if len(set(auto_tasks)) != len(auto_tasks):
+        raise SweQaError("selection gate.auto_tasks must not contain duplicates")
+    unknown_auto_tasks = sorted(set(auto_tasks) - ids)
+    if unknown_auto_tasks:
+        raise SweQaError(
+            "selection gate.auto_tasks contains unknown task IDs: "
+            f"{unknown_auto_tasks}"
+        )
+    if auto_tasks[0] != smoke_task_id:
+        raise SweQaError(
+            "selection gate.auto_tasks must start with the configured smoke task"
+        )
+    auto_category_tasks = [selected[task_id] for task_id in auto_tasks[1:]]
+    if any(task.get("role") != "category" for task in auto_category_tasks):
+        raise SweQaError(
+            "selection gate.auto_tasks entries after smoke must be category tasks"
+        )
+    auto_categories = [str(task.get("category")) for task in auto_category_tasks]
+    if tuple(auto_categories) != EXPECTED_CATEGORIES:
+        raise SweQaError(
+            "selection gate.auto_tasks must contain smoke followed by one category "
+            "task in what/where/how/why order"
+        )
+    expected_category_tasks = [
+        str(task["task_id"]) for task in tasks if task.get("role") == "category"
+    ]
+    if gate.get("category_tasks") != expected_category_tasks:
+        raise SweQaError(
+            "selection gate.category_tasks must list all non-smoke tasks in order"
+        )
 
     if not dataset_path.is_dir():
         raise SweQaError(f"Harbor dataset does not exist: {dataset_path}")
@@ -247,6 +282,8 @@ def validate_assets(
         "valid": True,
         "task_count": len(tasks),
         "task_ids": [str(task["task_id"]) for task in tasks],
+        "auto_task_count": len(auto_tasks),
+        "auto_task_ids": auto_tasks,
         "dataset_files_scanned": len(dataset_files),
         "references_are_judge_only": True,
     }


### PR DESCRIPTION
## Summary

- keep the 20-case All-Full benchmark manual-only
- run a five-case SWE-QA subset on trusted same-repository PRs and post-merge pushes to main
- keep fork and Dependabot PRs validation-only so GLM credentials are not exposed
- calculate each task reduction from its displayed baseline/zvec profile means, then aggregate tasks with equal weight

## Automatic set

- reflex:6 (smoke)
- pylint:9 (What)
- matplotlib:37 (Where)
- streamlink:14 (How)
- xarray:32 (Why)

Each profile runs three trials. The workflow remains completion/report-only and does not impose a numeric quality threshold.

## Validation

- 81 benchmark coding tests pass
- actionlint passes
- git diff --check passes