### PR TITLE
docs: document workspace index location

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ curl --retry 3 --retry-all-errors --progress-bar -fL \
 zg index --embedding local/potion-retrieval-32m
 ```
 
+> [!NOTE]
+> The index is stored in `.zvec-grep/` under the indexed project root.
+
 ### 2. Choose how to search
 
 #### For agents: ask with OpenCode

--- a/README_CN.md
+++ b/README_CN.md
@@ -75,6 +75,9 @@ curl --retry 3 --retry-all-errors --progress-bar -fL \
 zg index --embedding local/potion-retrieval-32m
 ```
 
+> [!NOTE]
+> 索引保存在被索引项目根目录的 `.zvec-grep/` 中。
+
 ### 2. 选择检索方式
 
 #### Agent：通过 OpenCode 提问


### PR DESCRIPTION
## Summary

- document the workspace index location in the English and Chinese quick starts
- clarify that indexes are stored in `.zvec-grep/` under the indexed project root

## Validation

- `./node_modules/.bin/prettier --check README.md README_CN.md`
- `git diff --check`
