### PR TITLE
feat(markdown): add CommonMark-aware extraction

### DIFF
--- a/docs/04-pipeline.md
+++ b/docs/04-pipeline.md
@@ -85,11 +85,24 @@ participate in indexed search.
 | Structure-aware code | C/C++ (`.c`, `.cc`, `.cpp`, `.cxx`, `.h`, `.hpp`), Go, Java, JavaScript/JSX, TypeScript/TSX, Python, Rust | `CodeExtractor` | Symbols, signatures, breadcrumbs, and surrounding source |
 | Component scripts | `.vue`, `.svelte` | `CodeExtractor` | JavaScript or TypeScript `<script>` blocks; plain-text fallback when no structure is found |
 | Other recognized code | Ruby, PHP, Swift, Kotlin, C#, Scala, shell, SQL, CSS/SCSS/Less, `Dockerfile`, `Makefile` | `CodeExtractor` | Plain-text chunks until a structural grammar is available |
-| Markdown | `.md`, `.mdx` | `MarkdownExtractor` | Heading sections and breadcrumbs; plain-text fallback for documents without headings |
+| Markdown | `.md`, `.mdx` | `MarkdownExtractor` | CommonMark/GFM block structure, heading sections and breadcrumbs, with block-aware chunks for documents without headings |
 | Text documents | `.txt`, `.rst`, `.html`, `.htm`, `.xml` | `TextExtractor` | Plain-text chunks |
 | Text data | `.csv`, `.json`, `.jsonc`, `.toml`, `.yaml`, `.yml` | `TextExtractor` | Plain-text chunks |
 | Other non-binary files | Unrecognized extensions that pass binary detection | `TextExtractor` | Plain-text chunks |
 | Raster images | `.gif`, `.jpeg`, `.jpg`, `.png`, `.webp` | `ImageExtractor` | Image content when explicitly included and the selected Embedding model accepts images |
+
+Markdown structure is parsed with CommonMark and GitHub Flavored Markdown block
+rules, including ATX and Setext headings, fenced code, HTML blocks, lists,
+blockquotes, and tables. Chunk boundaries prefer parsed block boundaries and do
+not treat heading-like text inside another block as a document section.
+
+An opening YAML front matter block closed by `---` or `...` is handled as the
+document envelope before Markdown section discovery and is excluded from stored
+chunks. Top-level scalar and scalar-list fields are normalized into a bounded
+`frontMatter` metadata map. High-signal fields such as titles, descriptions,
+names, and tags are prioritized in vector input without indexing the raw YAML
+preamble as document content. Nested YAML structures are intentionally omitted
+from indexed metadata.
 
 Raster images are excluded by the default discovery rules and must be selected
 explicitly. A text-only Embedding model cannot add image fragments to its

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,8 +18,13 @@
         "@vscode/ripgrep": "^1.18.0",
         "@zvec/zvec": "^0.7.0",
         "jsonc-parser": "^3.3.1",
+        "mdast-util-from-markdown": "^2.0.3",
+        "mdast-util-gfm": "^3.1.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-extension-gfm": "^3.0.0",
         "tree-sitter-wasms": "^0.1.13",
         "web-tree-sitter": "^0.20.8",
+        "yaml": "^2.9.0",
         "zod": "4.2.0"
       },
       "bin": {
@@ -28,6 +33,7 @@
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@modelcontextprotocol/conformance": "0.1.16",
+        "@types/mdast": "^4.0.4",
         "@types/node": "^22.20.1",
         "c8": "^11.0.0",
         "eslint": "^10.7.0",
@@ -1603,6 +1609,15 @@
         "url": "https://github.com/tinyhttp/tinyhttp?sponsor=1"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
@@ -1631,6 +1646,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.20.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
@@ -1639,6 +1669,12 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.64.0",
@@ -2416,6 +2452,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chalk": {
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
@@ -2427,6 +2473,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/chmodrp": {
@@ -2715,7 +2771,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2727,6 +2782,19 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/deep-extend": {
@@ -2790,6 +2858,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -2804,6 +2881,19 @@
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
       "license": "MIT"
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -4130,6 +4220,16 @@
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "license": "Apache-2.0"
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/lowdb": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/lowdb/-/lowdb-7.0.1.tgz",
@@ -4172,6 +4272,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/matcher": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
@@ -4192,6 +4302,207 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/media-typer": {
@@ -4216,6 +4527,569 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/mime-db": {
       "version": "1.54.0",
@@ -4308,7 +5182,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -5637,6 +6510,61 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/universal-user-agent": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
@@ -5860,7 +6788,6 @@
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
       "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -5992,6 +6919,16 @@
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.25.28 || ^4"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@modelcontextprotocol/conformance": "0.1.16",
+    "@types/mdast": "^4.0.4",
     "@types/node": "^22.20.1",
     "c8": "^11.0.0",
     "eslint": "^10.7.0",
@@ -76,8 +77,13 @@
     "@vscode/ripgrep": "^1.18.0",
     "@zvec/zvec": "^0.7.0",
     "jsonc-parser": "^3.3.1",
+    "mdast-util-from-markdown": "^2.0.3",
+    "mdast-util-gfm": "^3.1.0",
+    "mdast-util-to-string": "^4.0.0",
+    "micromark-extension-gfm": "^3.0.0",
     "tree-sitter-wasms": "^0.1.13",
     "web-tree-sitter": "^0.20.8",
+    "yaml": "^2.9.0",
     "zod": "4.2.0"
   },
   "optionalDependencies": {

--- a/src/engine/extraction/markdown/extractor.ts
+++ b/src/engine/extraction/markdown/extractor.ts
@@ -6,21 +6,23 @@ import type {
 } from "../../types.js";
 import { makeEntityId } from "../ids.js";
 import { validateSourceFile, type Source, type TextSource } from "../source.js";
-import { extractPlainTextFragments } from "../text/extractor.js";
 import type { ChunkOptions } from "../types.js";
 import { chunkOptionsForMetadata, fitTextToChars } from "../vector-content.js";
+import {
+  parseMarkdownFrontMatter,
+  type MarkdownDocumentMetadata,
+} from "./front-matter.js";
+import {
+  parseMarkdownStructure,
+  type MarkdownBlock,
+  type MarkdownHeading,
+} from "./structure.js";
 
 const DEFAULT_MARKDOWN_CHUNK_CHARS = 3600;
 const DEFAULT_MARKDOWN_CHUNK_OVERLAP_CHARS = 540;
 
-type Heading = {
-  level: number;
-  text: string;
-  lineIndex: number;
-};
-
 type Section = {
-  heading: Heading | null;
+  heading: MarkdownHeading | null;
   startIndex: number;
   endIndex: number;
   breadcrumb: readonly string[];
@@ -29,6 +31,11 @@ type Section = {
 type MarkdownWindow = {
   text: string;
   range: TextRange;
+};
+
+type MarkdownBlockLayout = {
+  starts: ReadonlySet<number>;
+  protectedBlockByLine: readonly (MarkdownBlock | undefined)[];
 };
 
 export class MarkdownExtractor {
@@ -44,18 +51,29 @@ export class MarkdownExtractor {
     const chunkOptions = resolveMarkdownChunkOptions(options);
 
     const lines = source.text.split("\n");
-    const headings = scanHeadings(lines);
-    if (headings.length === 0) {
-      return this.fallback(source, chunkOptions);
-    }
+    const frontMatter = parseMarkdownFrontMatter(lines);
+    const bodyStartIndex = frontMatter?.bodyStartIndex ?? 0;
+    const structure = parseMarkdownStructure(
+      lines.slice(bodyStartIndex).join("\n"),
+      bodyStartIndex,
+    );
 
     const lineOffsets = computeLineOffsets(lines);
-    const fenceLines = computeFenceLines(lines);
-    const sections = buildSections(headings, lines);
+    const blockLayout = createMarkdownBlockLayout(
+      lines.length,
+      structure.blocks,
+    );
+    const sections =
+      structure.headings.length > 0
+        ? buildSections(structure.headings, lines, bodyStartIndex)
+        : unheadedBodySection(lines, bodyStartIndex);
     const fragments: EntityFragment[] = [];
 
     for (const section of sections) {
-      const metadata = markdownMetadata(section);
+      const metadata =
+        section.heading || frontMatter
+          ? markdownMetadata(section, frontMatter?.metadata ?? {})
+          : undefined;
       const contentChunkOptions = chunkOptionsForMetadata(
         chunkOptions,
         metadata,
@@ -63,13 +81,13 @@ export class MarkdownExtractor {
       const windows = splitMarkdownSection({
         lines,
         lineOffsets,
-        fenceLines,
+        blockLayout,
         section,
         maxChars: contentChunkOptions.maxChunkChars,
         overlapChars: contentChunkOptions.chunkOverlapChars,
       });
 
-      if (windows.length > 1) {
+      if (windows.length > 1 && metadata) {
         const id = makeEntityId(source.file.id, fragments.length);
         fragments.push({
           id,
@@ -115,25 +133,12 @@ export class MarkdownExtractor {
             kind: "text",
             text: window.text,
           },
-          metadata,
+          ...(metadata ? { metadata } : {}),
         });
       }
     }
 
-    return fragments.length > 0
-      ? fragments
-      : this.fallback(source, chunkOptions);
-  }
-
-  private fallback(
-    source: TextSource,
-    options: Required<ChunkOptions>,
-  ): EntityFragment[] {
-    return extractPlainTextFragments(
-      source,
-      options.maxChunkChars,
-      options.chunkOverlapChars,
-    );
+    return fragments;
   }
 }
 
@@ -195,70 +200,23 @@ function markdownOutline(metadata: MarkdownEntityMetadata): string {
   return metadata.heading ?? "markdown section";
 }
 
-function scanHeadings(lines: readonly string[]): Heading[] {
-  const headings: Heading[] = [];
-  let fence: "```" | "~~~" | null = null;
-
-  for (let index = 0; index < lines.length; index++) {
-    const line = lines[index];
-    const trimmed = line.trimStart();
-
-    if (fence) {
-      if (trimmed.startsWith(fence)) {
-        fence = null;
-      }
-      continue;
-    }
-
-    if (trimmed.startsWith("```")) {
-      fence = "```";
-      continue;
-    }
-
-    if (trimmed.startsWith("~~~")) {
-      fence = "~~~";
-      continue;
-    }
-
-    const atx = line.match(/^(#{1,6})\s+(.+?)\s*#*\s*$/);
-    if (atx) {
-      headings.push({
-        level: atx[1].length,
-        text: atx[2].trim(),
-        lineIndex: index,
-      });
-      continue;
-    }
-
-    const next = lines[index + 1]?.trim();
-    if (line.trim().length > 0 && next && /^(=+|-+)\s*$/.test(next)) {
-      headings.push({
-        level: next.startsWith("=") ? 1 : 2,
-        text: line.trim(),
-        lineIndex: index,
-      });
-      index++;
-    }
-  }
-
-  return headings;
-}
-
 function buildSections(
-  headings: readonly Heading[],
+  headings: readonly MarkdownHeading[],
   lines: readonly string[],
+  contentStartIndex = 0,
 ): Section[] {
-  const stack: Heading[] = [];
+  const stack: MarkdownHeading[] = [];
   const sections: Section[] = [];
   const firstHeading = headings[0];
 
   if (
-    firstHeading.lineIndex > 0 &&
-    lines.slice(0, firstHeading.lineIndex).join("\n").trim().length > 0
+    firstHeading.lineIndex > contentStartIndex &&
+    lines.slice(contentStartIndex, firstHeading.lineIndex).join("\n").trim()
+      .length > 0
   ) {
     sections.push({
       heading: null,
-      startIndex: 0,
+      startIndex: contentStartIndex,
       endIndex: firstHeading.lineIndex - 1,
       breadcrumb: [],
     });
@@ -286,10 +244,31 @@ function buildSections(
   return sections;
 }
 
+function unheadedBodySection(
+  lines: readonly string[],
+  bodyStartIndex: number,
+): Section[] {
+  if (
+    bodyStartIndex >= lines.length ||
+    lines.slice(bodyStartIndex).join("\n").trim().length === 0
+  ) {
+    return [];
+  }
+
+  return [
+    {
+      heading: null,
+      startIndex: bodyStartIndex,
+      endIndex: lines.length - 1,
+      breadcrumb: [],
+    },
+  ];
+}
+
 function splitMarkdownSection(input: {
   lines: readonly string[];
   lineOffsets: readonly number[];
-  fenceLines: readonly boolean[];
+  blockLayout: MarkdownBlockLayout;
   section: Section;
   maxChars: number;
   overlapChars: number;
@@ -326,7 +305,7 @@ function splitMarkdownSection(input: {
     if (endIndex <= input.section.endIndex && endIndex - startIndex > 1) {
       endIndex = chooseMarkdownBreak(
         input.lines,
-        input.fenceLines,
+        input.blockLayout,
         startIndex,
         endIndex,
       );
@@ -346,7 +325,11 @@ function splitMarkdownSection(input: {
       endIndex,
       input.overlapChars,
     );
-    const nextStart = endIndex - overlapLines;
+    const nextStart = adjustMarkdownOverlapStart(
+      input.blockLayout,
+      endIndex - overlapLines,
+      endIndex,
+    );
     startIndex = nextStart > startIndex ? nextStart : endIndex;
   }
 
@@ -355,17 +338,22 @@ function splitMarkdownSection(input: {
 
 function chooseMarkdownBreak(
   lines: readonly string[],
-  fenceLines: readonly boolean[],
+  blockLayout: MarkdownBlockLayout,
   startIndex: number,
   endIndex: number,
 ): number {
+  const containingBlock = blockLayout.protectedBlockByLine[endIndex];
+  if (containingBlock && containingBlock.startIndex > startIndex) {
+    return containingBlock.startIndex;
+  }
+
   const minBreak =
     startIndex + Math.max(1, Math.floor((endIndex - startIndex) * 0.7));
   let bestBreak = endIndex;
-  let bestScore = markdownBreakScore(lines, fenceLines, endIndex);
+  let bestScore = markdownBreakScore(lines, blockLayout, endIndex);
 
   for (let index = minBreak; index <= endIndex; index++) {
-    const score = markdownBreakScore(lines, fenceLines, index);
+    const score = markdownBreakScore(lines, blockLayout, index);
     if (score > bestScore) {
       bestBreak = index;
       bestScore = score;
@@ -377,17 +365,22 @@ function chooseMarkdownBreak(
 
 function markdownBreakScore(
   lines: readonly string[],
-  fenceLines: readonly boolean[],
+  blockLayout: MarkdownBlockLayout,
   breakIndex: number,
 ): number {
-  if (breakIndex <= 0 || breakIndex >= lines.length || fenceLines[breakIndex]) {
+  if (breakIndex <= 0 || breakIndex >= lines.length) {
+    return 0;
+  }
+
+  const containingBlock = blockLayout.protectedBlockByLine[breakIndex];
+  if (containingBlock && containingBlock.startIndex < breakIndex) {
     return 0;
   }
 
   const current = lines[breakIndex].trim();
   const previous = lines[breakIndex - 1].trim();
 
-  if (/^#{1,6}\s+/.test(current)) {
+  if (blockLayout.starts.has(breakIndex)) {
     return 100;
   }
 
@@ -473,29 +466,40 @@ function computeLineOffsets(lines: readonly string[]): number[] {
   return offsets;
 }
 
-function computeFenceLines(lines: readonly string[]): boolean[] {
-  const inFence = new Array<boolean>(lines.length).fill(false);
-  let fence: "```" | "~~~" | null = null;
+function createMarkdownBlockLayout(
+  lineCount: number,
+  blocks: readonly MarkdownBlock[],
+): MarkdownBlockLayout {
+  const starts = new Set<number>();
+  const protectedBlockByLine = new Array<MarkdownBlock | undefined>(lineCount);
 
-  for (let index = 0; index < lines.length; index++) {
-    const trimmed = lines[index].trimStart();
-
-    if (fence) {
-      inFence[index] = true;
-      if (trimmed.startsWith(fence)) {
-        fence = null;
-      }
+  for (const block of blocks) {
+    starts.add(block.startIndex);
+    if (!isProtectedMarkdownBlock(block.type)) {
       continue;
     }
-
-    if (trimmed.startsWith("```")) {
-      fence = "```";
-    } else if (trimmed.startsWith("~~~")) {
-      fence = "~~~";
+    for (let index = block.startIndex; index <= block.endIndex; index++) {
+      protectedBlockByLine[index] = block;
     }
   }
 
-  return inFence;
+  return { starts, protectedBlockByLine };
+}
+
+function isProtectedMarkdownBlock(type: string): boolean {
+  return type === "code" || type === "html" || type === "table";
+}
+
+function adjustMarkdownOverlapStart(
+  blockLayout: MarkdownBlockLayout,
+  startIndex: number,
+  endIndex: number,
+): number {
+  const containingBlock = blockLayout.protectedBlockByLine[startIndex];
+  if (!containingBlock || containingBlock.startIndex === startIndex) {
+    return startIndex;
+  }
+  return Math.min(endIndex, containingBlock.endIndex + 1);
 }
 
 function computeMarkdownOverlapLines(
@@ -550,11 +554,15 @@ function findLineCut(line: string, maxChars: number): number {
   return bestPosition > 0 ? bestPosition : maxChars;
 }
 
-function markdownMetadata(section: Section): MarkdownEntityMetadata {
+function markdownMetadata(
+  section: Section,
+  document: MarkdownDocumentMetadata,
+): MarkdownEntityMetadata {
   return {
     kind: "markdown",
     heading: section.heading?.text ?? null,
     level: section.heading?.level ?? null,
     scope: section.breadcrumb.length > 0 ? section.breadcrumb.join("::") : null,
+    ...document,
   };
 }

--- a/src/engine/extraction/markdown/front-matter.ts
+++ b/src/engine/extraction/markdown/front-matter.ts
@@ -1,0 +1,174 @@
+import { parseDocument } from "yaml";
+import type {
+  MarkdownEntityMetadata,
+  MarkdownFrontMatterValue,
+} from "../../types.js";
+
+const MAX_FRONT_MATTER_FIELDS = 64;
+const MAX_FRONT_MATTER_KEY_CHARS = 128;
+const MAX_FRONT_MATTER_SCALAR_CHARS = 2_048;
+const MAX_FRONT_MATTER_ARRAY_ITEMS = 64;
+const MAX_FRONT_MATTER_TOTAL_CHARS = 16_384;
+
+export type MarkdownDocumentMetadata = Pick<
+  MarkdownEntityMetadata,
+  "frontMatter"
+>;
+
+export type MarkdownFrontMatter = {
+  bodyStartIndex: number;
+  metadata: MarkdownDocumentMetadata;
+};
+
+export function parseMarkdownFrontMatter(
+  lines: readonly string[],
+): MarkdownFrontMatter | undefined {
+  if (lines.length === 0 || !isOpeningDelimiter(lines[0])) {
+    return undefined;
+  }
+
+  const closingIndex = lines.findIndex(
+    (line, index) => index > 0 && isClosingDelimiter(line),
+  );
+  if (closingIndex < 0) {
+    return undefined;
+  }
+
+  return {
+    bodyStartIndex: closingIndex + 1,
+    metadata: parseDocumentMetadata(lines.slice(1, closingIndex).join("\n")),
+  };
+}
+
+function isOpeningDelimiter(line: string): boolean {
+  return /^---[\t ]*\r?$/.test(line.replace(/^\uFEFF/, ""));
+}
+
+function isClosingDelimiter(line: string): boolean {
+  return /^(?:---|\.\.\.)[\t ]*\r?$/.test(line);
+}
+
+function parseDocumentMetadata(source: string): MarkdownDocumentMetadata {
+  let value: unknown;
+  try {
+    const document = parseDocument(source, {
+      schema: "failsafe",
+      stringKeys: true,
+      prettyErrors: false,
+      logLevel: "silent",
+    });
+    if (document.errors.length > 0) {
+      return {};
+    }
+    value = document.toJS({ maxAliasCount: 100 });
+  } catch {
+    return {};
+  }
+
+  if (!isRecord(value)) {
+    return {};
+  }
+
+  const fields = new Map<string, MarkdownFrontMatterValue>();
+  for (const [key, fieldValue] of Object.entries(value)) {
+    const normalizedKey = normalizeKey(key);
+    const normalizedValue = normalizeValue(fieldValue);
+    if (
+      normalizedKey.length === 0 ||
+      normalizedKey.length > MAX_FRONT_MATTER_KEY_CHARS ||
+      normalizedValue === undefined
+    ) {
+      continue;
+    }
+
+    if (fields.size >= MAX_FRONT_MATTER_FIELDS && !fields.has(normalizedKey)) {
+      continue;
+    }
+    fields.set(normalizedKey, normalizedValue);
+  }
+
+  const entries: [string, MarkdownFrontMatterValue][] = [];
+  let usedChars = 0;
+  for (const [key, fieldValue] of fields) {
+    const fieldChars = key.length + valueChars(fieldValue);
+    if (usedChars + fieldChars > MAX_FRONT_MATTER_TOTAL_CHARS) {
+      continue;
+    }
+    entries.push([key, fieldValue]);
+    usedChars += fieldChars;
+  }
+
+  return entries.length > 0 ? { frontMatter: Object.fromEntries(entries) } : {};
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeKey(value: string): string {
+  return value
+    .trim()
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1_$2")
+    .replace(/([a-z\d])([A-Z])/g, "$1_$2")
+    .replace(/[^\p{L}\p{N}]+/gu, "_")
+    .replace(/^_+|_+$/g, "")
+    .toLowerCase();
+}
+
+function normalizeValue(value: unknown): MarkdownFrontMatterValue | undefined {
+  if (!Array.isArray(value)) {
+    return normalizeScalar(value);
+  }
+
+  const normalized = [
+    ...new Set(
+      value
+        .map(normalizeScalar)
+        .filter((item): item is string => item !== undefined),
+    ),
+  ].slice(0, MAX_FRONT_MATTER_ARRAY_ITEMS);
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+function normalizeScalar(value: unknown): string | undefined {
+  if (
+    typeof value !== "string" &&
+    typeof value !== "number" &&
+    typeof value !== "boolean" &&
+    typeof value !== "bigint"
+  ) {
+    return undefined;
+  }
+
+  const normalized = String(value).replace(/\s+/g, " ").trim();
+  if (normalized.length === 0) {
+    return undefined;
+  }
+  return truncateScalar(normalized, MAX_FRONT_MATTER_SCALAR_CHARS);
+}
+
+function truncateScalar(value: string, maxChars: number): string {
+  if (value.length <= maxChars) {
+    return value;
+  }
+  const end =
+    isHighSurrogate(value.charCodeAt(maxChars - 1)) &&
+    isLowSurrogate(value.charCodeAt(maxChars))
+      ? maxChars - 1
+      : maxChars;
+  return value.slice(0, end);
+}
+
+function valueChars(value: MarkdownFrontMatterValue): number {
+  return typeof value === "string"
+    ? value.length
+    : value.reduce((total, item) => total + item.length + 1, 0);
+}
+
+function isHighSurrogate(value: number): boolean {
+  return value >= 0xd800 && value <= 0xdbff;
+}
+
+function isLowSurrogate(value: number): boolean {
+  return value >= 0xdc00 && value <= 0xdfff;
+}

--- a/src/engine/extraction/markdown/structure.ts
+++ b/src/engine/extraction/markdown/structure.ts
@@ -1,0 +1,92 @@
+import type { Heading as MdastHeading, RootContent } from "mdast";
+import { fromMarkdown } from "mdast-util-from-markdown";
+import { gfmFromMarkdown } from "mdast-util-gfm";
+import { toString } from "mdast-util-to-string";
+import { gfm } from "micromark-extension-gfm";
+
+export type MarkdownHeading = {
+  level: number;
+  text: string;
+  lineIndex: number;
+};
+
+export type MarkdownBlock = {
+  type: string;
+  startIndex: number;
+  endIndex: number;
+};
+
+export type MarkdownStructure = {
+  headings: readonly MarkdownHeading[];
+  blocks: readonly MarkdownBlock[];
+};
+
+export function parseMarkdownStructure(
+  source: string,
+  lineIndexOffset = 0,
+): MarkdownStructure {
+  const tree = fromMarkdown(source, {
+    extensions: [gfm()],
+    mdastExtensions: [gfmFromMarkdown()],
+  });
+  const blocks = tree.children.flatMap((node) =>
+    markdownBlocks(node, lineIndexOffset),
+  );
+  const headings = tree.children.flatMap((node) =>
+    node.type === "heading" ? markdownHeading(node, lineIndexOffset) : [],
+  );
+
+  return { headings, blocks };
+}
+
+function markdownHeading(
+  node: MdastHeading,
+  lineIndexOffset: number,
+): MarkdownHeading[] {
+  const startLine = node.position?.start.line;
+  if (startLine === undefined) {
+    return [];
+  }
+
+  return [
+    {
+      level: node.depth,
+      text: toString(node).replace(/\s+/g, " ").trim(),
+      lineIndex: lineIndexOffset + startLine - 1,
+    },
+  ];
+}
+
+function markdownBlocks(
+  node: RootContent,
+  lineIndexOffset: number,
+): MarkdownBlock[] {
+  const startLine = node.position?.start.line;
+  const endLine = node.position?.end.line;
+  if (startLine === undefined || endLine === undefined) {
+    return [];
+  }
+
+  return [
+    {
+      type: node.type,
+      startIndex: lineIndexOffset + startLine - 1,
+      endIndex: lineIndexOffset + endLine - 1,
+    },
+    ...nestedBlockChildren(node).flatMap((child) =>
+      markdownBlocks(child, lineIndexOffset),
+    ),
+  ];
+}
+
+function nestedBlockChildren(node: RootContent): readonly RootContent[] {
+  switch (node.type) {
+    case "blockquote":
+    case "footnoteDefinition":
+    case "list":
+    case "listItem":
+      return node.children;
+    default:
+      return [];
+  }
+}

--- a/src/engine/extraction/vector-content.ts
+++ b/src/engine/extraction/vector-content.ts
@@ -97,9 +97,53 @@ function vectorMetadataText(
         ? `heading_level: ${metadata.level}`
         : null,
       metadata.scope ? `scope: ${metadata.scope}` : null,
+      ...markdownFrontMatterLines(metadata.frontMatter),
     ],
     maxChars,
   );
+}
+
+function markdownFrontMatterLines(
+  frontMatter: Extract<EntityMetadata, { kind: "markdown" }>["frontMatter"],
+): string[] {
+  if (!frontMatter) {
+    return [];
+  }
+
+  return Object.entries(frontMatter)
+    .map(([key, value], index) => ({
+      index,
+      priority: frontMatterPriority(key),
+      line: `${key}: ${oneLine(
+        typeof value === "string" ? value : value.join(", "),
+      )}`,
+    }))
+    .sort((left, right) =>
+      left.priority === right.priority
+        ? left.index - right.index
+        : left.priority - right.priority,
+    )
+    .map(({ line }) => line);
+}
+
+function frontMatterPriority(key: string): number {
+  if (key === "title") {
+    return 0;
+  }
+  if (key === "description" || key === "summary" || key === "abstract") {
+    return 1;
+  }
+  if (/(?:^|_)(?:name|names)$/.test(key)) {
+    return 2;
+  }
+  if (
+    /^(?:keywords?|tags?|topics?|categories|category|aliases?|authors?|languages?)$/.test(
+      key,
+    )
+  ) {
+    return 3;
+  }
+  return 4;
 }
 
 function metadataBudget(maxChars: number | undefined): number | undefined {

--- a/src/engine/storage/zvec.ts
+++ b/src/engine/storage/zvec.ts
@@ -25,6 +25,8 @@ import type {
   EntityMetadata,
   FileInfo,
   ImageFormat,
+  MarkdownFrontMatterMetadata,
+  MarkdownFrontMatterValue,
   Range,
 } from "../types.js";
 import { normalizePath } from "../utils/path.js";
@@ -912,6 +914,7 @@ function createSchema(
         dataType: ZVecDataType.INT32,
         nullable: true,
       },
+      stringField("markdown_front_matter", true),
       {
         name: ENTITY_TEXT_FIELD,
         dataType: ZVecDataType.STRING,
@@ -1043,6 +1046,9 @@ function metadataToFields(
       symbol_scope: metadata.scope,
       heading: metadata.heading,
       heading_level: metadata.level,
+      markdown_front_matter: metadata.frontMatter
+        ? JSON.stringify(metadata.frontMatter)
+        : null,
     }),
   };
 }
@@ -1112,11 +1118,15 @@ function parseMetadata(
   }
 
   if (kind === "markdown") {
+    const frontMatter = parseMarkdownFrontMatterMetadata(
+      readNullableStringFieldFromFields(fields, "markdown_front_matter"),
+    );
     return {
       kind: "markdown",
       heading: readNullableStringFieldFromFields(fields, "heading"),
       level: readNullableNumberFieldFromFields(fields, "heading_level"),
       scope: readNullableStringFieldFromFields(fields, "symbol_scope"),
+      ...(frontMatter ? { frontMatter } : {}),
     };
   }
 
@@ -1278,6 +1288,32 @@ function parseStringArray(value: string): string[] {
   } catch {
     return [];
   }
+}
+
+function parseMarkdownFrontMatterMetadata(
+  value: string | null,
+): MarkdownFrontMatterMetadata | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value) as unknown;
+  } catch {
+    return undefined;
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return undefined;
+  }
+
+  const entries = Object.entries(parsed).filter(
+    (entry): entry is [string, MarkdownFrontMatterValue] =>
+      typeof entry[1] === "string" ||
+      (Array.isArray(entry[1]) &&
+        entry[1].every((item) => typeof item === "string")),
+  );
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
 }
 
 function assertZvecStatus(

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -164,11 +164,18 @@ export type CodeEntityMetadata = {
   modifiers: readonly CodeEntityModifier[];
 };
 
+export type MarkdownFrontMatterValue = string | readonly string[];
+
+export type MarkdownFrontMatterMetadata = Readonly<
+  Record<string, MarkdownFrontMatterValue>
+>;
+
 export type MarkdownEntityMetadata = {
   kind: "markdown";
   heading: string | null;
   level: number | null;
   scope: string | null;
+  frontMatter?: MarkdownFrontMatterMetadata;
 };
 
 export type EntityMetadata = CodeEntityMetadata | MarkdownEntityMetadata;
@@ -194,7 +201,7 @@ export type EntityFragment = {
 // Workspace index types
 // -----------------------------------------------------------------------------
 
-export const CURRENT_INDEX_VERSION = 1;
+export const CURRENT_INDEX_VERSION = 2;
 
 export type WorkspaceIndexEmbeddingSchema = {
   provider: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,8 @@ export type {
   IndexProgressPhase,
   IndexResult,
   MarkdownEntityMetadata,
+  MarkdownFrontMatterMetadata,
+  MarkdownFrontMatterValue,
   RootPath,
   SkippedFile,
   SkippedFileReason,

--- a/test/unit/extraction/core.test.mjs
+++ b/test/unit/extraction/core.test.mjs
@@ -5,6 +5,7 @@ import { ImageExtractor } from "../../../dist/engine/extraction/image/extractor.
 import { MarkdownExtractor } from "../../../dist/engine/extraction/markdown/extractor.js";
 import { extract } from "../../../dist/engine/extraction/index.js";
 import { TextExtractor } from "../../../dist/engine/extraction/text/extractor.js";
+import { vectorContentForFragment } from "../../../dist/engine/extraction/vector-content.js";
 
 function file(overrides = {}) {
   return {
@@ -240,6 +241,205 @@ test("markdown extractor handles heading styles, fences, hierarchy, and windows"
   assert.equal(plainMarkdown.length, 1);
   assert.equal(plainMarkdown[0].content.text, "plain markdown");
   assert.equal(plainMarkdown[0].metadata, undefined);
+});
+
+test("markdown extractor excludes YAML front matter before Setext heading discovery", async () => {
+  const extractor = new MarkdownExtractor();
+  const source = textSource(
+    [
+      "---",
+      "title: Search configuration",
+      "description: >",
+      "  Configures indexing and",
+      "  retrieval.",
+      "api_name: configureSearch",
+      "tags:",
+      "- indexing",
+      "draft: false",
+      "release.channel: stable",
+      "repository:",
+      "  url: https://example.test/project",
+      "---",
+      "",
+      "# Search configuration",
+      "",
+      "## Options",
+      "",
+      "Controls how documents are indexed.",
+    ].join("\n"),
+    {
+      kind: "text",
+      format: "markdown",
+      relativePath: "docs/search-configuration.md",
+    },
+  );
+
+  const fragments = await extractor.extract(source);
+  assert.deepEqual(
+    fragments.map((fragment) => fragment.metadata?.heading),
+    ["Search configuration", "Options"],
+  );
+  assert.equal(
+    fragments.some((fragment) => fragment.metadata?.heading === "- indexing"),
+    false,
+  );
+  assert.equal(
+    fragments.some(
+      (fragment) =>
+        fragment.content.kind === "text" &&
+        /^(?:---|title:|description:|api_name:|tags:|- indexing)/m.test(
+          fragment.content.text,
+        ),
+    ),
+    false,
+  );
+  assert.equal(fragments[0].range.startLine, 15);
+  assert.equal(
+    fragments[0].range.startOffset,
+    source.text.indexOf("# Search configuration"),
+  );
+
+  for (const fragment of fragments) {
+    assert.deepEqual(fragment.metadata?.frontMatter, {
+      title: "Search configuration",
+      description: "Configures indexing and retrieval.",
+      api_name: "configureSearch",
+      tags: ["indexing"],
+      draft: "false",
+      release_channel: "stable",
+    });
+  }
+
+  const vectorContent = vectorContentForFragment(fragments[1]);
+  assert.equal(vectorContent.kind, "text");
+  assert.match(vectorContent.text, /title: Search configuration/);
+  assert.match(
+    vectorContent.text,
+    /description: Configures indexing and retrieval\./,
+  );
+  assert.match(vectorContent.text, /api_name: configureSearch/);
+});
+
+test("markdown front matter boundaries are conservative and resilient", async () => {
+  const extractor = new MarkdownExtractor();
+  const unterminated = await extractor.extract(
+    textSource("---\ntitle: Still markdown\nplain body", {
+      kind: "text",
+      format: "markdown",
+    }),
+  );
+  assert.match(unterminated[0].content.text, /title: Still markdown/);
+
+  const invalid = await extractor.extract(
+    textSource("---\ntitle: [invalid\n---\n# Body", {
+      kind: "text",
+      format: "markdown",
+    }),
+  );
+  assert.equal(invalid.length, 1);
+  assert.equal(invalid[0].metadata?.heading, "Body");
+  assert.equal(invalid[0].metadata?.frontMatter, undefined);
+  assert.equal(invalid[0].range.startLine, 4);
+
+  const plainBody = await extractor.extract(
+    textSource(
+      "\uFEFF---\ntitle:  Plain   document\napiName: PlainApi\n...\nplain body",
+      { kind: "text", format: "markdown" },
+    ),
+  );
+  assert.equal(plainBody.length, 1);
+  assert.equal(plainBody[0].content.text, "plain body");
+  assert.equal(plainBody[0].range.startLine, 5);
+  assert.deepEqual(plainBody[0].metadata?.frontMatter, {
+    title: "Plain document",
+    api_name: "PlainApi",
+  });
+});
+
+test("markdown extractor follows CommonMark heading and block rules", async () => {
+  const extractor = new MarkdownExtractor();
+  const source = textSource(
+    [
+      "   # Indented heading",
+      "body",
+      "",
+      "# foo#",
+      "body",
+      "",
+      "Foo",
+      "Bar",
+      "---",
+      "body",
+      "",
+      "````md",
+      "# Not a heading in a code fence",
+      "```",
+      "still code",
+      "````",
+      "",
+      "<script>",
+      "# Not a heading in HTML",
+      "</script>",
+      "",
+      "- list item",
+      "---",
+      "",
+      "> # Nested blockquote heading",
+    ].join("\n"),
+    { kind: "text", format: "markdown", relativePath: "docs/commonmark.md" },
+  );
+
+  const fragments = await extractor.extract(source);
+  assert.deepEqual(
+    fragments.map((fragment) => fragment.metadata?.heading),
+    ["Indented heading", "foo#", "Foo Bar"],
+  );
+});
+
+test("markdown chunking keeps a fitting GFM table intact", async () => {
+  const extractor = new MarkdownExtractor();
+  const table = [
+    "| Name | Value |",
+    "| --- | --- |",
+    "| alpha | one |",
+    "| beta | two |",
+  ].join("\n");
+  const source = textSource(
+    [
+      "An introductory paragraph before the structured data.",
+      "",
+      table,
+      "",
+      "A trailing paragraph after the structured data.",
+    ].join("\n"),
+    { kind: "text", format: "markdown", relativePath: "docs/table.md" },
+  );
+
+  const fragments = await extractor.extract(source, {
+    maxChunkChars: 90,
+    chunkOverlapChars: 0,
+  });
+  assert.ok(fragments.length > 1);
+  assert.ok(
+    fragments.some(
+      (fragment) =>
+        fragment.content.kind === "text" &&
+        fragment.content.text.includes(table),
+    ),
+  );
+  assert.equal(
+    fragments.some(
+      (fragment) =>
+        fragment.content.kind === "text" &&
+        fragment.content.text.includes("| Name |") &&
+        !fragment.content.text.includes("| beta | two |"),
+    ),
+    false,
+  );
+  assert.equal(
+    fragments.every((fragment) => fragment.metadata === undefined),
+    true,
+  );
 });
 
 test("code extractor parses TypeScript and script blocks", async () => {

--- a/test/unit/zvec-storage.test.mjs
+++ b/test/unit/zvec-storage.test.mjs
@@ -140,6 +140,63 @@ test("file metadata supports one batched path-prefix lookup", async (t) => {
   ]);
 });
 
+test("markdown front matter metadata survives storage round trips", async (t) => {
+  const parent = await mkdtemp(join(tmpdir(), "zvec-grep-markdown-meta-"));
+  const root = join(parent, "repo");
+  const storage = createWorkspaceIndexStorage({
+    storagePath: join(parent, "storage"),
+    readOnly: false,
+    embedding: {
+      provider: "local",
+      model: "test",
+      dimension: 2,
+      metric: "cosine",
+    },
+  });
+  t.after(async () => {
+    storage.close();
+    await rm(parent, { recursive: true, force: true });
+  });
+
+  const file = fileInfo("a", root, "docs/api.md");
+  const metadata = {
+    kind: "markdown",
+    heading: "Search configuration",
+    level: 1,
+    scope: null,
+    frontMatter: {
+      title: "Search configuration",
+      description: "Configures indexing and retrieval.",
+      api_name: ["configureSearch"],
+      tags: ["indexing", "search"],
+    },
+  };
+  storage.replaceFile(file, [
+    {
+      fragment: {
+        id: "b".repeat(64),
+        fileId: file.id,
+        range: {
+          kind: "text",
+          startLine: 11,
+          endLine: 15,
+          startOffset: 160,
+          endOffset: 240,
+        },
+        content: {
+          kind: "text",
+          text: "# Search configuration",
+        },
+        metadata,
+      },
+      vector: [1, 0],
+    },
+  ]);
+
+  const [stored] = storage.listEntitiesByFile(file.id);
+  assert.deepEqual(stored.entity.metadata, metadata);
+});
+
 function fileInfo(id, root, relativePath) {
   return {
     id: id.repeat(64),


### PR DESCRIPTION
## Summary

Improve Markdown extraction by replacing ad-hoc heading and fence detection with CommonMark and GitHub Flavored Markdown block parsing.

- Parse ATX and Setext headings according to CommonMark rules.
- Respect fenced code, HTML blocks, lists, blockquotes, footnotes, and GFM tables during section discovery.
- Prefer parsed block boundaries when splitting large Markdown documents.
- Treat leading YAML front matter as a document envelope and exclude it from content chunks.
- Normalize bounded top-level scalar and scalar-list front matter fields into generic `frontMatter` metadata.
- Prioritize high-signal metadata such as titles, descriptions, names, and tags in embedding input.
- Persist generic front matter metadata and bump the workspace index version.

## Motivation

A YAML sequence item immediately before a closing front matter delimiter can resemble a Markdown Setext heading:

```yaml
---
api_name:
- ExampleApi
---