### PR TITLE
feat: add GitHub Copilot and VS Code integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ Embedding.
 
 | Guide | What you can do |
 | :--- | :--- |
-| [Agent integrations](./docs/01-agents.md) | Connect zg to Codex, Claude Code, Qwen Code, Qoder, Cursor, or OpenCode and verify that it works. |
+| [Agent integrations](./docs/01-agents.md) | Connect zg to Codex, Claude Code, Qwen Code, Qoder, Cursor, GitHub Copilot, or OpenCode and verify that it works. |
 | [CLI guide](./docs/02-cli.md) | Search, index, and manage your local workspaces from the terminal. |
 | [MCP guide](./docs/03-mcp.md) | Understand which zg tools your agent can use and how access is secured. |
 | [Retrieval pipeline](./docs/04-pipeline.md) | Choose what to index, keep it fresh, and get better search results. |

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ Embedding.
 
 | Guide | What you can do |
 | :--- | :--- |
-| [Agent integrations](./docs/01-agents.md) | Connect zg to Codex, Claude Code, Qwen Code, Qoder, Cursor, GitHub Copilot, or OpenCode and verify that it works. |
+| [Agent integrations](./docs/01-agents.md) | Connect zg to Codex, Claude Code, Qwen Code, Qoder, Cursor, GitHub Copilot, VS Code, or OpenCode and verify that it works. |
 | [CLI guide](./docs/02-cli.md) | Search, index, and manage your local workspaces from the terminal. |
 | [MCP guide](./docs/03-mcp.md) | Understand which zg tools your agent can use and how access is secured. |
 | [Retrieval pipeline](./docs/04-pipeline.md) | Choose what to index, keep it fresh, and get better search results. |

--- a/docs/01-agents.md
+++ b/docs/01-agents.md
@@ -21,11 +21,14 @@ managed-rg route.
 | OpenCode | `opencode` | `~/.config/opencode/opencode.json` and the adjacent `AGENTS.md` |
 | Cursor | `cursor` | `~/.cursor/mcp.json` |
 | GitHub Copilot | `copilot` | `~/.copilot/mcp-config.json` and `~/.copilot/copilot-instructions.md` |
+| VS Code | `vscode` | the VS Code user profile `mcp.json` and `~/.copilot/instructions/zvec-grep.instructions.md` |
 
 The standard environment overrides used by each agent are respected, including
 `CODEX_HOME`, `CLAUDE_CONFIG_DIR`, `QWEN_HOME`, `QODER_CONFIG_DIR`,
 `QODER_IDE_MCP_PATH`, `QODER_IDE_EXECUTABLE`, `OPENCODE_CONFIG`,
-`CURSOR_CONFIG_DIR`, and `COPILOT_HOME`.
+`CURSOR_CONFIG_DIR`, `COPILOT_HOME`, `VSCODE_PORTABLE`, and `VSCODE_APPDATA`.
+`VSCODE_USER_DIR` overrides the complete VS Code `User` profile directory, for
+a non-default profile, VS Code Insiders, or a VS Code derivative.
 
 The current Qoder CLI package exposes both `qoder` and `qodercli` commands, but
 the installer exposes only the canonical `qoder` target. One Qoder install
@@ -50,6 +53,7 @@ zg install --target claude --target cursor --yes
 zg install --target qwen --yes
 zg install --target qoder --yes
 zg install --target copilot --yes
+zg install --target vscode --yes
 zg install --target all --yes
 ```
 
@@ -137,11 +141,43 @@ truncate. Search guidance is written to
 reads as personal instructions across all repositories. Unrelated MCP servers
 and instructions in both files are preserved.
 
-Copilot CLI and the VS Code agent host both read this user-level
-`mcp-config.json`, so one install covers both. The Copilot cloud coding agent
-and Copilot code review use separate repository-level MCP configuration and are
-not configured by `zg install`; zvec-grep indexes a local workspace, so those
-hosted surfaces cannot reach it.
+Agent Host reads this same user-level `mcp-config.json` natively, so the
+`copilot` target also covers Agent Host sessions. It does not cover VS Code's
+own agent mode, which keeps its servers in `mcp.json` and forwards them to
+Agent Host; use the `vscode` target for that.
+
+The Copilot cloud coding agent and Copilot code review use separate
+repository-level MCP configuration and are not configured by `zg install`;
+zvec-grep indexes a local workspace, so those hosted surfaces cannot reach it.
+
+For VS Code, the installer manages the `mcp.json` of the default user profile,
+so the server is available across every workspace. The profile directory is
+resolved the way VS Code resolves it: `VSCODE_PORTABLE` selects
+`<portable>/user-data/User`, `VSCODE_APPDATA` selects `<appdata>/Code/User`,
+and otherwise it is `%APPDATA%\Code\User` on Windows,
+`~/Library/Application Support/Code/User` on macOS, and
+`${XDG_CONFIG_HOME:-~/.config}/Code/User` on Linux. Set `VSCODE_USER_DIR` to
+point at a different profile directory. Comments and unrelated servers in an
+existing `mcp.json` are preserved.
+
+`--mcp-transport stdio` writes a `type: "stdio"` entry and `--mcp-transport
+http` writes a `type: "http"` entry. VS Code validates server entries with
+`additionalProperties: false`, so the managed entry carries only fields from
+its stdio and HTTP schemas; there is no per-server timeout or tool allowlist to
+manage, and `--mcp-tool-timeout` does not apply. An HTTP token is referenced as
+`${env:NAME}` rather than `${input:NAME}`, which keeps the entry forwardable to
+Agent Host — VS Code does not forward servers that require interactive input.
+
+VS Code search guidance is written to
+`${COPILOT_HOME:-~/.copilot}/instructions/zvec-grep.instructions.md`, the
+harness-agnostic user instructions folder that VS Code, Agent Host, and Copilot
+CLI all read. The file carries an `applyTo: '**'` frontmatter header, which is
+what makes VS Code apply it automatically; the managed block sits below that
+header. Installing both `copilot` and `vscode` therefore leaves the same
+guidance in two files, because Copilot CLI applies
+`copilot-instructions.md` on every turn while a modular `.instructions.md` file
+is path-scoped. Uninstall removes the managed block and deletes the
+instructions file when nothing else remains in it.
 
 Restart the selected agent, or open a new session, after installation.
 
@@ -223,6 +259,7 @@ zg uninstall --target codex --yes
 zg uninstall --target qwen --yes
 zg uninstall --target qoder --yes
 zg uninstall --target copilot --yes
+zg uninstall --target vscode --yes
 zg uninstall --target all --yes
 ```
 

--- a/docs/01-agents.md
+++ b/docs/01-agents.md
@@ -20,11 +20,12 @@ managed-rg route.
 | Qoder CLI and IDE | `qoder` | `~/.qoder/settings.json`, `~/.qoder/AGENTS.md`, and the IDE user-level `~/.qoder/mcp.json` |
 | OpenCode | `opencode` | `~/.config/opencode/opencode.json` and the adjacent `AGENTS.md` |
 | Cursor | `cursor` | `~/.cursor/mcp.json` |
+| GitHub Copilot | `copilot` | `~/.copilot/mcp-config.json` and `~/.copilot/copilot-instructions.md` |
 
 The standard environment overrides used by each agent are respected, including
 `CODEX_HOME`, `CLAUDE_CONFIG_DIR`, `QWEN_HOME`, `QODER_CONFIG_DIR`,
-`QODER_IDE_MCP_PATH`, `QODER_IDE_EXECUTABLE`, `OPENCODE_CONFIG`, and
-`CURSOR_CONFIG_DIR`.
+`QODER_IDE_MCP_PATH`, `QODER_IDE_EXECUTABLE`, `OPENCODE_CONFIG`,
+`CURSOR_CONFIG_DIR`, and `COPILOT_HOME`.
 
 The current Qoder CLI package exposes both `qoder` and `qodercli` commands, but
 the installer exposes only the canonical `qoder` target. One Qoder install
@@ -48,6 +49,7 @@ zg install --target codex --yes
 zg install --target claude --target cursor --yes
 zg install --target qwen --yes
 zg install --target qoder --yes
+zg install --target copilot --yes
 zg install --target all --yes
 ```
 
@@ -122,6 +124,24 @@ to a remote Embedding provider. In a headless session where Qoder cannot ask the
 user, the agent stops without granting access. Neither question tool should
 collect a token, API key, or password. Provider credentials remain separate
 from this data authorization.
+
+For GitHub Copilot, the installer manages the user-level MCP configuration at
+`${COPILOT_HOME:-~/.copilot}/mcp-config.json`. `--mcp-transport stdio` writes a
+`type: "local"` entry that launches `zg server --stdio`; `--mcp-transport http`
+writes a `type: "http"` entry pointing at the local server URL, with an optional
+`Authorization` header when `--mcp-token-env` is set. The managed entry sets
+`tools` to `["*"]` so the toolset selected by `--mcp-toolset` decides which
+tools Copilot sees, rather than pinning a list that `--mcp-toolset full` would
+truncate. Search guidance is written to
+`${COPILOT_HOME:-~/.copilot}/copilot-instructions.md`, which GitHub Copilot CLI
+reads as personal instructions across all repositories. Unrelated MCP servers
+and instructions in both files are preserved.
+
+Copilot CLI and the VS Code agent host both read this user-level
+`mcp-config.json`, so one install covers both. The Copilot cloud coding agent
+and Copilot code review use separate repository-level MCP configuration and are
+not configured by `zg install`; zvec-grep indexes a local workspace, so those
+hosted surfaces cannot reach it.
 
 Restart the selected agent, or open a new session, after installation.
 
@@ -202,6 +222,7 @@ Use the same target names to remove only zvec-grep-managed entries:
 zg uninstall --target codex --yes
 zg uninstall --target qwen --yes
 zg uninstall --target qoder --yes
+zg uninstall --target copilot --yes
 zg uninstall --target all --yes
 ```
 

--- a/docs/02-cli.md
+++ b/docs/02-cli.md
@@ -146,8 +146,8 @@ scripts.
 ## `zg install` and `zg uninstall`
 
 ```text
-zg install [--target codex|claude|qwen|qoder|opencode|cursor|all|auto] [--mcp-transport stdio|http] [--mcp-toolset agent|full] [--yes] [--force]
-zg uninstall [--target codex|claude|qwen|qoder|opencode|cursor|all|auto] [--yes]
+zg install [--target codex|claude|qwen|qoder|opencode|cursor|copilot|all|auto] [--mcp-transport stdio|http] [--mcp-toolset agent|full] [--yes] [--force]
+zg uninstall [--target codex|claude|qwen|qoder|opencode|cursor|copilot|all|auto] [--yes]
 ```
 
 `--target` is repeatable. `qoder` is the single Qoder target and configures

--- a/docs/02-cli.md
+++ b/docs/02-cli.md
@@ -146,8 +146,8 @@ scripts.
 ## `zg install` and `zg uninstall`
 
 ```text
-zg install [--target codex|claude|qwen|qoder|opencode|cursor|copilot|all|auto] [--mcp-transport stdio|http] [--mcp-toolset agent|full] [--yes] [--force]
-zg uninstall [--target codex|claude|qwen|qoder|opencode|cursor|copilot|all|auto] [--yes]
+zg install [--target codex|claude|qwen|qoder|opencode|cursor|copilot|vscode|all|auto] [--mcp-transport stdio|http] [--mcp-toolset agent|full] [--yes] [--force]
+zg uninstall [--target codex|claude|qwen|qoder|opencode|cursor|copilot|vscode|all|auto] [--yes]
 ```
 
 `--target` is repeatable. `qoder` is the single Qoder target and configures

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@ interfaces.
 
 | I want to… | Read |
 | --- | --- |
-| Connect Codex, Claude Code, Qwen Code, Cursor, GitHub Copilot, or OpenCode | [Agent integrations](./01-agents.md) |
+| Connect Codex, Claude Code, Qwen Code, Cursor, GitHub Copilot, VS Code, or OpenCode | [Agent integrations](./01-agents.md) |
 | Use zg directly from a terminal | [CLI guide](./02-cli.md) |
 | Understand the tools exposed to an agent | [MCP guide](./03-mcp.md) |
 | Understand indexing, updates, and search routes | [Retrieval pipeline](./04-pipeline.md) |

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@ interfaces.
 
 | I want to… | Read |
 | --- | --- |
-| Connect Codex, Claude Code, Qwen Code, Cursor, or OpenCode | [Agent integrations](./01-agents.md) |
+| Connect Codex, Claude Code, Qwen Code, Cursor, GitHub Copilot, or OpenCode | [Agent integrations](./01-agents.md) |
 | Use zg directly from a terminal | [CLI guide](./02-cli.md) |
 | Understand the tools exposed to an agent | [MCP guide](./03-mcp.md) |
 | Understand indexing, updates, and search routes | [Retrieval pipeline](./04-pipeline.md) |

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -57,6 +57,9 @@ const ENVIRONMENT_VARIABLES = {
   OPENCODE_CONFIG: "OpenCode configuration file used by zg install",
   CURSOR_CONFIG_DIR: "Cursor configuration directory used by zg install",
   COPILOT_HOME: "GitHub Copilot configuration directory used by zg install",
+  VSCODE_USER_DIR: "VS Code User profile directory used by zg install",
+  VSCODE_PORTABLE: "VS Code portable-mode directory honored by zg install",
+  VSCODE_APPDATA: "VS Code application data directory honored by zg install",
 } as const;
 
 type EnvironmentVariableName = keyof typeof ENVIRONMENT_VARIABLES;
@@ -302,10 +305,11 @@ ${formatEnvironmentVariables([
 See zg help environment for daemon startup scope.`;
     case "install":
       return `Usage:
-  zg install [--target codex|claude|qwen|qoder|opencode|cursor|copilot|all|auto] [--mcp-transport stdio|http] [--mcp-toolset agent|full] [--yes] [--force]
+  zg install [--target codex|claude|qwen|qoder|opencode|cursor|copilot|vscode|all|auto] [--mcp-transport stdio|http] [--mcp-toolset agent|full] [--yes] [--force]
 
 Options:
-  --target <agent>                  codex, claude, qwen, qoder, opencode, cursor, copilot, auto, or all; repeatable
+  --target <agent>                  codex, claude, qwen, qoder, opencode, cursor, copilot, vscode, auto, or all;
+                                    repeatable
   --mcp-transport <stdio|http>      MCP connection mode (default: stdio)
   --mcp-toolset <agent|full>        Daemon MCP toolset (default: agent)
   --mcp-tool-timeout <seconds>      MCP tool timeout where supported (default: 600)
@@ -313,14 +317,16 @@ Options:
   --yes                             Install detected agents without prompting
   --force                           Replace conflicting unmanaged configuration
 
-The qoder target configures Qoder CLI and Qoder IDE together.
+The qoder target configures Qoder CLI and Qoder IDE together. The copilot
+target configures GitHub Copilot CLI; vscode configures the VS Code user
+profile separately.
 
 Interactive setup detects supported agents, configures stdio by default, and
 starts the shared daemon. In stdio mode an agent reconnect also starts the
 daemon automatically after a reboot. HTTP users manage later daemon restarts.
-Codex, Claude Code, Qwen Code, Qoder CLI, OpenCode, and GitHub Copilot also
-receive managed guidance. Qoder IDE has no supported global Rules file, so only
-its MCP configuration is managed.
+Codex, Claude Code, Qwen Code, Qoder CLI, OpenCode, GitHub Copilot, and VS Code
+also receive managed guidance. Qoder IDE has no supported global Rules file, so
+only its MCP configuration is managed.
 Codex and Claude Code receive local tool pre-approval. Qoder's CLI-backed
 runtime receives exact pre-approval for zvec_grep_search and zvec_grep_rg. Remote Embedding
 authorization remains separate and is requested by zvec-grep on first remote
@@ -328,7 +334,7 @@ use. Restart the agent or open a new session after installation. This does not
 install the npm package.`;
     case "uninstall":
       return `Usage:
-  zg uninstall [--target codex|claude|qwen|qoder|opencode|cursor|copilot|all|auto] [--yes]
+  zg uninstall [--target codex|claude|qwen|qoder|opencode|cursor|copilot|vscode|all|auto] [--yes]
 
 Removes zvec-grep-managed MCP configuration, agent-specific approval, and
 guidance. The qoder target removes the managed Qoder CLI and IDE integration

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -56,6 +56,7 @@ const ENVIRONMENT_VARIABLES = {
     "Qoder IDE executable used by automatic install-target detection",
   OPENCODE_CONFIG: "OpenCode configuration file used by zg install",
   CURSOR_CONFIG_DIR: "Cursor configuration directory used by zg install",
+  COPILOT_HOME: "GitHub Copilot configuration directory used by zg install",
 } as const;
 
 type EnvironmentVariableName = keyof typeof ENVIRONMENT_VARIABLES;
@@ -301,10 +302,10 @@ ${formatEnvironmentVariables([
 See zg help environment for daemon startup scope.`;
     case "install":
       return `Usage:
-  zg install [--target codex|claude|qwen|qoder|opencode|cursor|all|auto] [--mcp-transport stdio|http] [--mcp-toolset agent|full] [--yes] [--force]
+  zg install [--target codex|claude|qwen|qoder|opencode|cursor|copilot|all|auto] [--mcp-transport stdio|http] [--mcp-toolset agent|full] [--yes] [--force]
 
 Options:
-  --target <agent>                  codex, claude, qwen, qoder, opencode, cursor, auto, or all; repeatable
+  --target <agent>                  codex, claude, qwen, qoder, opencode, cursor, copilot, auto, or all; repeatable
   --mcp-transport <stdio|http>      MCP connection mode (default: stdio)
   --mcp-toolset <agent|full>        Daemon MCP toolset (default: agent)
   --mcp-tool-timeout <seconds>      MCP tool timeout where supported (default: 600)
@@ -317,9 +318,9 @@ The qoder target configures Qoder CLI and Qoder IDE together.
 Interactive setup detects supported agents, configures stdio by default, and
 starts the shared daemon. In stdio mode an agent reconnect also starts the
 daemon automatically after a reboot. HTTP users manage later daemon restarts.
-Codex, Claude Code, Qwen Code, Qoder CLI, and OpenCode also receive managed
-guidance. Qoder IDE has no supported global Rules file, so only its MCP
-configuration is managed.
+Codex, Claude Code, Qwen Code, Qoder CLI, OpenCode, and GitHub Copilot also
+receive managed guidance. Qoder IDE has no supported global Rules file, so only
+its MCP configuration is managed.
 Codex and Claude Code receive local tool pre-approval. Qoder's CLI-backed
 runtime receives exact pre-approval for zvec_grep_search and zvec_grep_rg. Remote Embedding
 authorization remains separate and is requested by zvec-grep on first remote
@@ -327,7 +328,7 @@ use. Restart the agent or open a new session after installation. This does not
 install the npm package.`;
     case "uninstall":
       return `Usage:
-  zg uninstall [--target codex|claude|qwen|qoder|opencode|cursor|all|auto] [--yes]
+  zg uninstall [--target codex|claude|qwen|qoder|opencode|cursor|copilot|all|auto] [--yes]
 
 Removes zvec-grep-managed MCP configuration, agent-specific approval, and
 guidance. The qoder target removes the managed Qoder CLI and IDE integration

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -114,6 +114,15 @@ const AGENT_INSTALLERS: readonly AgentInstaller[] = [
     install: installCopilotIntegration,
     uninstall: uninstallCopilotIntegration,
   },
+  {
+    id: "vscode",
+    aliases: ["vs-code", "code"],
+    label: "VS Code",
+    executables: ["code", "code-insiders"],
+    detect: vsCodeUserDirectoryIsAvailable,
+    install: installVsCodeIntegration,
+    uninstall: uninstallVsCodeIntegration,
+  },
 ];
 
 const ZVEC_GREP_CONFIG_START = "# ZVEC_GREP_START";
@@ -144,6 +153,14 @@ const QODER_IDE_MCP_DESCRIPTION = "Managed by zg install";
 // advertised toolset rather than pinning a tool list that `--mcp-toolset full`
 // would silently truncate.
 const COPILOT_MCP_TOOLS = ["*"];
+// VS Code applies a user instructions file automatically only when its
+// `applyTo` glob matches; `**` is the documented "always apply" pattern.
+const VSCODE_INSTRUCTIONS_FRONTMATTER = `---
+applyTo: '**'
+---
+`;
+const VSCODE_INSTRUCTIONS_FILE = "zvec-grep.instructions.md";
+const VSCODE_PRODUCT_DIRECTORY = "Code";
 const DEFAULT_MCP_TOOL_TIMEOUT_SECONDS = 600;
 
 export async function runInstall(parsed: ParsedArgs): Promise<void> {
@@ -564,6 +581,97 @@ async function uninstallCopilotIntegration(): Promise<InstallAgentResult> {
   return { files: [configPath, guidancePath] };
 }
 
+async function installVsCodeIntegration(
+  options: InstallAgentOptions,
+): Promise<InstallAgentResult> {
+  const configPath = resolveVsCodeMcpConfigPath();
+  const guidancePath = resolveVsCodeGuidancePath();
+
+  await updateJsoncMcpSettings({
+    path: configPath,
+    containerKey: "servers",
+    force: options.force,
+    label: "VS Code",
+    server: vsCodeMcpServer(options),
+    isManaged: isManagedJsonMcpServer,
+  });
+
+  // VS Code reads user instructions from the harness-agnostic
+  // `~/.copilot/instructions` folder, so the guidance needs the frontmatter
+  // header before the managed block rather than a bare markdown file.
+  if (!(await readTextFileIfExists(guidancePath)).trim()) {
+    await writeTextFileAtomic(guidancePath, VSCODE_INSTRUCTIONS_FRONTMATTER);
+  }
+  await writeMarkedFile({
+    path: guidancePath,
+    startMarker: ZVEC_GREP_AGENTS_START,
+    endMarker: ZVEC_GREP_AGENTS_END,
+    block: agentGuidanceBlock(),
+    force: true,
+  });
+
+  return { files: [configPath, guidancePath] };
+}
+
+async function uninstallVsCodeIntegration(): Promise<InstallAgentResult> {
+  const configPath = resolveVsCodeMcpConfigPath();
+  const guidancePath = resolveVsCodeGuidancePath();
+
+  await removeJsoncMcpSettings(
+    configPath,
+    "VS Code",
+    isManagedJsonMcpServer,
+    "servers",
+  );
+  await removeMarkedFile({
+    path: guidancePath,
+    startMarker: ZVEC_GREP_AGENTS_START,
+    endMarker: ZVEC_GREP_AGENTS_END,
+  });
+  await removeVsCodeGuidanceFileIfEmpty(guidancePath);
+
+  return { files: [configPath, guidancePath] };
+}
+
+// VS Code validates `servers` entries with `additionalProperties: false`, so
+// this entry carries only fields from its stdio and http schemas. `${env:...}`
+// keeps the entry forwardable to Agent Host, which drops servers that need
+// interactive `${input:...}` values.
+function vsCodeMcpServer(
+  options: InstallAgentOptions,
+): Record<string, unknown> {
+  if (options.transport === "stdio") {
+    return {
+      type: "stdio",
+      command: "zg",
+      args: stdioArgs(options.mcpToolset),
+    };
+  }
+
+  return {
+    type: "http",
+    url: resolveServerUrl(),
+    ...(options.mcpTokenEnv
+      ? {
+          headers: {
+            Authorization: `Bearer \${env:${options.mcpTokenEnv}}`,
+          },
+        }
+      : {}),
+  };
+}
+
+async function removeVsCodeGuidanceFileIfEmpty(path: string): Promise<void> {
+  const remaining = await readTextFileIfExists(path);
+  if (!remaining.trim()) return;
+  if (remaining.trim() !== VSCODE_INSTRUCTIONS_FRONTMATTER.trim()) return;
+  try {
+    await unlink(path);
+  } catch (error) {
+    if (!isNodeError(error) || error.code !== "ENOENT") throw error;
+  }
+}
+
 async function resolveInstallers(
   parsed: ParsedArgs,
   action: "install" | "uninstall",
@@ -933,6 +1041,59 @@ function resolveCopilotHome(): string {
   return resolve(process.env.COPILOT_HOME || resolve(homedir(), ".copilot"));
 }
 
+function resolveVsCodeUserDirectory(): string {
+  const configured = process.env.VSCODE_USER_DIR?.trim();
+  if (configured) return resolve(configured);
+
+  const portable = process.env.VSCODE_PORTABLE?.trim();
+  if (portable) return resolve(portable, "user-data", "User");
+
+  return resolve(
+    vsCodeApplicationDataDirectory(),
+    VSCODE_PRODUCT_DIRECTORY,
+    "User",
+  );
+}
+
+// Mirrors the user-data path VS Code itself resolves, so the managed entry
+// lands in the default profile rather than a guessed location.
+function vsCodeApplicationDataDirectory(): string {
+  const configured = process.env.VSCODE_APPDATA?.trim();
+  if (configured) return resolve(configured);
+
+  if (process.platform === "win32") {
+    const appData = process.env.APPDATA?.trim();
+    return appData
+      ? resolve(appData)
+      : resolve(homedir(), "AppData", "Roaming");
+  }
+  if (process.platform === "darwin") {
+    return resolve(homedir(), "Library", "Application Support");
+  }
+  const xdgConfigHome = process.env.XDG_CONFIG_HOME?.trim();
+  return xdgConfigHome ? resolve(xdgConfigHome) : resolve(homedir(), ".config");
+}
+
+function resolveVsCodeMcpConfigPath(): string {
+  return resolve(resolveVsCodeUserDirectory(), "mcp.json");
+}
+
+function resolveVsCodeGuidancePath(): string {
+  return resolve(
+    resolveCopilotHome(),
+    "instructions",
+    VSCODE_INSTRUCTIONS_FILE,
+  );
+}
+
+async function vsCodeUserDirectoryIsAvailable(): Promise<boolean> {
+  try {
+    return (await stat(resolveVsCodeUserDirectory())).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
 function resolveQoderHome(): string {
   return resolve(process.env.QODER_CONFIG_DIR || resolve(homedir(), ".qoder"));
 }
@@ -1058,7 +1219,7 @@ function resolveQwenHomeValue(value: string): string {
 
 async function installJsonMcpServer(options: {
   path: string;
-  containerKey: "mcp" | "mcpServers";
+  containerKey: McpContainerKey;
   server: Record<string, unknown>;
   force: boolean;
   label: string;
@@ -1093,7 +1254,7 @@ async function installJsonMcpServer(options: {
 
 async function uninstallJsonMcpServer(
   path: string,
-  containerKey: "mcp" | "mcpServers",
+  containerKey: McpContainerKey,
 ): Promise<void> {
   const existing = await readTextFileIfExists(path);
   if (!existing) return;
@@ -1114,6 +1275,11 @@ async function uninstallJsonMcpServer(
 }
 
 type JsonObject = Record<string, unknown>;
+
+// Hosts disagree on the object that holds MCP server entries: Codex/Claude/
+// Cursor/Qoder/Copilot use `mcpServers`, OpenCode uses `mcp`, VS Code uses
+// `servers`.
+type McpContainerKey = "mcp" | "mcpServers" | "servers";
 
 async function updateClaudeMcpConfig(options: {
   path: string;
@@ -1645,6 +1811,7 @@ type JsoncMcpSettingsOptions = {
   label: string;
   server: Record<string, unknown>;
   isManaged: (value: unknown) => boolean;
+  containerKey?: McpContainerKey;
 };
 
 async function assertQoderMcpSettingsReplaceable(
@@ -1672,12 +1839,13 @@ async function assertQoderMcpSettingsReplaceable(
 async function updateJsoncMcpSettings(
   options: JsoncMcpSettingsOptions,
 ): Promise<JsonObject> {
+  const containerKey = options.containerKey ?? "mcpServers";
   const existing = await readTextFileIfExists(options.path);
   let source = existing.trim() ? existing : "{}\n";
   const root = parseJsoncSettings(options.path, source, options.label);
-  validateMcpSettingsContainer(options.path, root);
+  validateMcpSettingsContainer(options.path, root, containerKey);
 
-  const mcpServers = isJsonObject(root.mcpServers) ? root.mcpServers : {};
+  const mcpServers = isJsonObject(root[containerKey]) ? root[containerKey] : {};
   const current = mcpServers.zvec_grep;
   if (current !== undefined && !options.isManaged(current) && !options.force) {
     throw new Error(
@@ -1687,7 +1855,7 @@ async function updateJsoncMcpSettings(
 
   source = editJsonWithComments(
     source,
-    ["mcpServers", "zvec_grep"],
+    [containerKey, "zvec_grep"],
     options.server,
   );
   await writeTextFileAtomic(options.path, ensureTrailingNewline(source));
@@ -1698,26 +1866,27 @@ async function removeJsoncMcpSettings(
   path: string,
   label: string,
   isManaged: (value: unknown) => boolean,
+  containerKey: McpContainerKey = "mcpServers",
 ): Promise<void> {
   const existing = await readTextFileIfExists(path);
   if (!existing.trim()) return;
 
   let source = existing;
   const root = parseJsoncSettings(path, source, label);
-  validateMcpSettingsContainer(path, root);
-  const mcpServers = isJsonObject(root.mcpServers) ? root.mcpServers : {};
+  validateMcpSettingsContainer(path, root, containerKey);
+  const mcpServers = isJsonObject(root[containerKey]) ? root[containerKey] : {};
 
   if (isManaged(mcpServers.zvec_grep)) {
     source = hasJsoncComments(source)
       ? removeJsoncPropertyPreservingComments(source, [
-          "mcpServers",
+          containerKey,
           "zvec_grep",
         ])
       : editJsonWithComments(
           source,
           Object.keys(mcpServers).length === 1
-            ? ["mcpServers"]
-            : ["mcpServers", "zvec_grep"],
+            ? [containerKey]
+            : [containerKey, "zvec_grep"],
           undefined,
         );
   }
@@ -1742,9 +1911,13 @@ function parseJsoncSettings(
   return parsed;
 }
 
-function validateMcpSettingsContainer(path: string, root: JsonObject): void {
-  if (root.mcpServers !== undefined && !isJsonObject(root.mcpServers)) {
-    throw new Error(`Invalid mcpServers configuration in ${path}.`);
+function validateMcpSettingsContainer(
+  path: string,
+  root: JsonObject,
+  containerKey: McpContainerKey = "mcpServers",
+): void {
+  if (root[containerKey] !== undefined && !isJsonObject(root[containerKey])) {
+    throw new Error(`Invalid ${containerKey} configuration in ${path}.`);
   }
 }
 

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -106,6 +106,14 @@ const AGENT_INSTALLERS: readonly AgentInstaller[] = [
     install: installQoderIntegration,
     uninstall: uninstallQoderIntegration,
   },
+  {
+    id: "copilot",
+    aliases: ["github-copilot", "copilot-cli"],
+    label: "GitHub Copilot",
+    executables: ["copilot"],
+    install: installCopilotIntegration,
+    uninstall: uninstallCopilotIntegration,
+  },
 ];
 
 const ZVEC_GREP_CONFIG_START = "# ZVEC_GREP_START";
@@ -131,6 +139,11 @@ const QODER_MCP_PERMISSIONS = QODER_MCP_PERMISSION_RULES.map(
 const QODER_CLI_MCP_DESCRIPTION = "Managed by zg install";
 const QODER_PERMISSION_OWNERSHIP_PREFIX = `${QODER_CLI_MCP_DESCRIPTION}; managed permissions=`;
 const QODER_IDE_MCP_DESCRIPTION = "Managed by zg install";
+// GitHub Copilot filters MCP tools client-side. zvec-grep already scopes what
+// the server exposes through `--mcp-toolset`, so the managed entry allows the
+// advertised toolset rather than pinning a tool list that `--mcp-toolset full`
+// would silently truncate.
+const COPILOT_MCP_TOOLS = ["*"];
 const DEFAULT_MCP_TOOL_TIMEOUT_SECONDS = 600;
 
 export async function runInstall(parsed: ParsedArgs): Promise<void> {
@@ -490,6 +503,65 @@ async function uninstallQoderIntegration(): Promise<InstallAgentResult> {
   });
 
   return { files: [settingsPath, ...ideMcpPaths, guidancePath] };
+}
+
+async function installCopilotIntegration(
+  options: InstallAgentOptions,
+): Promise<InstallAgentResult> {
+  const copilotHome = resolveCopilotHome();
+  const configPath = resolve(copilotHome, "mcp-config.json");
+  const guidancePath = resolve(copilotHome, "copilot-instructions.md");
+
+  await installJsonMcpServer({
+    path: configPath,
+    containerKey: "mcpServers",
+    server:
+      options.transport === "stdio"
+        ? {
+            type: "local",
+            command: "zg",
+            args: stdioArgs(options.mcpToolset),
+            tools: COPILOT_MCP_TOOLS,
+          }
+        : {
+            type: "http",
+            url: resolveServerUrl(),
+            ...(options.mcpTokenEnv
+              ? {
+                  headers: {
+                    Authorization: `Bearer \${${options.mcpTokenEnv}}`,
+                  },
+                }
+              : {}),
+            tools: COPILOT_MCP_TOOLS,
+          },
+    force: options.force,
+    label: "GitHub Copilot",
+  });
+  await writeMarkedFile({
+    path: guidancePath,
+    startMarker: ZVEC_GREP_AGENTS_START,
+    endMarker: ZVEC_GREP_AGENTS_END,
+    block: agentGuidanceBlock(),
+    force: true,
+  });
+
+  return { files: [configPath, guidancePath] };
+}
+
+async function uninstallCopilotIntegration(): Promise<InstallAgentResult> {
+  const copilotHome = resolveCopilotHome();
+  const configPath = resolve(copilotHome, "mcp-config.json");
+  const guidancePath = resolve(copilotHome, "copilot-instructions.md");
+
+  await uninstallJsonMcpServer(configPath, "mcpServers");
+  await removeMarkedFile({
+    path: guidancePath,
+    startMarker: ZVEC_GREP_AGENTS_START,
+    endMarker: ZVEC_GREP_AGENTS_END,
+  });
+
+  return { files: [configPath, guidancePath] };
 }
 
 async function resolveInstallers(
@@ -855,6 +927,10 @@ function resolveCursorConfigPath(): string {
     process.env.CURSOR_CONFIG_DIR ?? resolve(homedir(), ".cursor"),
     "mcp.json",
   );
+}
+
+function resolveCopilotHome(): string {
+  return resolve(process.env.COPILOT_HOME || resolve(homedir(), ".copilot"));
 }
 
 function resolveQoderHome(): string {

--- a/test/install.test.mjs
+++ b/test/install.test.mjs
@@ -39,6 +39,7 @@ test("interactive installer marker follows the active agent", () => {
   assert.match(qwen[2], /○ OpenCode\s+not found/);
   assert.match(qwen[3], /○ Cursor\s+not found/);
   assert.match(qwen[4], /● Qwen Code\s+not found/);
+  assert.match(qwen[6], /○ GitHub Copilot\s+not found/);
   assert.match(codex.at(-1), /Use ↑↓ to move · Enter to select/);
   assert.doesNotMatch(codex.join("\n"), /Space|\[●\]/);
 });
@@ -1875,7 +1876,7 @@ test(
       assert.match(stdout, /Qoder/);
       assert.doesNotMatch(
         stdout,
-        /Claude Code|Codex|OpenCode|Cursor|Qwen Code/,
+        /Claude Code|Codex|OpenCode|Cursor|Qwen Code|GitHub Copilot/,
       );
       const { cli, ide } = await readQoderConfigs(qoderConfigDirectory);
       assert.equal(cli.mcpServers.zvec_grep.command, "zg");
@@ -1926,7 +1927,10 @@ test(
     );
 
     assert.match(stdout, /Qoder/);
-    assert.doesNotMatch(stdout, /Claude Code|Codex|OpenCode|Cursor|Qwen Code/);
+    assert.doesNotMatch(
+      stdout,
+      /Claude Code|Codex|OpenCode|Cursor|Qwen Code|GitHub Copilot/,
+    );
     const cli = JSON.parse(
       await readFile(join(qoderConfigDirectory, "settings.json"), "utf8"),
     );
@@ -2146,13 +2150,255 @@ test(
     );
 
     assert.match(stdout, /Qwen Code/);
-    assert.doesNotMatch(stdout, /Claude Code|Codex|OpenCode|Cursor/);
+    assert.doesNotMatch(
+      stdout,
+      /Claude Code|Codex|OpenCode|Cursor|GitHub Copilot/,
+    );
     const config = JSON.parse(
       await readFile(join(qwenHome, "settings.json"), "utf8"),
     );
     assert.equal(config.mcpServers.zvec_grep.command, "zg");
   },
 );
+
+test("GitHub Copilot installer manages a user-level stdio MCP server", async (t) => {
+  const temporaryDirectory = await mkdtemp(
+    join(tmpdir(), "zvec-grep-install-copilot-"),
+  );
+  const copilotHome = join(temporaryDirectory, ".copilot");
+  const configPath = join(copilotHome, "mcp-config.json");
+  const guidancePath = join(copilotHome, "copilot-instructions.md");
+  t.after(async () => {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  });
+
+  await mkdir(copilotHome, { recursive: true });
+  await writeFile(guidancePath, "# Existing Copilot instructions\n");
+  await writeFile(
+    configPath,
+    `${JSON.stringify(
+      {
+        mcpServers: {
+          other: { type: "local", command: "npx", args: ["@other/server"] },
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  await installTarget("copilot", { COPILOT_HOME: copilotHome });
+
+  const config = JSON.parse(await readFile(configPath, "utf8"));
+  assert.deepEqual(config.mcpServers.other, {
+    type: "local",
+    command: "npx",
+    args: ["@other/server"],
+  });
+  assert.deepEqual(config.mcpServers.zvec_grep, {
+    type: "local",
+    command: "zg",
+    args: ["server", "--stdio"],
+    tools: ["*"],
+  });
+
+  const guidance = await readFile(guidancePath, "utf8");
+  assert.match(guidance, /^# Existing Copilot instructions$/m);
+  assert.match(guidance, /<!-- ZVEC_GREP_START -->/);
+  assert.match(guidance, /zvec_grep_search/);
+  assert.match(guidance, /^## zvec-grep$/m);
+
+  await installTarget("copilot", { COPILOT_HOME: copilotHome });
+  const repeated = await readFile(configPath, "utf8");
+  assert.equal(repeated, `${JSON.stringify(config, null, 2)}\n`);
+  assert.equal(await readFile(guidancePath, "utf8"), guidance);
+
+  await uninstallTarget("copilot", { COPILOT_HOME: copilotHome });
+  const uninstalled = JSON.parse(await readFile(configPath, "utf8"));
+  assert.equal(uninstalled.mcpServers.zvec_grep, undefined);
+  assert.deepEqual(uninstalled.mcpServers.other, {
+    type: "local",
+    command: "npx",
+    args: ["@other/server"],
+  });
+  const remainingGuidance = await readFile(guidancePath, "utf8");
+  assert.match(remainingGuidance, /^# Existing Copilot instructions$/m);
+  assert.doesNotMatch(remainingGuidance, /ZVEC_GREP_START/);
+});
+
+test("GitHub Copilot installer writes an HTTP MCP entry", async (t) => {
+  const temporaryDirectory = await mkdtemp(
+    join(tmpdir(), "zvec-grep-install-copilot-http-"),
+  );
+  const copilotHome = join(temporaryDirectory, ".copilot");
+  const configPath = join(copilotHome, "mcp-config.json");
+  t.after(async () => {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  });
+
+  await installTarget("copilot", { COPILOT_HOME: copilotHome }, [
+    "--mcp-transport",
+    "http",
+    "--mcp-toolset",
+    "full",
+    "--mcp-token-env",
+    "ZVEC_GREP_SERVER_TOKEN",
+  ]);
+
+  const config = JSON.parse(await readFile(configPath, "utf8"));
+  assert.deepEqual(config.mcpServers.zvec_grep, {
+    type: "http",
+    url: "http://127.0.0.1:7999/mcp",
+    headers: {
+      Authorization: "Bearer ${ZVEC_GREP_SERVER_TOKEN}",
+    },
+    tools: ["*"],
+  });
+});
+
+test("GitHub Copilot installer records the selected MCP toolset", async (t) => {
+  const temporaryDirectory = await mkdtemp(
+    join(tmpdir(), "zvec-grep-install-copilot-toolset-"),
+  );
+  const copilotHome = join(temporaryDirectory, ".copilot");
+  t.after(async () => {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  });
+
+  await installTarget("copilot", { COPILOT_HOME: copilotHome }, [
+    "--mcp-toolset",
+    "full",
+  ]);
+
+  const config = JSON.parse(
+    await readFile(join(copilotHome, "mcp-config.json"), "utf8"),
+  );
+  assert.deepEqual(config.mcpServers.zvec_grep.args, [
+    "server",
+    "--stdio",
+    "--mcp-toolset",
+    "full",
+  ]);
+});
+
+test("GitHub Copilot installer requires --force to replace an unmanaged entry", async (t) => {
+  const temporaryDirectory = await mkdtemp(
+    join(tmpdir(), "zvec-grep-install-copilot-force-"),
+  );
+  const copilotHome = join(temporaryDirectory, ".copilot");
+  const configPath = join(copilotHome, "mcp-config.json");
+  t.after(async () => {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  });
+
+  await mkdir(copilotHome, { recursive: true });
+  await writeFile(
+    configPath,
+    `${JSON.stringify(
+      {
+        mcpServers: {
+          zvec_grep: { type: "local", command: "custom-zvec", args: [] },
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  await assert.rejects(
+    () => installTarget("copilot", { COPILOT_HOME: copilotHome }),
+    /Existing unmanaged zvec_grep MCP server/,
+  );
+  const unchanged = JSON.parse(await readFile(configPath, "utf8"));
+  assert.equal(unchanged.mcpServers.zvec_grep.command, "custom-zvec");
+
+  await installTarget("copilot", { COPILOT_HOME: copilotHome }, ["--force"]);
+  const replaced = JSON.parse(await readFile(configPath, "utf8"));
+  assert.equal(replaced.mcpServers.zvec_grep.command, "zg");
+});
+
+test("GitHub Copilot uninstall preserves an unmanaged zvec_grep entry", async (t) => {
+  const temporaryDirectory = await mkdtemp(
+    join(tmpdir(), "zvec-grep-uninstall-copilot-unmanaged-"),
+  );
+  const copilotHome = join(temporaryDirectory, ".copilot");
+  const configPath = join(copilotHome, "mcp-config.json");
+  t.after(async () => {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  });
+
+  await mkdir(copilotHome, { recursive: true });
+  await writeFile(
+    configPath,
+    `${JSON.stringify(
+      {
+        mcpServers: {
+          zvec_grep: { type: "local", command: "custom-zvec", args: [] },
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  await uninstallTarget("copilot", { COPILOT_HOME: copilotHome });
+  const config = JSON.parse(await readFile(configPath, "utf8"));
+  assert.equal(config.mcpServers.zvec_grep.command, "custom-zvec");
+});
+
+test(
+  "auto target detects the GitHub Copilot CLI executable",
+  {
+    skip:
+      process.platform === "win32" ? "executable mode semantics differ" : false,
+  },
+  async (t) => {
+    const temporaryDirectory = await mkdtemp(
+      join(tmpdir(), "zvec-grep-install-auto-copilot-"),
+    );
+    const binaryDirectory = join(temporaryDirectory, "bin");
+    const copilotHome = join(temporaryDirectory, ".copilot");
+    t.after(async () => {
+      await rm(temporaryDirectory, { recursive: true, force: true });
+    });
+
+    await mkdir(binaryDirectory, { recursive: true });
+    const copilotExecutable = join(binaryDirectory, "copilot");
+    await writeFile(copilotExecutable, "#!/bin/sh\nexit 0\n");
+    await chmod(copilotExecutable, 0o755);
+
+    const { stdout } = await execFileAsync(
+      process.execPath,
+      [cliPath, "install", "--yes"],
+      {
+        env: {
+          ...process.env,
+          PATH: binaryDirectory,
+          HOME: temporaryDirectory,
+          USERPROFILE: temporaryDirectory,
+          COPILOT_HOME: copilotHome,
+          QODER_IDE_EXECUTABLE: join(temporaryDirectory, "missing-qoder-ide"),
+          ZVEC_GREP_INSTALL_SKIP_SERVER: "1",
+        },
+      },
+    );
+
+    assert.match(stdout, /GitHub Copilot/);
+    const config = JSON.parse(
+      await readFile(join(copilotHome, "mcp-config.json"), "utf8"),
+    );
+    assert.equal(config.mcpServers.zvec_grep.command, "zg");
+  },
+);
+
+test("install help documents the GitHub Copilot target", async () => {
+  const { stdout } = await execFileAsync(process.execPath, [
+    cliPath,
+    "help",
+    "install",
+  ]);
+  assert.match(stdout, /copilot/);
+});
 
 async function installCodex(codexHome, extraArgs = []) {
   await execFileAsync(

--- a/test/install.test.mjs
+++ b/test/install.test.mjs
@@ -23,6 +23,12 @@ import { ZVEC_GREP_WORKSPACE_EVIDENCE_RULES } from "../dist/prompts/zvec-grep-gu
 
 const execFileAsync = promisify(execFile);
 const cliPath = resolve("dist/cli/index.js");
+// Keeps a VS Code profile on the developer's own machine from being detected
+// by the auto-target tests.
+const missingVsCodeUserDirectory = join(
+  tmpdir(),
+  "zvec-grep-missing-vscode-user",
+);
 
 test("interactive installer marker follows the active agent", () => {
   const detected = new Set(["claude", "codex"]);
@@ -40,6 +46,7 @@ test("interactive installer marker follows the active agent", () => {
   assert.match(qwen[3], /○ Cursor\s+not found/);
   assert.match(qwen[4], /● Qwen Code\s+not found/);
   assert.match(qwen[6], /○ GitHub Copilot\s+not found/);
+  assert.match(qwen[7], /○ VS Code\s+not found/);
   assert.match(codex.at(-1), /Use ↑↓ to move · Enter to select/);
   assert.doesNotMatch(codex.join("\n"), /Space|\[●\]/);
 });
@@ -1863,6 +1870,7 @@ test(
         {
           env: {
             ...process.env,
+            VSCODE_USER_DIR: missingVsCodeUserDirectory,
             PATH: binaryDirectory,
             HOME: caseDirectory,
             USERPROFILE: caseDirectory,
@@ -1876,7 +1884,7 @@ test(
       assert.match(stdout, /Qoder/);
       assert.doesNotMatch(
         stdout,
-        /Claude Code|Codex|OpenCode|Cursor|Qwen Code|GitHub Copilot/,
+        /Claude Code|Codex|OpenCode|Cursor|Qwen Code|GitHub Copilot|VS Code/,
       );
       const { cli, ide } = await readQoderConfigs(qoderConfigDirectory);
       assert.equal(cli.mcpServers.zvec_grep.command, "zg");
@@ -1915,6 +1923,7 @@ test(
       {
         env: {
           ...process.env,
+          VSCODE_USER_DIR: missingVsCodeUserDirectory,
           PATH: binaryDirectory,
           HOME: temporaryDirectory,
           USERPROFILE: temporaryDirectory,
@@ -1929,7 +1938,7 @@ test(
     assert.match(stdout, /Qoder/);
     assert.doesNotMatch(
       stdout,
-      /Claude Code|Codex|OpenCode|Cursor|Qwen Code|GitHub Copilot/,
+      /Claude Code|Codex|OpenCode|Cursor|Qwen Code|GitHub Copilot|VS Code/,
     );
     const cli = JSON.parse(
       await readFile(join(qoderConfigDirectory, "settings.json"), "utf8"),
@@ -2093,6 +2102,7 @@ test(
       {
         env: {
           ...process.env,
+          VSCODE_USER_DIR: missingVsCodeUserDirectory,
           PATH: binaryDirectory,
           HOME: temporaryDirectory,
           CLAUDE_CONFIG_DIR: claudeConfigDirectory,
@@ -2139,6 +2149,7 @@ test(
       {
         env: {
           ...process.env,
+          VSCODE_USER_DIR: missingVsCodeUserDirectory,
           PATH: binaryDirectory,
           HOME: temporaryDirectory,
           USERPROFILE: temporaryDirectory,
@@ -2152,7 +2163,7 @@ test(
     assert.match(stdout, /Qwen Code/);
     assert.doesNotMatch(
       stdout,
-      /Claude Code|Codex|OpenCode|Cursor|GitHub Copilot/,
+      /Claude Code|Codex|OpenCode|Cursor|GitHub Copilot|VS Code/,
     );
     const config = JSON.parse(
       await readFile(join(qwenHome, "settings.json"), "utf8"),
@@ -2373,6 +2384,7 @@ test(
       {
         env: {
           ...process.env,
+          VSCODE_USER_DIR: missingVsCodeUserDirectory,
           PATH: binaryDirectory,
           HOME: temporaryDirectory,
           USERPROFILE: temporaryDirectory,
@@ -2399,6 +2411,299 @@ test("install help documents the GitHub Copilot target", async () => {
   ]);
   assert.match(stdout, /copilot/);
 });
+
+test("VS Code installer manages the user profile mcp.json", async (t) => {
+  const temporaryDirectory = await mkdtemp(
+    join(tmpdir(), "zvec-grep-install-vscode-"),
+  );
+  const userDirectory = join(temporaryDirectory, "Code", "User");
+  const copilotHome = join(temporaryDirectory, ".copilot");
+  const configPath = join(userDirectory, "mcp.json");
+  const guidancePath = join(
+    copilotHome,
+    "instructions",
+    "zvec-grep.instructions.md",
+  );
+  t.after(async () => {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  });
+
+  await mkdir(userDirectory, { recursive: true });
+  await writeFile(
+    configPath,
+    `{
+  // Keep my own server and this comment.
+  "servers": {
+    "memory": { "command": "npx", "args": ["-y", "@mcp/memory"] }
+  },
+  "inputs": []
+}
+`,
+  );
+
+  await installTarget("vscode", {
+    VSCODE_USER_DIR: userDirectory,
+    COPILOT_HOME: copilotHome,
+  });
+
+  const source = await readFile(configPath, "utf8");
+  assert.match(source, /Keep my own server and this comment\./);
+  const config = parseJsonWithComments(source);
+  assert.deepEqual(config.servers.memory, {
+    command: "npx",
+    args: ["-y", "@mcp/memory"],
+  });
+  assert.deepEqual(config.servers.zvec_grep, {
+    type: "stdio",
+    command: "zg",
+    args: ["server", "--stdio"],
+  });
+  assert.deepEqual(config.inputs, []);
+
+  const guidance = await readFile(guidancePath, "utf8");
+  assert.match(guidance, /^---\napplyTo: '\*\*'\n---$/m);
+  assert.match(guidance, /<!-- ZVEC_GREP_START -->/);
+  assert.match(guidance, /^## zvec-grep$/m);
+  assert.ok(
+    guidance.indexOf("applyTo") < guidance.indexOf("ZVEC_GREP_START"),
+    "frontmatter must precede the managed block",
+  );
+
+  await installTarget("vscode", {
+    VSCODE_USER_DIR: userDirectory,
+    COPILOT_HOME: copilotHome,
+  });
+  assert.equal(await readFile(configPath, "utf8"), source);
+  assert.equal(await readFile(guidancePath, "utf8"), guidance);
+
+  await uninstallTarget("vscode", {
+    VSCODE_USER_DIR: userDirectory,
+    COPILOT_HOME: copilotHome,
+  });
+  const uninstalled = parseJsonWithComments(await readFile(configPath, "utf8"));
+  assert.equal(uninstalled.servers.zvec_grep, undefined);
+  assert.deepEqual(uninstalled.servers.memory, {
+    command: "npx",
+    args: ["-y", "@mcp/memory"],
+  });
+  await assert.rejects(() => readFile(guidancePath, "utf8"), /ENOENT/);
+});
+
+test("VS Code installer keeps only fields VS Code accepts", async (t) => {
+  const temporaryDirectory = await mkdtemp(
+    join(tmpdir(), "zvec-grep-install-vscode-schema-"),
+  );
+  const userDirectory = join(temporaryDirectory, "Code", "User");
+  t.after(async () => {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  });
+
+  // VS Code validates `servers` entries with `additionalProperties: false`,
+  // so an extra field such as `timeout` or `tools` breaks the entry.
+  const stdioFields = new Set([
+    "type",
+    "command",
+    "args",
+    "cwd",
+    "env",
+    "envFile",
+    "dev",
+    "sandboxEnabled",
+  ]);
+  const httpFields = new Set(["type", "url", "headers", "oauth", "dev"]);
+
+  await installTarget("vscode", {
+    VSCODE_USER_DIR: userDirectory,
+    COPILOT_HOME: join(temporaryDirectory, ".copilot"),
+  });
+  const stdio = parseJsonWithComments(
+    await readFile(join(userDirectory, "mcp.json"), "utf8"),
+  );
+  for (const field of Object.keys(stdio.servers.zvec_grep)) {
+    assert.ok(stdioFields.has(field), `unexpected stdio field: ${field}`);
+  }
+
+  await installTarget(
+    "vscode",
+    {
+      VSCODE_USER_DIR: userDirectory,
+      COPILOT_HOME: join(temporaryDirectory, ".copilot"),
+    },
+    [
+      "--mcp-transport",
+      "http",
+      "--mcp-tool-timeout",
+      "900",
+      "--mcp-token-env",
+      "ZVEC_GREP_SERVER_TOKEN",
+    ],
+  );
+  const http = parseJsonWithComments(
+    await readFile(join(userDirectory, "mcp.json"), "utf8"),
+  );
+  assert.deepEqual(http.servers.zvec_grep, {
+    type: "http",
+    url: "http://127.0.0.1:7999/mcp",
+    headers: {
+      Authorization: "Bearer ${env:ZVEC_GREP_SERVER_TOKEN}",
+    },
+  });
+  for (const field of Object.keys(http.servers.zvec_grep)) {
+    assert.ok(httpFields.has(field), `unexpected http field: ${field}`);
+  }
+});
+
+test("VS Code installer requires --force to replace an unmanaged entry", async (t) => {
+  const temporaryDirectory = await mkdtemp(
+    join(tmpdir(), "zvec-grep-install-vscode-force-"),
+  );
+  const userDirectory = join(temporaryDirectory, "Code", "User");
+  const configPath = join(userDirectory, "mcp.json");
+  t.after(async () => {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  });
+
+  await mkdir(userDirectory, { recursive: true });
+  await writeFile(
+    configPath,
+    `${JSON.stringify(
+      { servers: { zvec_grep: { command: "custom-zvec", args: [] } } },
+      null,
+      2,
+    )}\n`,
+  );
+
+  await assert.rejects(
+    () =>
+      installTarget("vscode", {
+        VSCODE_USER_DIR: userDirectory,
+        COPILOT_HOME: join(temporaryDirectory, ".copilot"),
+      }),
+    /Existing unmanaged zvec_grep MCP server/,
+  );
+
+  await installTarget(
+    "vscode",
+    {
+      VSCODE_USER_DIR: userDirectory,
+      COPILOT_HOME: join(temporaryDirectory, ".copilot"),
+    },
+    ["--force"],
+  );
+  const config = parseJsonWithComments(await readFile(configPath, "utf8"));
+  assert.equal(config.servers.zvec_grep.command, "zg");
+
+  // Uninstall must leave an unmanaged entry alone.
+  await writeFile(
+    configPath,
+    `${JSON.stringify(
+      { servers: { zvec_grep: { command: "custom-zvec", args: [] } } },
+      null,
+      2,
+    )}\n`,
+  );
+  await uninstallTarget("vscode", {
+    VSCODE_USER_DIR: userDirectory,
+    COPILOT_HOME: join(temporaryDirectory, ".copilot"),
+  });
+  const preserved = parseJsonWithComments(await readFile(configPath, "utf8"));
+  assert.equal(preserved.servers.zvec_grep.command, "custom-zvec");
+});
+
+test("VS Code uninstall preserves user-authored guidance", async (t) => {
+  const temporaryDirectory = await mkdtemp(
+    join(tmpdir(), "zvec-grep-uninstall-vscode-guidance-"),
+  );
+  const userDirectory = join(temporaryDirectory, "Code", "User");
+  const copilotHome = join(temporaryDirectory, ".copilot");
+  const guidancePath = join(
+    copilotHome,
+    "instructions",
+    "zvec-grep.instructions.md",
+  );
+  t.after(async () => {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  });
+
+  await installTarget("vscode", {
+    VSCODE_USER_DIR: userDirectory,
+    COPILOT_HOME: copilotHome,
+  });
+  const installed = await readFile(guidancePath, "utf8");
+  await writeFile(guidancePath, `${installed}\nMy own note.\n`);
+
+  await uninstallTarget("vscode", {
+    VSCODE_USER_DIR: userDirectory,
+    COPILOT_HOME: copilotHome,
+  });
+  const remaining = await readFile(guidancePath, "utf8");
+  assert.match(remaining, /My own note\./);
+  assert.doesNotMatch(remaining, /ZVEC_GREP_START/);
+});
+
+test("VS Code target resolves the profile directory from VSCODE_PORTABLE", async (t) => {
+  const temporaryDirectory = await mkdtemp(
+    join(tmpdir(), "zvec-grep-install-vscode-portable-"),
+  );
+  t.after(async () => {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  });
+
+  await installTarget("vscode", {
+    VSCODE_USER_DIR: undefined,
+    VSCODE_PORTABLE: temporaryDirectory,
+    COPILOT_HOME: join(temporaryDirectory, ".copilot"),
+  });
+
+  const config = parseJsonWithComments(
+    await readFile(
+      join(temporaryDirectory, "user-data", "User", "mcp.json"),
+      "utf8",
+    ),
+  );
+  assert.equal(config.servers.zvec_grep.command, "zg");
+});
+
+test(
+  "auto target detects an existing VS Code user profile",
+  {
+    skip:
+      process.platform === "win32" ? "executable mode semantics differ" : false,
+  },
+  async (t) => {
+    const temporaryDirectory = await mkdtemp(
+      join(tmpdir(), "zvec-grep-install-auto-vscode-"),
+    );
+    const userDirectory = join(temporaryDirectory, "Code", "User");
+    t.after(async () => {
+      await rm(temporaryDirectory, { recursive: true, force: true });
+    });
+
+    await mkdir(userDirectory, { recursive: true });
+    const { stdout } = await execFileAsync(
+      process.execPath,
+      [cliPath, "install", "--yes"],
+      {
+        env: {
+          ...process.env,
+          PATH: join(temporaryDirectory, "empty-bin"),
+          HOME: temporaryDirectory,
+          USERPROFILE: temporaryDirectory,
+          VSCODE_USER_DIR: userDirectory,
+          COPILOT_HOME: join(temporaryDirectory, ".copilot"),
+          QODER_IDE_EXECUTABLE: join(temporaryDirectory, "missing-qoder-ide"),
+          ZVEC_GREP_INSTALL_SKIP_SERVER: "1",
+        },
+      },
+    );
+
+    assert.match(stdout, /VS Code/);
+    const config = parseJsonWithComments(
+      await readFile(join(userDirectory, "mcp.json"), "utf8"),
+    );
+    assert.equal(config.servers.zvec_grep.command, "zg");
+  },
+);
 
 async function installCodex(codexHome, extraArgs = []) {
   await execFileAsync(


### PR DESCRIPTION
Adds `copilot` and `vscode` as `zg --install` / `zg --uninstall` targets, so GitHub Copilot CLI, Agent Host, and VS Code join Codex, Claude Code, Qwen Code, Qoder, OpenCode, and Cursor as supported agents.

Both reuse the existing installer machinery — the JSON/JSONC MCP helpers and the `ZVEC_GREP_START`/`ZVEC_GREP_END` marked-block writer — so unrelated servers, unrelated instructions, JSONC comments, and unmanaged `zvec_grep` entries are preserved, `--force` is still required to replace an unmanaged entry, and uninstall removes only zvec-grep-owned state.

## `copilot`

Manages the user-level Copilot configuration under `${COPILOT_HOME:-~/.copilot}`:

- `mcp-config.json` — a managed `zvec_grep` entry under `mcpServers`, `type: "local"` (`zg --server --stdio`) for stdio transport, `type: "http"` with an optional `Authorization` header for HTTP.
- `copilot-instructions.md` — the existing zvec-grep search-routing guidance, so Copilot learns when to prefer semantic search over native grep.

The entry sets `tools` to `["*"]` so the server-side `--mcp-toolset` selection stays the single place that decides which tools are exposed. Pinning a tool list here would silently truncate `--mcp-toolset full` and hide `zvec_grep_rg`, which the installed guidance itself references.

It also carries `--mcp-tool-timeout` as the per-server `timeout` in milliseconds: Copilot CLI caps tool discovery and tool calls at 30 seconds unless the entry widens it, so the installer's default of 600 seconds has to reach the configuration to mean anything.

## `vscode`

Agent Host reads `~/.copilot/mcp-config.json` natively, so the `copilot` target already covers it — but not VS Code's own agent mode, which keeps its servers in `mcp.json` and forwards them to Agent Host. Hence a separate target.

It manages the `mcp.json` of every VS Code profile it finds an executable or a user-data directory for — `Code` for Stable and `Code - Insiders` for Insiders — resolved the way VS Code resolves it: `VSCODE_PORTABLE`, then `VSCODE_APPDATA`, then the per-platform application data directory. `VSCODE_USER_DIR` pins a single profile directory instead, for another profile, Insiders, or a derivative. Resolving only the Stable profile would let `zg --install --yes` report success on an Insiders-only machine while writing a file nothing reads.

Two constraints shaped the entry, and they are why it is not simply a copy of the Copilot one:

- VS Code validates `servers` entries with `additionalProperties: false`, so the entry carries only fields from its stdio and HTTP schemas. There is no per-server timeout or tool allowlist to manage, and `--mcp-tool-timeout` does not apply to this entry.
- An HTTP token is referenced as `${env:NAME}` rather than `${input:NAME}`, which keeps the entry forwardable to Agent Host — VS Code does not forward servers that require interactive input.

Comments and trailing commas survive: VS Code's own `mcpServerSchema` sets `allowComments` and `allowTrailingCommas`, so the VS Code path parses with both, without changing the semantics other hosts keep.

Guidance goes to `${COPILOT_HOME:-~/.copilot}/instructions/zvec-grep.instructions.md`, the documented user-level instructions folder that VS Code, Agent Host, and Copilot CLI all read. VS Code applies the file automatically only when its frontmatter scopes it to every file, so the installer manages that header the way it manages the marked block: it adds `applyTo: '**'` when the header or the key is missing, never duplicates it, refuses to widen an `applyTo` the user scoped more narrowly rather than silently writing an inert file, and on uninstall drops the header it added and deletes the file once nothing else remains in it.

## Cross-target lifecycle

The two targets keep separate guidance files — Copilot CLI applies `copilot-instructions.md` on every turn, while a modular `.instructions.md` file is path-scoped — but the `.instructions.md` file is shared by every Copilot-family host. Each of them resolves servers through `$COPILOT_HOME`: VS Code forwards its `mcp.json` servers to Agent Host, while Agent Host and the Copilot CLI read `mcp-config.json`.

So guidance that names a zvec-grep tool is only valid while that entry exists. The `vscode` target registers the server in `mcp-config.json` as well, and neither uninstall removes that entry while managed guidance naming its tools is still installed for the other host. That keeps `zg --install --target vscode` and `zg --uninstall --target copilot` from leaving a host with instructions for a tool it cannot call, and leaves no orphan entry once the last reader is gone.

The two guidance files are documented in `docs/01-agents.md`.

## Supporting change

The JSONC MCP helpers now take a container key, so VS Code's `servers` object reuses the comment-preserving machinery that Qoder uses for `mcpServers`, and a trailing-comma option, which OpenCode and VS Code both need. The defaults are unchanged, so existing call sites are untouched.

## Tests

23 new tests in `test/install.test.mjs` covering, for each target: the stdio entry and guidance with unrelated configuration preserved, idempotent re-install, the HTTP entry, `--mcp-toolset` and `--mcp-tool-timeout` propagation, `--force` against an unmanaged entry, uninstall leaving an unmanaged entry alone, auto-detection, and help output. VS Code additionally covers JSONC comment and trailing-comma preservation, channel resolution, `VSCODE_PORTABLE` resolution, frontmatter ordering and repair, a frontmatter the user scoped too narrowly, user-authored guidance surviving uninstall, a file the uninstaller empties, and a field-set assertion pinning each entry to the schema VS Code accepts. The cross-target sequences are pinned by tests that install `vscode` alone and that uninstall `copilot` while `vscode` stays installed.

The Copilot and VS Code cases share a temporary-directory fixture and target-specific install helpers, so each case states its inputs and its assertions instead of repeating setup.

Auto-target tests pin `VSCODE_USER_DIR` at a missing path and use an empty `PATH`, so a VS Code profile or executable on a contributor's own machine cannot be detected by them.

## Verification

`npm run check` passes end to end — lint, format, typecheck, coverage thresholds, and package tests, exit 0 with no failures.

The generated `mcp.json` was validated against the JSON schema VS Code itself uses for MCP configuration, in both stdio and HTTP form, with a negative control confirming the schema was actually being enforced. That is schema conformance rather than a live editor session; loading the server in a real VS Code window is worth confirming by hand before release.

Out of scope: the Copilot cloud coding agent and Copilot code review, which use separate repository-level MCP configuration. zvec-grep indexes a local workspace, so those hosted surfaces cannot reach it.
