### PR TITLE
fix: persist Qoder MCP tool permissions

### DIFF
--- a/docs/01-agents.md
+++ b/docs/01-agents.md
@@ -55,8 +55,9 @@ The installer:
 
 1. adds a managed `zvec_grep` MCP entry;
 2. adds search guidance where the agent supports it;
-3. adds local MCP tool approval for Codex and Claude Code, and managed server
-   trust for Qwen Code and Qoder CLI;
+3. adds local MCP tool approval for Codex and Claude Code, managed server trust
+   for Qwen Code and Qoder CLI, and exact search/rg allow rules for Qoder's
+   CLI-backed runtime;
 4. starts the local zvec-grep server when possible.
 
 The [Server guide](./06-server.md) explains when the daemon is useful and how its
@@ -71,6 +72,13 @@ For Qoder CLI, `--mcp-transport` selects either a stdio or HTTP entry under
 `mcpServers`; the installer also manages the timeout and trust fields. Search
 guidance is written to `${QODER_CONFIG_DIR:-~/.qoder}/AGENTS.md` without
 replacing unrelated guidance.
+
+The same Qoder `settings.json`, used by Qoder CLI and CLI-backed Qoder clients,
+receives exact `permissions.allow` rules for
+`mcp__zvec_grep__zvec_grep_search` and `mcp__zvec_grep__zvec_grep_rg`, plus the
+equivalent server-level `alwaysAllow` policy. This avoids repeated tool approval
+prompts without allowing other MCP tools. Existing permission rules and JSONC
+comments are preserved; uninstall removes only rules added by zg.
 
 The same install writes the Qoder IDE MCP entry to its user-level
 `~/.qoder/mcp.json`. Set `QODER_IDE_MCP_PATH` to override that complete file

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -320,7 +320,8 @@ daemon automatically after a reboot. HTTP users manage later daemon restarts.
 Codex, Claude Code, Qwen Code, Qoder CLI, and OpenCode also receive managed
 guidance. Qoder IDE has no supported global Rules file, so only its MCP
 configuration is managed.
-Codex and Claude Code receive local tool pre-approval. Remote Embedding
+Codex and Claude Code receive local tool pre-approval. Qoder's CLI-backed
+runtime receives exact pre-approval for zvec_grep_search and zvec_grep_rg. Remote Embedding
 authorization remains separate and is requested by zvec-grep on first remote
 use. Restart the agent or open a new session after installation. This does not
 install the npm package.`;

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -115,6 +115,21 @@ const ZVEC_GREP_AGENTS_END = "<!-- ZVEC_GREP_END -->";
 const CLAUDE_MCP_PERMISSION = "mcp__zvec_grep__*";
 const NAMESPACED_SEARCH_TOOL = "mcp__zvec_grep__zvec_grep_search";
 const NAMESPACED_RG_TOOL = "mcp__zvec_grep__zvec_grep_rg";
+const QODER_MCP_PERMISSION_RULES = [
+  {
+    permission: NAMESPACED_SEARCH_TOOL,
+    tool: "zvec_grep_search",
+  },
+  {
+    permission: NAMESPACED_RG_TOOL,
+    tool: "zvec_grep_rg",
+  },
+] as const;
+const QODER_MCP_PERMISSIONS = QODER_MCP_PERMISSION_RULES.map(
+  ({ permission }) => permission,
+);
+const QODER_CLI_MCP_DESCRIPTION = "Managed by zg install";
+const QODER_PERMISSION_OWNERSHIP_PREFIX = `${QODER_CLI_MCP_DESCRIPTION}; managed permissions=`;
 const QODER_IDE_MCP_DESCRIPTION = "Managed by zg install";
 const DEFAULT_MCP_TOOL_TIMEOUT_SECONDS = 600;
 
@@ -426,6 +441,7 @@ async function installQoderIntegration(
     options.force,
     isManagedJsonMcpServer,
   );
+  await assertQoderPermissionSettingsValid(settingsPath);
   await assertQoderMcpSettingsReplaceable(
     ideMcpPath,
     "Qoder IDE",
@@ -1166,18 +1182,275 @@ async function removeQwenSettings(path: string): Promise<void> {
 async function updateQoderSettings(
   options: InstallAgentOptions & { path: string },
 ): Promise<string[]> {
-  const root = await updateJsoncMcpSettings({
-    path: options.path,
-    force: options.force,
-    label: "Qoder",
-    server: qoderMcpServer(options),
-    isManaged: isManagedJsonMcpServer,
-  });
+  const existing = await readTextFileIfExists(options.path);
+  let source = existing.trim() ? existing : "{}\n";
+  const root = parseJsoncSettings(options.path, source, "Qoder");
+  validateMcpSettingsContainer(options.path, root);
+  const mcpServers = isJsonObject(root.mcpServers) ? root.mcpServers : {};
+  const current = mcpServers.zvec_grep;
+  const currentIsManaged = isManagedJsonMcpServer(current);
+  if (current !== undefined && !currentIsManaged && !options.force) {
+    throw new Error(
+      `Existing unmanaged zvec_grep MCP server found in ${options.path}. Re-run with --force to replace it for Qoder.`,
+    );
+  }
+
+  const allow = qoderPermissionAllowRules(options.path, root);
+  const ownedPermissions = new Set([
+    ...(currentIsManaged ? qoderOwnedPermissionRules(current) : []),
+    ...QODER_MCP_PERMISSIONS.filter(
+      (permission) => !allow.includes(permission),
+    ),
+  ]);
+  const alwaysAllow = currentIsManaged ? qoderAlwaysAllowTools(current) : [];
+  for (const { tool } of QODER_MCP_PERMISSION_RULES) {
+    if (!alwaysAllow.includes(tool)) {
+      alwaysAllow.push(tool);
+    }
+  }
+
+  source = editJsonWithComments(
+    source,
+    ["mcpServers", "zvec_grep"],
+    qoderMcpServer(options, alwaysAllow, [...ownedPermissions]),
+  );
+  source = addQoderPermissionRules(source, options.path, root);
+  await writeTextFileAtomic(options.path, ensureTrailingNewline(source));
   return contextFileWarnings(root, "AGENTS.md");
 }
 
 async function removeQoderSettings(path: string): Promise<void> {
-  await removeJsoncMcpSettings(path, "Qoder", isManagedJsonMcpServer);
+  const existing = await readTextFileIfExists(path);
+  if (!existing.trim()) return;
+
+  let source = existing;
+  const root = parseJsoncSettings(path, source, "Qoder");
+  validateMcpSettingsContainer(path, root);
+  qoderPermissionAllowRules(path, root);
+  const mcpServers = isJsonObject(root.mcpServers) ? root.mcpServers : {};
+  const current = mcpServers.zvec_grep;
+  if (!isManagedJsonMcpServer(current)) return;
+  const ownedPermissions = qoderOwnedPermissionRules(current);
+
+  source = hasJsoncComments(source)
+    ? removeJsoncPropertyPreservingComments(source, ["mcpServers", "zvec_grep"])
+    : editJsonWithComments(
+        source,
+        Object.keys(mcpServers).length === 1
+          ? ["mcpServers"]
+          : ["mcpServers", "zvec_grep"],
+        undefined,
+      );
+  source = removeQoderPermissionRules(source, path, root, ownedPermissions);
+  if (source !== existing) {
+    await writeTextFileAtomic(path, ensureTrailingNewline(source));
+  }
+}
+
+async function assertQoderPermissionSettingsValid(path: string): Promise<void> {
+  const source = await readTextFileIfExists(path);
+  if (!source.trim()) return;
+  const root = parseJsoncSettings(path, source, "Qoder");
+  qoderPermissionAllowRules(path, root);
+}
+
+function addQoderPermissionRules(
+  source: string,
+  path: string,
+  root: JsonObject,
+): string {
+  const allow = qoderPermissionAllowRules(path, root);
+  const missing = QODER_MCP_PERMISSIONS.filter(
+    (permission) => !allow.includes(permission),
+  );
+  if (missing.length === 0) return source;
+
+  const hasAllowArray =
+    isJsonObject(root.permissions) && Array.isArray(root.permissions.allow);
+  if (!hasAllowArray) {
+    return editJsonWithComments(
+      source,
+      ["permissions", "allow"],
+      [...allow, ...missing],
+    );
+  }
+  return insertJsoncArrayValuesAtStart(
+    source,
+    ["permissions", "allow"],
+    missing,
+  );
+}
+
+function removeQoderPermissionRules(
+  source: string,
+  path: string,
+  root: JsonObject,
+  ownedPermissions: readonly string[],
+): string {
+  const allow = qoderPermissionAllowRules(path, root);
+  let removedCount = 0;
+  for (const permission of ownedPermissions) {
+    const removal = removeFirstJsoncArrayStringValue(
+      source,
+      ["permissions", "allow"],
+      permission,
+    );
+    source = removal.source;
+    if (removal.removed) removedCount += 1;
+  }
+  if (removedCount === 0) return source;
+
+  if (removedCount < allow.length) return source;
+
+  const permissions = root.permissions as JsonObject;
+  const hasOtherPermissionSettings = Object.keys(permissions).some(
+    (key) => key !== "allow",
+  );
+  if (hasJsoncComments(source)) {
+    return source;
+  }
+  if (hasOtherPermissionSettings) {
+    return editJsonWithComments(source, ["permissions", "allow"], undefined);
+  }
+  return editJsonWithComments(source, ["permissions"], undefined);
+}
+
+function qoderOwnedPermissionRules(server: unknown): string[] {
+  if (
+    !isJsonObject(server) ||
+    typeof server.description !== "string" ||
+    !server.description.startsWith(QODER_PERMISSION_OWNERSHIP_PREFIX)
+  ) {
+    return [];
+  }
+  const alwaysAllow = server.description
+    .slice(QODER_PERMISSION_OWNERSHIP_PREFIX.length)
+    .split(",")
+    .filter(Boolean);
+  return QODER_MCP_PERMISSION_RULES.filter(({ tool }) =>
+    alwaysAllow.includes(tool),
+  ).map(({ permission }) => permission);
+}
+
+function qoderMcpDescription(ownedPermissions: readonly string[]): string {
+  const tools = QODER_MCP_PERMISSION_RULES.filter(({ permission }) =>
+    ownedPermissions.includes(permission),
+  ).map(({ tool }) => tool);
+  return tools.length > 0
+    ? `${QODER_PERMISSION_OWNERSHIP_PREFIX}${tools.join(",")}`
+    : QODER_CLI_MCP_DESCRIPTION;
+}
+
+function qoderAlwaysAllowTools(server: unknown): string[] {
+  if (!isJsonObject(server) || !Array.isArray(server.alwaysAllow)) return [];
+  return server.alwaysAllow.filter(
+    (tool): tool is string => typeof tool === "string",
+  );
+}
+
+function insertJsoncArrayValuesAtStart(
+  source: string,
+  path: readonly (string | number)[],
+  values: readonly string[],
+): string {
+  if (values.length === 0) return source;
+  const root = parseTree(source);
+  const arrayNode = root ? findNodeAtLocation(root, [...path]) : undefined;
+  if (arrayNode?.type !== "array") return source;
+
+  const children = arrayNode.children ?? [];
+  const insertionOffset = arrayNode.offset + 1;
+  const closingBracketOffset = arrayNode.offset + arrayNode.length - 1;
+  const multiline = source
+    .slice(arrayNode.offset, closingBracketOffset + 1)
+    .includes("\n");
+  const serialized = values.map((value) => JSON.stringify(value));
+
+  let insertion: string;
+  if (multiline) {
+    const formatting = jsonFormattingOptions(source);
+    const lineStart = source.lastIndexOf("\n", arrayNode.offset - 1) + 1;
+    const propertyIndent =
+      source.slice(lineStart, arrayNode.offset).match(/^[\t ]*/)?.[0] ?? "";
+    const indentUnit = formatting.insertSpaces
+      ? " ".repeat(formatting.tabSize ?? 2)
+      : "\t";
+    const itemIndent = `${propertyIndent}${indentUnit}`;
+    const lines = serialized.map(
+      (value, index) =>
+        `${itemIndent}${value}${index < serialized.length - 1 || children.length > 0 ? "," : ""}`,
+    );
+    insertion = `${formatting.eol}${lines.join(formatting.eol)}`;
+  } else {
+    insertion = `${serialized.join(", ")}${children.length > 0 ? ", " : ""}`;
+  }
+
+  return (
+    source.slice(0, insertionOffset) + insertion + source.slice(insertionOffset)
+  );
+}
+
+function removeFirstJsoncArrayStringValue(
+  source: string,
+  path: readonly (string | number)[],
+  value: string,
+): { source: string; removed: boolean } {
+  const root = parseTree(source);
+  const arrayNode = root ? findNodeAtLocation(root, [...path]) : undefined;
+  if (arrayNode?.type !== "array" || !arrayNode.children) {
+    return { source, removed: false };
+  }
+
+  const index = arrayNode.children.findIndex(
+    (child) => child.type === "string" && child.value === value,
+  );
+  if (index < 0) return { source, removed: false };
+
+  const target = arrayNode.children[index]!;
+  const previous = arrayNode.children[index - 1];
+  const next = arrayNode.children[index + 1];
+  const ranges = [nodeRange(target)];
+  const commaOffset = next
+    ? findComma(source, target.offset + target.length, next.offset)
+    : previous
+      ? findComma(source, previous.offset + previous.length, target.offset)
+      : undefined;
+  if (commaOffset !== undefined) {
+    ranges.push({ offset: commaOffset, length: 1 });
+  }
+
+  return {
+    source: ranges
+      .sort((left, right) => right.offset - left.offset)
+      .reduce(
+        (current, range) =>
+          current.slice(0, range.offset) +
+          current.slice(range.offset + range.length),
+        source,
+      ),
+    removed: true,
+  };
+}
+
+function qoderPermissionAllowRules(path: string, root: JsonObject): string[] {
+  const currentPermissions = root.permissions;
+  if (currentPermissions !== undefined && !isJsonObject(currentPermissions)) {
+    throw new Error(`Invalid permissions configuration in ${path}.`);
+  }
+  const permissions = isJsonObject(currentPermissions)
+    ? currentPermissions
+    : {};
+  const currentAllow = permissions.allow;
+  if (currentAllow !== undefined && !Array.isArray(currentAllow)) {
+    throw new Error(`Invalid permissions.allow configuration in ${path}.`);
+  }
+  if (
+    Array.isArray(currentAllow) &&
+    currentAllow.some((permission) => typeof permission !== "string")
+  ) {
+    throw new Error(`Invalid permissions.allow rule in ${path}.`);
+  }
+  return Array.isArray(currentAllow) ? (currentAllow as string[]) : [];
 }
 
 async function updateQoderIdeSettings(
@@ -1225,14 +1498,22 @@ function qwenMcpServer(options: InstallAgentOptions): Record<string, unknown> {
   };
 }
 
-function qoderMcpServer(options: InstallAgentOptions): Record<string, unknown> {
+function qoderMcpServer(
+  options: InstallAgentOptions,
+  alwaysAllow: readonly string[] = [],
+  ownedPermissions: readonly string[] = [],
+): Record<string, unknown> {
   const timeout = options.mcpToolTimeoutSeconds * 1_000;
+  const permissionPolicy =
+    alwaysAllow.length > 0 ? { alwaysAllow: [...alwaysAllow] } : {};
   if (options.transport === "stdio") {
     return {
       command: "zg",
       args: stdioArgs(options.mcpToolset),
       timeout,
       trust: true,
+      description: qoderMcpDescription(ownedPermissions),
+      ...permissionPolicy,
     };
   }
 
@@ -1241,6 +1522,8 @@ function qoderMcpServer(options: InstallAgentOptions): Record<string, unknown> {
     url: resolveServerUrl(),
     timeout,
     trust: true,
+    description: qoderMcpDescription(ownedPermissions),
+    ...permissionPolicy,
     ...(options.mcpTokenEnv
       ? {
           headers: {

--- a/test/install.test.mjs
+++ b/test/install.test.mjs
@@ -1215,6 +1215,12 @@ test("Qoder installer preserves JSONC comments and writes trusted stdio config a
     args: ["server", "--stdio", "--mcp-toolset", "full"],
     timeout: 900000,
     trust: true,
+    description:
+      "Managed by zg install; managed permissions=zvec_grep_search,zvec_grep_rg",
+    alwaysAllow: ["zvec_grep_search", "zvec_grep_rg"],
+  });
+  assert.deepEqual(config.permissions, {
+    allow: ["mcp__zvec_grep__zvec_grep_search", "mcp__zvec_grep__zvec_grep_rg"],
   });
   const ideInstalled = await readFile(ideConfigPath, "utf8");
   assert.match(ideInstalled, /Keep the user's IDE MCP servers/);
@@ -1282,6 +1288,230 @@ test("Qoder installer preserves JSONC comments and writes trusted stdio config a
   );
   assert.equal(countOccurrences(guidance, "<!-- ZVEC_GREP_START -->"), 1);
   assert.equal(countOccurrences(guidance, "<!-- ZVEC_GREP_END -->"), 1);
+});
+
+test("Qoder installer manages least-privilege MCP permissions without replacing user policy", async (t) => {
+  const temporaryDirectory = await mkdtemp(
+    join(tmpdir(), "zvec-grep-install-qoder-permissions-"),
+  );
+  const qoderHome = join(temporaryDirectory, ".qoder");
+  const settingsPath = join(qoderHome, "settings.json");
+  t.after(async () => {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  });
+
+  await mkdir(qoderHome, { recursive: true });
+  await writeFile(
+    settingsPath,
+    [
+      "{",
+      "  // Keep the user's permission policy.",
+      '  "permissions": {',
+      '    "allow": [',
+      "      // Keep this user rule comment.",
+      '      "Bash(git status)" // Keep this inline rule comment.',
+      "      // Keep this trailing array comment.",
+      "    ],",
+      '    "ask": ["mcp__github__create_issue"],',
+      '    "deny": ["Bash(rm -rf:*)"],',
+      '    "customPolicy": { "nested": ["keep"] }',
+      "  }",
+      "}",
+      "",
+    ].join("\n"),
+  );
+
+  await installTarget("qoder", { QODER_CONFIG_DIR: qoderHome });
+  const firstInstall = await readFile(settingsPath, "utf8");
+  await installTarget("qoder", { QODER_CONFIG_DIR: qoderHome });
+  assert.equal(await readFile(settingsPath, "utf8"), firstInstall);
+
+  assert.match(firstInstall, /Keep the user's permission policy/);
+  const userRuleCommentSequence =
+    /Keep this user rule comment\.\s*"Bash\(git status\)"\s*\/\/ Keep this inline rule comment\.\s*\/\/ Keep this trailing array comment\./;
+  assert.match(firstInstall, userRuleCommentSequence);
+  const installed = parseJsonWithComments(firstInstall);
+  assert.deepEqual(installed.permissions, {
+    allow: [
+      "mcp__zvec_grep__zvec_grep_search",
+      "mcp__zvec_grep__zvec_grep_rg",
+      "Bash(git status)",
+    ],
+    ask: ["mcp__github__create_issue"],
+    deny: ["Bash(rm -rf:*)"],
+    customPolicy: { nested: ["keep"] },
+  });
+
+  await uninstallTarget("qoder", { QODER_CONFIG_DIR: qoderHome });
+  const uninstalledSource = await readFile(settingsPath, "utf8");
+  assert.match(uninstalledSource, /Keep the user's permission policy/);
+  assert.match(uninstalledSource, userRuleCommentSequence);
+  const uninstalled = parseJsonWithComments(uninstalledSource);
+  assert.deepEqual(uninstalled.permissions, {
+    allow: ["Bash(git status)"],
+    ask: ["mcp__github__create_issue"],
+    deny: ["Bash(rm -rf:*)"],
+    customPolicy: { nested: ["keep"] },
+  });
+});
+
+test("Qoder uninstaller retains permission rules that predated installation", async (t) => {
+  const temporaryDirectory = await mkdtemp(
+    join(tmpdir(), "zvec-grep-uninstall-qoder-preexisting-permission-"),
+  );
+  const qoderHome = join(temporaryDirectory, ".qoder");
+  const settingsPath = join(qoderHome, "settings.json");
+  t.after(async () => {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  });
+
+  await mkdir(qoderHome, { recursive: true });
+  await writeFile(
+    settingsPath,
+    `${JSON.stringify({
+      mcpServers: {
+        zvec_grep: {
+          type: "http",
+          url: "https://example.test/user-owned-mcp",
+          alwaysAllow: ["zvec_grep_search"],
+        },
+      },
+      permissions: {
+        allow: ["Bash(git status)", "mcp__zvec_grep__zvec_grep_search"],
+      },
+    })}\n`,
+  );
+
+  await installTarget("qoder", { QODER_CONFIG_DIR: qoderHome }, ["--force"]);
+  const installed = JSON.parse(await readFile(settingsPath, "utf8"));
+  assert.deepEqual(installed.mcpServers.zvec_grep.alwaysAllow, [
+    "zvec_grep_search",
+    "zvec_grep_rg",
+  ]);
+  assert.equal(
+    installed.mcpServers.zvec_grep.description,
+    "Managed by zg install; managed permissions=zvec_grep_rg",
+  );
+  assert.deepEqual(installed.permissions.allow, [
+    "mcp__zvec_grep__zvec_grep_rg",
+    "Bash(git status)",
+    "mcp__zvec_grep__zvec_grep_search",
+  ]);
+
+  await uninstallTarget("qoder", { QODER_CONFIG_DIR: qoderHome });
+  const uninstalled = JSON.parse(await readFile(settingsPath, "utf8"));
+  assert.equal(uninstalled.mcpServers, undefined);
+  assert.deepEqual(uninstalled.permissions.allow, [
+    "Bash(git status)",
+    "mcp__zvec_grep__zvec_grep_search",
+  ]);
+});
+
+test("Qoder installer validates permissions before changing either client config", async (t) => {
+  const temporaryDirectory = await mkdtemp(
+    join(tmpdir(), "zvec-grep-install-qoder-permission-preflight-"),
+  );
+  const qoderHome = join(temporaryDirectory, ".qoder");
+  const settingsPath = join(qoderHome, "settings.json");
+  const idePath = join(qoderHome, "mcp.json");
+  const guidancePath = join(qoderHome, "AGENTS.md");
+  const settings = '{"permissions":{"allow":"mcp__zvec_grep__*"}}\n';
+  const ide = '{"mcpServers":{"github":{"command":"github-mcp"}}}\n';
+  const guidance = "# Existing Qoder guidance\n";
+  t.after(async () => {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  });
+
+  await mkdir(qoderHome, { recursive: true });
+  await writeFile(settingsPath, settings);
+  await writeFile(idePath, ide);
+  await writeFile(guidancePath, guidance);
+
+  await assert.rejects(
+    installTarget("qoder", { QODER_CONFIG_DIR: qoderHome }),
+    /Invalid permissions\.allow configuration/,
+  );
+  assert.equal(await readFile(settingsPath, "utf8"), settings);
+  assert.equal(await readFile(idePath, "utf8"), ide);
+  assert.equal(await readFile(guidancePath, "utf8"), guidance);
+});
+
+test("Qoder uninstaller leaves user-owned server permissions unchanged", async (t) => {
+  const temporaryDirectory = await mkdtemp(
+    join(tmpdir(), "zvec-grep-uninstall-qoder-user-permissions-"),
+  );
+  const qoderHome = join(temporaryDirectory, ".qoder");
+  const settingsPath = join(qoderHome, "settings.json");
+  const original = `${JSON.stringify(
+    {
+      mcpServers: {
+        zvec_grep: {
+          type: "http",
+          url: "https://example.test/user-owned-mcp",
+        },
+      },
+      permissions: {
+        allow: [
+          "mcp__zvec_grep__zvec_grep_search",
+          "mcp__zvec_grep__zvec_grep_rg",
+        ],
+      },
+    },
+    null,
+    2,
+  )}\n`;
+  t.after(async () => {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  });
+
+  await mkdir(qoderHome, { recursive: true });
+  await writeFile(settingsPath, original);
+  await uninstallTarget("qoder", { QODER_CONFIG_DIR: qoderHome });
+  assert.equal(await readFile(settingsPath, "utf8"), original);
+});
+
+test("Qoder uninstaller preserves comments in a managed-only permission array", async (t) => {
+  const temporaryDirectory = await mkdtemp(
+    join(tmpdir(), "zvec-grep-uninstall-qoder-managed-comments-"),
+  );
+  const qoderHome = join(temporaryDirectory, ".qoder");
+  const settingsPath = join(qoderHome, "settings.json");
+  t.after(async () => {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  });
+
+  await mkdir(qoderHome, { recursive: true });
+  await writeFile(
+    settingsPath,
+    [
+      "{",
+      '  "mcpServers": {',
+      '    "zvec_grep": {',
+      '      "command": "zg",',
+      '      "args": ["server", "--stdio"],',
+      '      "description": "Managed by zg install; managed permissions=zvec_grep_search,zvec_grep_rg"',
+      "    }",
+      "  },",
+      '  "permissions": {',
+      '    "allow": [',
+      "      // Keep this managed permission note.",
+      '      "mcp__zvec_grep__zvec_grep_search",',
+      '      "mcp__zvec_grep__zvec_grep_rg" // Keep this inline note.',
+      "      // Keep this trailing permission note.",
+      "    ]",
+      "  }",
+      "}",
+      "",
+    ].join("\n"),
+  );
+
+  await uninstallTarget("qoder", { QODER_CONFIG_DIR: qoderHome });
+  const uninstalledSource = await readFile(settingsPath, "utf8");
+  assert.match(uninstalledSource, /Keep this managed permission note/);
+  assert.match(uninstalledSource, /Keep this inline note/);
+  assert.match(uninstalledSource, /Keep this trailing permission note/);
+  const uninstalled = parseJsonWithComments(uninstalledSource);
+  assert.deepEqual(uninstalled.permissions.allow, []);
 });
 
 test("Qoder uninstaller preserves comments around a first or only managed server", async (t) => {
@@ -1390,6 +1620,9 @@ test("Qoder installer writes trusted HTTP configuration and token expansion", as
     url: "http://127.0.0.1:7999/mcp",
     timeout: 42000,
     trust: true,
+    description:
+      "Managed by zg install; managed permissions=zvec_grep_search,zvec_grep_rg",
+    alwaysAllow: ["zvec_grep_search", "zvec_grep_rg"],
     headers: {
       Authorization: "Bearer ${ZVEC_GREP_SERVER_TOKEN}",
     },
@@ -1471,6 +1704,7 @@ test("Qoder installer requires force and uninstall is managed and idempotent", a
 
   const config = JSON.parse(firstUninstallConfig);
   assert.equal(config.theme, "dark");
+  assert.equal(config.permissions, undefined);
   assert.equal(config.mcpServers.zvec_grep, undefined);
   assert.equal(config.mcpServers.other.url, "https://example.test/mcp");
   const ideConfig = JSON.parse(firstUninstallIdeConfig);


### PR DESCRIPTION
## Summary

- persist exact Qoder allow rules for zvec_grep_search and zvec_grep_rg
- add matching server-level alwaysAllow without granting wildcard MCP access
- preserve user-owned permission rules and JSONC comments during install and uninstall

## Validation

- npm run lint
- npm run typecheck
- npm run build
- node --test --test-concurrency=1 test/install.test.mjs
- npm run test:coverage