### PR TITLE
ci: align SWE-QA smoke with README cases

### DIFF
--- a/.github/workflows/swe-qa-bench.yml
+++ b/.github/workflows/swe-qa-bench.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
     inputs:
       scope:
-        description: Run the smoke pair or the 20-task All-Full benchmark
+        description: Run the three-case smoke benchmark or the 20-task All-Full benchmark
         required: true
         default: smoke
         type: choice
@@ -73,9 +73,7 @@ jobs:
           tasks = selection["tasks"]
           tasks_by_id = {task["task_id"]: task for task in tasks}
           scope = os.environ["SCOPE"]
-          if scope == "smoke":
-              task_ids = [selection["gate"]["smoke_task"]]
-          elif scope == "auto":
+          if scope in {"smoke", "auto"}:
               task_ids = selection["gate"]["auto_tasks"]
           elif scope in {"all-full", "gate-20"}:
               # gate-20 remains accepted for legacy API/CLI dispatches.
@@ -109,7 +107,6 @@ jobs:
           uv run --project benchmarks/swe-qa-bench zg-bench run
           swe-qa-bench
           --tier smoke
-          --task reflex-6
           --agent opencode
           --model custom-openai/glm-5.2
           --profile all

--- a/benchmarks/swe-qa-bench/README.md
+++ b/benchmarks/swe-qa-bench/README.md
@@ -37,11 +37,14 @@ reference isolation before starting model-backed jobs.
 
 ## CI scopes
 
-- Same-repository pull requests and pushes to `main` run the three cases shown
-  in the root README: `pylint:10`, `matplotlib:37`, and `django:32`.
+- Same-repository pull requests and pushes to `main` run these three smoke
+  tasks: `pylint:10`, `matplotlib:37`, and `django:32`.
+- Model-backed CI uses the `opencode` agent with
+  `custom-openai/glm-5.2` for both profiles.
 - Fork and Dependabot pull requests run locked-asset validation, unit tests, and
   a dry-run preflight only, without model credentials.
-- Manual `workflow_dispatch` with `scope=smoke` runs the same three cases.
+- Manual `workflow_dispatch` with `scope=smoke` runs the same three smoke
+  tasks.
 - Manual `workflow_dispatch` with `scope=all-full` runs all 20 pinned tasks.
 
 From the repository root, maintainers can trigger the manual scopes with the

--- a/benchmarks/swe-qa-bench/README.md
+++ b/benchmarks/swe-qa-bench/README.md
@@ -37,12 +37,11 @@ reference isolation before starting model-backed jobs.
 
 ## CI scopes
 
-- Same-repository pull requests and pushes to `main` run these five curated
-  tasks: `reflex:6`, `pylint:9`, `matplotlib:37`, `streamlink:14`, and
-  `xarray:32`.
+- Same-repository pull requests and pushes to `main` run the three cases shown
+  in the root README: `pylint:10`, `matplotlib:37`, and `django:32`.
 - Fork and Dependabot pull requests run locked-asset validation, unit tests, and
   a dry-run preflight only, without model credentials.
-- Manual `workflow_dispatch` with `scope=smoke` runs `reflex:6`.
+- Manual `workflow_dispatch` with `scope=smoke` runs the same three cases.
 - Manual `workflow_dispatch` with `scope=all-full` runs all 20 pinned tasks.
 
 From the repository root, maintainers can trigger the manual scopes with the
@@ -131,12 +130,11 @@ zg-bench list tasks swe-qa-bench --tier smoke
 zg-bench list tasks swe-qa-bench --tier ci
 ```
 
-Start with a dry run of the one-task, three-trial-per-profile configuration:
+Start with a dry run of the three-task, three-trial-per-profile configuration:
 
 ```sh
 zg-bench run swe-qa-bench \
   --tier smoke \
-  --task reflex-6 \
   --agent opencode \
   --model custom-openai/glm-5.2 \
   --profile all \

--- a/benchmarks/swe-qa-bench/README_CN.md
+++ b/benchmarks/swe-qa-bench/README_CN.md
@@ -24,9 +24,9 @@ Workflow 会在启动需要模型的 job 前，验证锁定的任务选择、代
 
 ## CI scope
 
-- 同一代码仓库的 pull request 和向 `main` 的 push 会运行以下 5 个精选任务：`reflex:6`、`pylint:9`、`matplotlib:37`、`streamlink:14` 和 `xarray:32`。
+- 同一代码仓库的 pull request 和向 `main` 的 push 会运行根 README 展示的 3 个案例：`pylint:10`、`matplotlib:37` 和 `django:32`。
 - 来自 fork 和 Dependabot 的 pull request 只运行锁定资源验证、单元测试和 dry-run 预检，不使用模型凭证。
-- 手动运行 `workflow_dispatch` 并设置 `scope=smoke` 时，会运行 `reflex:6`。
+- 手动运行 `workflow_dispatch` 并设置 `scope=smoke` 时，会运行相同的 3 个案例。
 - 手动运行 `workflow_dispatch` 并设置 `scope=all-full` 时，会运行全部 20 个锁定任务。
 
 维护者可以在代码仓库根目录使用 GitHub CLI 触发手动 scope：
@@ -102,12 +102,11 @@ zg-bench list tasks swe-qa-bench --tier smoke
 zg-bench list tasks swe-qa-bench --tier ci
 ```
 
-首先 dry run 单任务、每个 profile 三次 trial 的配置：
+首先 dry run 3 个任务、每个 profile 三次 trial 的配置：
 
 ```sh
 zg-bench run swe-qa-bench \
   --tier smoke \
-  --task reflex-6 \
   --agent opencode \
   --model custom-openai/glm-5.2 \
   --profile all \

--- a/benchmarks/swe-qa-bench/README_CN.md
+++ b/benchmarks/swe-qa-bench/README_CN.md
@@ -24,9 +24,10 @@ Workflow 会在启动需要模型的 job 前，验证锁定的任务选择、代
 
 ## CI scope
 
-- 同一代码仓库的 pull request 和向 `main` 的 push 会运行根 README 展示的 3 个案例：`pylint:10`、`matplotlib:37` 和 `django:32`。
+- 同一代码仓库的 pull request 和向 `main` 的 push 会运行以下 3 个 smoke 任务：`pylint:10`、`matplotlib:37` 和 `django:32`。
+- 需要模型的 CI 在两个 profile 中均使用 `opencode` Agent 和 `custom-openai/glm-5.2` 模型。
 - 来自 fork 和 Dependabot 的 pull request 只运行锁定资源验证、单元测试和 dry-run 预检，不使用模型凭证。
-- 手动运行 `workflow_dispatch` 并设置 `scope=smoke` 时，会运行相同的 3 个案例。
+- 手动运行 `workflow_dispatch` 并设置 `scope=smoke` 时，会运行相同的 3 个 smoke 任务。
 - 手动运行 `workflow_dispatch` 并设置 `scope=all-full` 时，会运行全部 20 个锁定任务。
 
 维护者可以在代码仓库根目录使用 GitHub CLI 触发手动 scope：

--- a/benchmarks/swe-qa-bench/suites/swe-qa-bench.yaml
+++ b/benchmarks/swe-qa-bench/suites/swe-qa-bench.yaml
@@ -3,7 +3,9 @@ path: ../datasets
 tiers:
   smoke:
     tasks:
-      - reflex-6
+      - pylint-10
+      - matplotlib-37
+      - django-32
   ci:
     tasks:
       - reflex-6

--- a/benchmarks/swe-qa-bench/tests/test_runner.py
+++ b/benchmarks/swe-qa-bench/tests/test_runner.py
@@ -466,6 +466,18 @@ class SuiteTierTests(unittest.TestCase):
     def setUp(self) -> None:
         self.suite_name = _install_external_suite_fixture(self)
 
+    def test_local_swe_qa_smoke_uses_readme_cases(self) -> None:
+        suite_path = (
+            Path(__file__).resolve().parents[1] / "suites" / "swe-qa-bench.yaml"
+        )
+
+        suite = runner.load_suite(suite_path, tier="smoke")
+
+        self.assertEqual(
+            suite.tasks,
+            ("pylint-10", "matplotlib-37", "django-32"),
+        )
+
     def test_local_swe_qa_suite_uses_harbor_path(self) -> None:
         suite_path = (
             Path(__file__).resolve().parents[1] / "suites" / "swe-qa-bench.yaml"

--- a/benchmarks/swe-qa-bench/tests/test_swe_qa_validation.py
+++ b/benchmarks/swe-qa-bench/tests/test_swe_qa_validation.py
@@ -14,11 +14,9 @@ SELECTION_PATH = SWE_QA_BENCH_DIR / "zg_bench" / "swe_qa" / "data" / "selection.
 REFERENCES_PATH = SWE_QA_BENCH_DIR / "zg_bench" / "swe_qa" / "data" / "references.json"
 DATASET_PATH = SWE_QA_BENCH_DIR / "datasets"
 EXPECTED_AUTO_TASK_IDS = (
-    "reflex:6",
-    "pylint:9",
+    "pylint:10",
     "matplotlib:37",
-    "streamlink:14",
-    "xarray:32",
+    "django:32",
 )
 
 
@@ -40,29 +38,36 @@ class AutoSelectionValidationTests(unittest.TestCase):
             dataset_path=DATASET_PATH,
         )
 
-        self.assertEqual(result["auto_task_count"], 5)
+        self.assertEqual(result["auto_task_count"], 3)
         self.assertEqual(tuple(result["auto_task_ids"]), EXPECTED_AUTO_TASK_IDS)
 
     def test_auto_selection_requires_exact_task_count(self) -> None:
         selection = json.loads(SELECTION_PATH.read_text(encoding="utf-8"))
         selection["gate"]["auto_tasks"].pop()
 
-        with self.assertRaisesRegex(SweQaError, "exactly 5 tasks"):
+        with self.assertRaisesRegex(SweQaError, "exactly 3 tasks"):
             self._validate_selection(selection)
 
-    def test_auto_selection_must_start_with_smoke(self) -> None:
+    def test_auto_selection_requires_what_where_why_order(self) -> None:
         selection = json.loads(SELECTION_PATH.read_text(encoding="utf-8"))
         auto_tasks = selection["gate"]["auto_tasks"]
         auto_tasks[0], auto_tasks[1] = auto_tasks[1], auto_tasks[0]
 
-        with self.assertRaisesRegex(SweQaError, "start with the configured smoke"):
+        with self.assertRaisesRegex(SweQaError, "what/where/why order"):
             self._validate_selection(selection)
 
-    def test_auto_selection_requires_all_four_categories_in_order(self) -> None:
+    def test_auto_selection_requires_category_tasks(self) -> None:
         selection = json.loads(SELECTION_PATH.read_text(encoding="utf-8"))
-        selection["gate"]["auto_tasks"][-1] = "sqlfluff:2"
+        selection["gate"]["auto_tasks"][0] = "reflex:6"
 
-        with self.assertRaisesRegex(SweQaError, "what/where/how/why order"):
+        with self.assertRaisesRegex(SweQaError, "entries must be category tasks"):
+            self._validate_selection(selection)
+
+    def test_auto_selection_rejects_duplicates(self) -> None:
+        selection = json.loads(SELECTION_PATH.read_text(encoding="utf-8"))
+        selection["gate"]["auto_tasks"][-1] = "matplotlib:37"
+
+        with self.assertRaisesRegex(SweQaError, "must not contain duplicates"):
             self._validate_selection(selection)
 
     def test_auto_selection_rejects_unknown_task(self) -> None:

--- a/benchmarks/swe-qa-bench/zg_bench/runner.py
+++ b/benchmarks/swe-qa-bench/zg_bench/runner.py
@@ -219,9 +219,6 @@ def load_suite(
         )
         if len(set(tasks)) != len(tasks):
             raise SuiteConfigError(f"tiers.{tier}.tasks must not contain duplicates")
-    if tier == "smoke" and tasks is not None and len(tasks) != 1:
-        raise SuiteConfigError("the smoke tier must contain exactly one task")
-
     if task_overrides:
         tasks = tuple(
             _require_nonempty_string(task, f"task override {index}")

--- a/benchmarks/swe-qa-bench/zg_bench/swe_qa/data/selection.json
+++ b/benchmarks/swe-qa-bench/zg_bench/swe_qa/data/selection.json
@@ -8,11 +8,9 @@
     "required_tasks": 20,
     "smoke_task": "reflex:6",
     "auto_tasks": [
-      "reflex:6",
-      "pylint:9",
+      "pylint:10",
       "matplotlib:37",
-      "streamlink:14",
-      "xarray:32"
+      "django:32"
     ],
     "category_tasks": [
       "sqlfluff:2",

--- a/benchmarks/swe-qa-bench/zg_bench/swe_qa/data/selection.json
+++ b/benchmarks/swe-qa-bench/zg_bench/swe_qa/data/selection.json
@@ -7,11 +7,7 @@
   "gate": {
     "required_tasks": 20,
     "smoke_task": "reflex:6",
-    "auto_tasks": [
-      "pylint:10",
-      "matplotlib:37",
-      "django:32"
-    ],
+    "auto_tasks": ["pylint:10", "matplotlib:37", "django:32"],
     "category_tasks": [
       "sqlfluff:2",
       "conan:1",

--- a/benchmarks/swe-qa-bench/zg_bench/swe_qa/validation.py
+++ b/benchmarks/swe-qa-bench/zg_bench/swe_qa/validation.py
@@ -16,7 +16,8 @@ FULL_COMMIT_RE = re.compile(r"^[0-9a-fA-F]{40}$")
 EXPECTED_TASK_COUNT = 20
 EXPECTED_CATEGORIES = ("what", "where", "how", "why")
 EXPECTED_TASKS_PER_CATEGORY = 5
-EXPECTED_AUTO_TASK_COUNT = 1 + len(EXPECTED_CATEGORIES)
+EXPECTED_AUTO_TASK_COUNT = 3
+EXPECTED_AUTO_CATEGORIES = ("what", "where", "why")
 
 
 def _object(path: Path, *, label: str) -> dict[str, Any]:
@@ -162,20 +163,14 @@ def validate_assets(
             "selection gate.auto_tasks contains unknown task IDs: "
             f"{unknown_auto_tasks}"
         )
-    if auto_tasks[0] != smoke_task_id:
-        raise SweQaError(
-            "selection gate.auto_tasks must start with the configured smoke task"
-        )
-    auto_category_tasks = [selected[task_id] for task_id in auto_tasks[1:]]
+    auto_category_tasks = [selected[task_id] for task_id in auto_tasks]
     if any(task.get("role") != "category" for task in auto_category_tasks):
-        raise SweQaError(
-            "selection gate.auto_tasks entries after smoke must be category tasks"
-        )
+        raise SweQaError("selection gate.auto_tasks entries must be category tasks")
     auto_categories = [str(task.get("category")) for task in auto_category_tasks]
-    if tuple(auto_categories) != EXPECTED_CATEGORIES:
+    if tuple(auto_categories) != EXPECTED_AUTO_CATEGORIES:
         raise SweQaError(
-            "selection gate.auto_tasks must contain smoke followed by one category "
-            "task in what/where/how/why order"
+            "selection gate.auto_tasks must contain one category task in "
+            "what/where/why order"
         )
     expected_category_tasks = [
         str(task["task_id"]) for task in tasks if task.get("role") == "category"


### PR DESCRIPTION
## Summary

- replace the SWE-QA automatic and manual smoke selection with the three cases shown in the root README: `pylint:10`, `matplotlib:37`, and `django:32`
- align the local smoke suite and credential-free workflow preflight with the same three tasks
- update validation invariants, tests, and English/Chinese benchmark documentation

## Validation

- locked selection and dataset validation passes for all 20 tasks
- all 85 SWE-QA benchmark unit tests pass
- the workflow-equivalent dry run includes exactly the three selected tasks for both profiles
