### PR TITLE
test(ci): add real local model smoke coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,32 @@ jobs:
       - run: npm ci
       - run: npm run test:coverage
 
+  package-candidate:
+    name: package candidate
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      - name: Build the candidate tarball
+        run: |
+          mkdir -p "$RUNNER_TEMP/package"
+          npm pack --json --pack-destination "$RUNNER_TEMP/package"
+      - uses: actions/upload-artifact@v7
+        with:
+          name: package-candidate
+          path: ${{ runner.temp }}/package/
+          if-no-files-found: error
+          retention-days: 1
+
   unit:
     name: unit (${{ matrix.os }}, Node ${{ matrix.node }})
     runs-on: ${{ matrix.os }}
@@ -153,6 +179,42 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run test:package
+
+  local-model-smoke:
+    name: local model smoke (${{ matrix.os }})
+    needs: package-candidate
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 35
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+      - uses: actions/download-artifact@v8
+        with:
+          name: package-candidate
+          path: ${{ runner.temp }}/package
+      - name: Restore the real model cache
+        uses: actions/cache@v5
+        with:
+          path: ${{ runner.temp }}/zvec-grep-model-cache
+          key: >-
+            local-model-v1-${{ runner.os }}-${{ runner.arch }}-potion-code-16m-v2-${{ hashFiles('src/engine/models/catalog.ts', 'package-lock.json') }}
+      - name: Run the packed package with real Potion embeddings
+        env:
+          ZVEC_GREP_PACKAGE_TARBALL: ${{ runner.temp }}/package
+          ZVEC_GREP_MODEL_CACHE: ${{ runner.temp }}/zvec-grep-model-cache
+          ZVEC_GREP_SMOKE_MODEL: local/potion-code-16m-v2
+        run: npm run test:smoke:local-model
 
   isolated-install:
     name: isolated-install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,16 +181,20 @@ jobs:
       - run: npm run test:package
 
   local-model-smoke:
-    name: local model smoke (${{ matrix.os }})
+    name: local model smoke (${{ matrix.model }}, ${{ matrix.os }})
     needs: package-candidate
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 35
+    timeout-minutes: 60
     permissions:
       contents: read
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        model:
+          - local/potion-code-16m-v2
+          - local/all-minilm-l6-v2
+          - local/embeddinggemma-300m
     steps:
       - uses: actions/checkout@v6
         with:
@@ -208,12 +212,12 @@ jobs:
         with:
           path: ${{ runner.temp }}/zvec-grep-model-cache
           key: >-
-            local-model-v1-${{ runner.os }}-${{ runner.arch }}-potion-code-16m-v2-${{ hashFiles('src/engine/models/catalog.ts', 'package-lock.json') }}
-      - name: Run the packed package with real Potion embeddings
+            local-model-v2-${{ runner.os }}-${{ runner.arch }}-${{ matrix.model }}-${{ hashFiles('src/engine/models/catalog.ts', 'package-lock.json') }}
+      - name: Run the packed package with real local embeddings
         env:
           ZVEC_GREP_PACKAGE_TARBALL: ${{ runner.temp }}/package
           ZVEC_GREP_MODEL_CACHE: ${{ runner.temp }}/zvec-grep-model-cache
-          ZVEC_GREP_SMOKE_MODEL: local/potion-code-16m-v2
+          ZVEC_GREP_SMOKE_MODEL: ${{ matrix.model }}
         run: npm run test:smoke:local-model
 
   isolated-install:

--- a/.github/workflows/dependency-health.yml
+++ b/.github/workflows/dependency-health.yml
@@ -28,3 +28,79 @@ jobs:
       - run: npm install --package-lock=false
       - run: npm test
       - run: npm audit --omit=dev --audit-level=high
+
+  package-candidate:
+    name: local model package candidate
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      - name: Build the candidate tarball
+        run: |
+          mkdir -p "$RUNNER_TEMP/package"
+          npm pack --json --pack-destination "$RUNNER_TEMP/package"
+      - uses: actions/upload-artifact@v7
+        with:
+          name: local-model-package-candidate
+          path: ${{ runner.temp }}/package/
+          if-no-files-found: error
+          retention-days: 1
+
+  local-model-runtimes:
+    name: ${{ matrix.model }} (${{ matrix.os }}, Node ${{ matrix.node }})
+    needs: package-candidate
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        node: [22, 24, 26]
+        model:
+          - local/potion-code-16m-v2
+          - local/all-minilm-l6-v2
+          - local/embeddinggemma-300m
+        exclude:
+          - node: 22
+            model: local/all-minilm-l6-v2
+          - node: 22
+            model: local/embeddinggemma-300m
+          - node: 26
+            model: local/all-minilm-l6-v2
+          - node: 26
+            model: local/embeddinggemma-300m
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+      - uses: actions/download-artifact@v8
+        with:
+          name: local-model-package-candidate
+          path: ${{ runner.temp }}/package
+      - name: Restore the real model cache
+        uses: actions/cache@v5
+        with:
+          path: ${{ runner.temp }}/zvec-grep-model-cache
+          key: >-
+            health-model-v1-${{ runner.os }}-${{ runner.arch }}-${{ matrix.model }}-${{ hashFiles('src/engine/models/catalog.ts', 'package-lock.json') }}
+      - name: Exercise the real local model runtime
+        env:
+          ZVEC_GREP_PACKAGE_TARBALL: ${{ runner.temp }}/package
+          ZVEC_GREP_MODEL_CACHE: ${{ runner.temp }}/zvec-grep-model-cache
+          ZVEC_GREP_SMOKE_MODEL: ${{ matrix.model }}
+        run: npm run test:smoke:local-model

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,9 +11,10 @@ permissions:
   contents: read
 
 jobs:
-  publish:
+  package-candidate:
+    name: Build release candidate
     runs-on: ubuntu-latest
-
+    timeout-minutes: 35
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -24,7 +25,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 24
-          registry-url: https://registry.npmjs.org
+          cache: npm
 
       - name: Install dependencies
         run: npm ci
@@ -32,7 +33,92 @@ jobs:
       - name: Run release checks
         run: npm run check
 
+      - name: Build the release tarball
+        run: |
+          mkdir -p "$RUNNER_TEMP/package"
+          npm pack --json --pack-destination "$RUNNER_TEMP/package"
+
+      - name: Upload the release candidate
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-candidate
+          path: ${{ runner.temp }}/package/
+          if-no-files-found: error
+          retention-days: 1
+
+  verify-local-models:
+    name: Verify ${{ matrix.model }} (${{ matrix.os }}, Node ${{ matrix.node }})
+    needs: package-candidate
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        node: [22, 24, 26]
+        model:
+          - local/potion-code-16m-v2
+          - local/all-minilm-l6-v2
+          - local/embeddinggemma-300m
+        exclude:
+          - node: 22
+            model: local/all-minilm-l6-v2
+          - node: 22
+            model: local/embeddinggemma-300m
+          - node: 26
+            model: local/all-minilm-l6-v2
+          - node: 26
+            model: local/embeddinggemma-300m
+    steps:
+      - name: Checkout smoke tests
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+
+      - name: Download the release candidate
+        uses: actions/download-artifact@v8
+        with:
+          name: release-candidate
+          path: ${{ runner.temp }}/package
+
+      - name: Restore the real model cache
+        uses: actions/cache@v5
+        with:
+          path: ${{ runner.temp }}/zvec-grep-model-cache
+          key: >-
+            release-model-v1-${{ runner.os }}-${{ runner.arch }}-${{ matrix.model }}-${{ hashFiles('src/engine/models/catalog.ts', 'package-lock.json') }}
+
+      - name: Run the packed package with the real local model
+        env:
+          ZVEC_GREP_PACKAGE_TARBALL: ${{ runner.temp }}/package
+          ZVEC_GREP_MODEL_CACHE: ${{ runner.temp }}/zvec-grep-model-cache
+          ZVEC_GREP_SMOKE_MODEL: ${{ matrix.model }}
+        run: npm run test:smoke:local-model
+
+  publish:
+    name: Publish verified candidate
+    needs: verify-local-models
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+
+      - name: Download the verified release candidate
+        uses: actions/download-artifact@v8
+        with:
+          name: release-candidate
+          path: ${{ runner.temp }}/package
+
       - name: Publish package
-        run: npm publish
+        run: npm publish "$RUNNER_TEMP/package"/*.tgz
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "test:e2e": "npm run build && npm run test:run:e2e",
     "test:integration": "npm run build && npm run test:run:root && npm run test:run:integration",
     "test:package": "npm run build && node --test --test-concurrency=1 test/package/*.test.mjs",
+    "test:smoke:local-model": "node --test --test-concurrency=1 test/smoke/local-model-package.test.mjs",
     "test:run:e2e": "node --test --test-concurrency=1 test/e2e/*.test.mjs",
     "test:run:integration": "node --test --test-concurrency=1 test/integration/*.test.mjs",
     "test:run:root": "node --test --test-concurrency=1 test/*.test.mjs",

--- a/test/smoke/local-model-package.test.mjs
+++ b/test/smoke/local-model-package.test.mjs
@@ -1,0 +1,219 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, readdir, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { promisify } from "node:util";
+import test from "node:test";
+
+const execFileAsync = promisify(execFile);
+const DEFAULT_MODEL = "local/potion-code-16m-v2";
+
+function runNpm(args, options) {
+  const npmExecPath = process.env.npm_execpath;
+  if (npmExecPath) {
+    return execFileAsync(process.execPath, [npmExecPath, ...args], options);
+  }
+
+  return execFileAsync("npm", args, options);
+}
+
+function runExecutable(file, args, options) {
+  return execFileAsync(file, args, {
+    ...options,
+    shell: process.platform === "win32",
+    windowsHide: true,
+  });
+}
+
+async function resolvePackageTarball(root, temporaryDirectory, npmEnvironment) {
+  const configured = process.env.ZVEC_GREP_PACKAGE_TARBALL;
+  if (configured) {
+    const candidate = resolve(configured);
+    if ((await stat(candidate)).isFile()) {
+      return candidate;
+    }
+
+    const tarballs = (await readdir(candidate))
+      .filter((name) => name.endsWith(".tgz"))
+      .sort();
+    assert.equal(
+      tarballs.length,
+      1,
+      `expected exactly one package tarball in ${candidate}`,
+    );
+    return join(candidate, tarballs[0]);
+  }
+
+  const packDirectory = join(temporaryDirectory, "pack");
+  await mkdir(packDirectory, { recursive: true });
+  const packed = await runNpm(
+    ["pack", "--json", "--pack-destination", packDirectory],
+    { cwd: root, env: npmEnvironment, timeout: 180_000 },
+  );
+  const [metadata] = JSON.parse(packed.stdout);
+  return join(packDirectory, metadata.filename);
+}
+
+test("packed package runs a real local embedding model end to end", async (t) => {
+  const root = resolve(".");
+  const temporaryDirectory = await mkdtemp(
+    join(tmpdir(), "zvec-grep-local-model-package-"),
+  );
+  t.after(() => rm(temporaryDirectory, { recursive: true, force: true }));
+
+  const consumerDirectory = join(temporaryDirectory, "consumer");
+  const modelCache = resolve(
+    process.env.ZVEC_GREP_MODEL_CACHE ??
+      join(temporaryDirectory, "model-cache"),
+  );
+  const modelReference =
+    process.env.ZVEC_GREP_SMOKE_MODEL?.trim() || DEFAULT_MODEL;
+  const npmEnvironment = {
+    ...process.env,
+    npm_config_registry: "https://registry.npmjs.org/",
+  };
+
+  await mkdir(consumerDirectory, { recursive: true });
+  await writeFile(
+    join(consumerDirectory, "package.json"),
+    JSON.stringify({ private: true, type: "module" }),
+  );
+  const tarball = await resolvePackageTarball(
+    root,
+    temporaryDirectory,
+    npmEnvironment,
+  );
+  const installArguments = ["install", "--no-audit", "--no-fund"];
+  installArguments.push(tarball);
+  await runNpm(installArguments, {
+    cwd: consumerDirectory,
+    env: npmEnvironment,
+    timeout: 600_000,
+  });
+
+  const cli = join(
+    consumerDirectory,
+    "node_modules",
+    ".bin",
+    process.platform === "win32" ? "zg.cmd" : "zg",
+  );
+  const packageHome = join(temporaryDirectory, "home");
+  const runtimeEnvironment = {
+    ...process.env,
+    HOME: packageHome,
+    USERPROFILE: packageHome,
+    NO_COLOR: "1",
+    ZVEC_GREP_HOME: packageHome,
+    ZVEC_GREP_MODEL_CACHE: modelCache,
+  };
+
+  const embeddingSmokeScript = join(consumerDirectory, "embedding-smoke.mjs");
+  await writeFile(
+    embeddingSmokeScript,
+    [
+      "import { createEmbeddingModel } from '@zvec/zvec-grep';",
+      "const reference = process.env.ZVEC_GREP_SMOKE_MODEL;",
+      "const model = createEmbeddingModel(reference, { modelCacheDir: process.env.ZVEC_GREP_MODEL_CACHE, device: 'cpu' });",
+      "try {",
+      "  const result = await model.embed([{ kind: 'text', text: 'CrossPlatformPotionNeedle validates package-local embedding.' }], { purpose: 'query' });",
+      "  const vector = result.vectors[0];",
+      "  if (!vector || vector.length !== model.info.dimension || vector.some((value) => !Number.isFinite(value))) throw new Error('invalid embedding vector');",
+      "  const norm = Math.sqrt(vector.reduce((sum, value) => sum + value * value, 0));",
+      "  if (!(norm > 0 && Number.isFinite(norm))) throw new Error('invalid embedding norm');",
+      "  console.log('ZVEC_GREP_SMOKE_RESULT=' + JSON.stringify({ dimension: vector.length, norm }));",
+      "} finally {",
+      "  await model.dispose();",
+      "}",
+      "",
+    ].join("\n"),
+  );
+  const directEmbedding = await execFileAsync(
+    process.execPath,
+    [embeddingSmokeScript],
+    {
+      cwd: consumerDirectory,
+      env: {
+        ...runtimeEnvironment,
+        ZVEC_GREP_SMOKE_MODEL: modelReference,
+      },
+      timeout: 600_000,
+    },
+  );
+  const resultLine = directEmbedding.stdout
+    .split(/\r?\n/)
+    .find((line) => line.startsWith("ZVEC_GREP_SMOKE_RESULT="));
+  assert.ok(resultLine, "direct embedding did not report a result");
+  const embeddingResult = JSON.parse(resultLine.split("=", 2)[1]);
+  assert.ok(embeddingResult.dimension > 0);
+  assert.ok(embeddingResult.norm > 0);
+
+  await writeFile(
+    join(consumerDirectory, "fixture.ts"),
+    [
+      "export function CrossPlatformPotionNeedle(token: string): boolean {",
+      "  return token.startsWith('potion-');",
+      "}",
+      "",
+    ].join("\n"),
+  );
+  const indexed = await runExecutable(
+    cli,
+    [
+      "index",
+      "--mode",
+      "direct",
+      "--embedding",
+      modelReference,
+      "--device",
+      "cpu",
+      "-g",
+      "fixture.ts",
+      "-t",
+      "ts",
+      ".",
+    ],
+    {
+      cwd: consumerDirectory,
+      env: runtimeEnvironment,
+      timeout: 600_000,
+    },
+  );
+  assert.match(indexed.stdout, /^Workspace index$/m);
+  assert.match(indexed.stdout, /1 added/);
+
+  const queried = await runExecutable(
+    cli,
+    [
+      "query",
+      "--mode",
+      "direct",
+      "--vector",
+      "CrossPlatformPotionNeedle",
+      "--limit",
+      "5",
+      "-g",
+      "fixture.ts",
+      "-t",
+      "ts",
+      ".",
+    ],
+    {
+      cwd: consumerDirectory,
+      env: runtimeEnvironment,
+      timeout: 600_000,
+    },
+  );
+  assert.match(queried.stdout, /CrossPlatformPotionNeedle/);
+  assert.match(queried.stdout, /fixture\.ts/);
+
+  const status = await runExecutable(cli, ["status", "--mode", "direct", "."], {
+    cwd: consumerDirectory,
+    env: runtimeEnvironment,
+    timeout: 120_000,
+  });
+  assert.match(
+    status.stdout,
+    new RegExp(modelReference.replaceAll("/", "\\/")),
+  );
+});


### PR DESCRIPTION
## Summary

- add a packed-package smoke test that installs the candidate tarball and runs a real local embedding model without injected runtimes or mocked model assets
- require Linux, macOS, and Windows CI to run `local/potion-code-16m-v2` through direct embedding, indexing, vector query, and status
- add scheduled and release-time real-model coverage for Model2Vec, Transformers.js, and llama.cpp representatives across supported Node versions
- publish the exact tarball that passed cross-platform verification

## Why

The existing model unit tests validate adapter logic with injected tokenizers, downloaders, embedding tables, or runtimes. Generic cross-platform jobs also used mocked embeddings or a fake Qwen server, while package-install tests used `--ignore-scripts`. As a result, platform dependency installation, real model downloads, production worker startup, and local indexing/search failures could escape CI.

## Impact

PR CI now gates the default Potion model on Linux, macOS, and Windows. Weekly health checks and the release workflow exercise representative models for all three local backends. Release publishing is blocked until the candidate tarball passes verification.

## Validation

- `npm run test:smoke:local-model`
- `npm run test:unit` (100 tests)
- `npm run test:package`
- `npm run lint`
- `npm run format:check`
- workflow YAML parsed successfully