### PR TITLE
docs: make OpenCode model selection resilient

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,13 @@ With [OpenCode](https://opencode.ai/) configured:
 
 ```bash
 zg install --target opencode --yes
-opencode run --model opencode/deepseek-v4-flash-free \
+opencode models
+opencode run --model opencode/nemotron-3-ultra-free \
   "An unseen creature left a few marks. What did the detective infer? Cite local evidence."
 ```
+
+Free model availability can change. Check `opencode models` and replace the
+example model with one that is currently available in your environment.
 
 OpenCode chooses zg on its own—the prompt does not name a tool.
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -83,9 +83,13 @@ zg index --embedding local/potion-retrieval-32m
 
 ```bash
 zg install --target opencode --yes
-opencode run --model opencode/deepseek-v4-flash-free \
+opencode models
+opencode run --model opencode/nemotron-3-ultra-free \
   "An unseen creature left a few marks. What did the detective infer? Cite local evidence."
 ```
+
+免费模型的可用性可能变化。请通过 `opencode models` 检查，并将示例模型
+替换为当前环境中可用的模型。
 
 Prompt 中没有指定任何工具，OpenCode 会自主选择 zg。
 


### PR DESCRIPTION
 ## Summary
Closes #59 
  - run `opencode models` before the OpenCode Quickstart example
  - replace the unavailable model with a currently verified example
  - clarify that free model availability may change
  - keep the English and Chinese READMEs consistent

  ## Motivation

  The Quickstart previously used
  `opencode/deepseek-v4-flash-free`, which is no longer listed by
  `opencode models` and fails with `Unexpected server error`.

  `opencode/nemotron-3-ultra-free` has been verified to run successfully and
  invoke `zvec_grep_zvec_grep_search`. Since free model availability may change,
  the updated instructions ask users to check `opencode models` and select a
  model available in their environment.

  ## Testing

  - confirmed that no references to `deepseek-v4-flash-free` remain
  - ran `git diff --check`
  - manually reviewed the English and Chinese Quickstart instructions