### PR TITLE
fix: surface embedding failures and avoid redundant retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,11 @@ zg index --embedding local/potion-retrieval-32m
 
 > [!TIP]
 > If `zg index` or `zg query` fails, rerun the same command with `--debug`
-> for diagnostics (supported in both direct and server modes). From the same
-> project, use `zg status --mode direct --debug` or
-> `zg status --mode server --debug` to inspect recorded indexing errors.
+> for diagnostics (supported in both direct and server modes).
+> `zg status --mode direct --debug` reports per-file failures stored in an
+> existing index; rerun a failed direct command to diagnose command-level
+> fatal errors. Use
+> `zg status --mode server --debug` to inspect recorded server indexing errors.
 > For server connection failures, check `zg server status` and the
 > [server logs](./docs/06-server.md#logs-and-state).
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,14 @@ zg index --embedding local/potion-retrieval-32m
 > [!NOTE]
 > The index is stored in `.zvec-grep/` under the indexed project root.
 
+> [!TIP]
+> If `zg index` or `zg query` fails, rerun the same command with `--debug`
+> for diagnostics (supported in both direct and server modes). From the same
+> project, use `zg status --mode direct --debug` or
+> `zg status --mode server --debug` to inspect recorded indexing errors.
+> For server connection failures, check `zg server status` and the
+> [server logs](./docs/06-server.md#logs-and-state).
+
 ### 2. Choose how to search
 
 #### For agents: ask with OpenCode

--- a/README_CN.md
+++ b/README_CN.md
@@ -78,6 +78,12 @@ zg index --embedding local/potion-retrieval-32m
 > [!NOTE]
 > 索引保存在被索引项目根目录的 `.zvec-grep/` 中。
 
+> [!TIP]
+> `zg index` 或 `zg query` 失败时，在原命令后加 `--debug` 重跑，查看诊断信息（direct 和 server 模式均支持）。
+> 在同一项目下，可用 `zg status --mode direct --debug` 或
+> `zg status --mode server --debug` 查看已记录的索引错误。
+> Server 连接失败时，检查 `zg server status` 和[服务日志](./docs/06-server.md#logs-and-state)。
+
 ### 2. 选择检索方式
 
 #### Agent：通过 OpenCode 提问

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -667,8 +667,15 @@ function validateCliShape(
   if (command !== "query" && queryOnly) {
     throw new Error(`${queryOnly} can only be used with zg query`);
   }
-  if (options.debug && command !== "query" && command !== "index") {
-    throw new Error("--debug can only be used with zg query or zg index");
+  if (
+    options.debug &&
+    command !== "query" &&
+    command !== "index" &&
+    command !== "status"
+  ) {
+    throw new Error(
+      "--debug can only be used with zg query, zg index, or zg status",
+    );
   }
 
   const sharedSelection = firstEnabledOption([

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -32,6 +32,7 @@ import {
 } from "./format/context.js";
 import { printDebug } from "./format/debug.js";
 import { createIndexProgressReporter } from "./format/progress.js";
+import { formatContextLines, modelDownloadFailureMessage } from "./errors.js";
 import {
   printWorkspaceInfo,
   printIndexPathFilterTip,
@@ -275,7 +276,9 @@ async function runIndex(parsed: ParsedArgs): Promise<void> {
         );
       }
       if (result.state === "failed") {
-        throw new Error(serverIndexFailureMessage(result));
+        throw new Error(
+          serverIndexFailureMessage(result, parsed.options.debug),
+        );
       }
       if (result.state === "succeeded") {
         const status = (await client
@@ -293,7 +296,34 @@ async function runIndex(parsed: ParsedArgs): Promise<void> {
   });
 }
 
-function serverIndexFailureMessage(result: Record<string, unknown>): string {
+function serverIndexFailureMessage(
+  result: Record<string, unknown>,
+  debug = false,
+): string {
+  const error = result.error;
+  const downloadFailure = modelDownloadFailureMessage(error);
+  if (downloadFailure && !debug) return downloadFailure;
+  const summary = downloadFailure ?? serverIndexFailureSummary(result);
+  const context =
+    error && typeof error === "object" && "context" in error
+      ? error.context
+      : undefined;
+  const details =
+    typeof context === "string" ? formatContextLines(context) : [];
+  const code =
+    downloadFailure && error && typeof error === "object" && "code" in error
+      ? [`Code: ${String(error.code)}`]
+      : [];
+  return [
+    summary,
+    ...code,
+    ...(details.length > 0
+      ? ["Details:", ...details.map((line) => `  ${line}`)]
+      : []),
+  ].join("\n");
+}
+
+function serverIndexFailureSummary(result: Record<string, unknown>): string {
   const error = result.error;
   if (error && typeof error === "object") {
     const code = (error as Record<string, unknown>).code;

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -12,6 +12,11 @@ import {
   type ZvecGrepInfoResult,
 } from "../index.js";
 import { globalConfigPath, updateGlobalConfig } from "../engine/config.js";
+import {
+  ENGINE_ERROR_CODE_PREFIX,
+  EngineError,
+  type EngineErrorCode,
+} from "../engine/errors.js";
 import { listEmbeddingModels } from "../engine/models/index.js";
 import { DaemonClient } from "../client/daemon-client.js";
 import {
@@ -275,7 +280,7 @@ async function runIndex(parsed: ParsedArgs): Promise<void> {
         );
       }
       if (result.state === "failed") {
-        throw new Error(serverIndexFailureMessage(result));
+        throw serverIndexFailure(result);
       }
       if (result.state === "succeeded") {
         const status = (await client
@@ -291,6 +296,24 @@ async function runIndex(parsed: ParsedArgs): Promise<void> {
     },
     direct: () => runDirectIndex(parsed, rootPath, explicitRoot),
   });
+}
+
+function serverIndexFailure(result: Record<string, unknown>): Error {
+  const error = result.error;
+  if (error && typeof error === "object") {
+    const fields = error as Record<string, unknown>;
+    const code = nonEmptyString(fields.code);
+    if (code?.startsWith(`${ENGINE_ERROR_CODE_PREFIX}.`)) {
+      const message =
+        nonEmptyString(fields.message) ?? "Index job failed unexpectedly.";
+      return new EngineError(stripErrorCode(message, code), {
+        code: code as EngineErrorCode,
+        context: nonEmptyString(fields.context),
+        cause: nonEmptyString(fields.cause),
+      });
+    }
+  }
+  return new Error(serverIndexFailureMessage(result));
 }
 
 function serverIndexFailureMessage(result: Record<string, unknown>): string {
@@ -313,6 +336,19 @@ function serverIndexFailureMessage(result: Record<string, unknown>): string {
     }
   }
   return `Index job ${String(result.job_id ?? "unknown")} failed. Run zg status --mode server for details.`;
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0
+    ? value
+    : undefined;
+}
+
+function stripErrorCode(message: string, code: string): string {
+  const prefix = `[${code}]`;
+  return message.startsWith(prefix)
+    ? message.slice(prefix.length).trimStart()
+    : message;
 }
 
 async function runDirectIndex(

--- a/src/cli/errors.ts
+++ b/src/cli/errors.ts
@@ -1,4 +1,4 @@
-import { isEngineError } from "../engine/errors.js";
+import { isEngineError, redactErrorText } from "../engine/errors.js";
 import type { ColorMode } from "./types.js";
 
 export type ErrorPrintOptions = {
@@ -24,12 +24,14 @@ export function printError(
 
   if (isEngineError(error)) {
     console.error(
-      `${theme.error("Error:")} ${downloadFailure ?? error.message}`,
+      `${theme.error("Error:")} ${redactErrorText(downloadFailure ?? error.message, 512)}`,
     );
     console.error(`${theme.label("Code:")} ${error.code}`);
     if (error.context) {
       console.error(`${theme.label("Details:")}`);
-      for (const line of formatContextLines(error.context)) {
+      for (const line of formatContextLines(
+        redactErrorText(error.context, 4_096),
+      )) {
         console.error(`  ${line}`);
       }
     }
@@ -38,7 +40,7 @@ export function printError(
   }
 
   console.error(
-    `${theme.error("Error:")} ${error instanceof Error ? error.message : String(error)}`,
+    `${theme.error("Error:")} ${redactErrorText(error instanceof Error ? error.message : String(error), 512)}`,
   );
   printCause(error, theme);
 }
@@ -122,7 +124,7 @@ function parseKeyValuePairs(line: string): { key: string; value: string }[] {
 function printCause(error: unknown, theme: ErrorTheme): void {
   const cause = errorCauseMessage(error);
   if (cause) {
-    console.error(`${theme.label("Cause:")} ${cause}`);
+    console.error(`${theme.label("Cause:")} ${redactErrorText(cause, 512)}`);
   }
 }
 

--- a/src/cli/errors.ts
+++ b/src/cli/errors.ts
@@ -3,6 +3,7 @@ import type { ColorMode } from "./types.js";
 
 export type ErrorPrintOptions = {
   color?: ColorMode;
+  debug?: boolean;
 };
 
 type ErrorTheme = {
@@ -15,9 +16,16 @@ export function printError(
   options: ErrorPrintOptions = {},
 ): void {
   const theme = createErrorTheme(options.color);
+  const downloadFailure = modelDownloadFailureMessage(error);
+  if (downloadFailure && !options.debug) {
+    console.error(`${theme.error("Error:")} ${downloadFailure}`);
+    return;
+  }
 
   if (isEngineError(error)) {
-    console.error(`${theme.error("Error:")} ${error.message}`);
+    console.error(
+      `${theme.error("Error:")} ${downloadFailure ?? error.message}`,
+    );
     console.error(`${theme.label("Code:")} ${error.code}`);
     if (error.context) {
       console.error(`${theme.label("Details:")}`);
@@ -35,7 +43,39 @@ export function printError(
   printCause(error, theme);
 }
 
-function formatContextLines(context: string): string[] {
+export function modelDownloadFailureMessage(
+  error: unknown,
+): string | undefined {
+  if (!error || typeof error !== "object" || !("code" in error)) {
+    return undefined;
+  }
+  const context =
+    "context" in error && typeof error.context === "string"
+      ? error.context
+      : "";
+  const downloadCode = "ZVEC_GREP.ENGINE.MODELS.MODEL2VEC_DOWNLOAD_FAILED";
+  let details = context;
+  if (error.code !== downloadCode) {
+    if (error.code !== "ZVEC_GREP.ENGINE.INDEXING.FILES_FAILED") {
+      return undefined;
+    }
+    const failedReasons = context
+      .split(/\r?\n/)
+      .find((line) => line.startsWith("failedReasons="));
+    if (!failedReasons) return undefined;
+    const causeIndex = failedReasons.indexOf(`${downloadCode}:`);
+    if (causeIndex < 0) return undefined;
+    details = failedReasons.slice(causeIndex + downloadCode.length);
+  }
+  const model = details.match(
+    /(?:^|[\s(])model=(local\/[A-Za-z0-9._/-]+)/,
+  )?.[1];
+  return model
+    ? `Failed to download model "${model}".`
+    : "Failed to download model.";
+}
+
+export function formatContextLines(context: string): string[] {
   return context
     .split(/\r?\n/)
     .flatMap(formatContextLine)

--- a/src/cli/format/status.ts
+++ b/src/cli/format/status.ts
@@ -16,6 +16,7 @@ import {
   indexCompletionFromStatus,
   indexStatusNeedsRefresh as statusNeedsRefresh,
 } from "../../engine/index-status.js";
+import { redactErrorText } from "../../engine/errors.js";
 
 type StatusTheme = {
   color: boolean;
@@ -425,24 +426,21 @@ function printWorkspaceIndexStatus(
     }
   }
   if (view.failedReasons) {
+    const failedReasons = redactErrorText(view.failedReasons, 4_096);
     const downloadFailure = modelDownloadFailureMessage({
       code: "ZVEC_GREP.ENGINE.INDEXING.FILES_FAILED",
-      context: `failedReasons=${view.failedReasons}`,
+      context: `failedReasons=${failedReasons}`,
     });
     diagnostics.push(
       ...formatStatusField(
         theme,
         downloadFailure ? "Error" : "Problem",
-        theme.danger(downloadFailure ?? view.failedReasons),
+        theme.danger(downloadFailure ?? failedReasons),
       ),
     );
     if (downloadFailure && view.debug) {
       diagnostics.push(
-        ...formatStatusField(
-          theme,
-          "Details",
-          theme.danger(view.failedReasons),
-        ),
+        ...formatStatusField(theme, "Details", theme.danger(failedReasons)),
       );
     }
   }
@@ -766,7 +764,12 @@ function summarizeFailedFileReasons(
     .slice(0, 3)
     .map(
       (file) =>
-        `${file.relativePath}: ${clipReason(explainStoredFailureReason(file.indexStatus!.error!, retryCommand))}`,
+        `${file.relativePath}: ${clipReason(
+          redactErrorText(
+            explainStoredFailureReason(file.indexStatus!.error!, retryCommand),
+            4_096,
+          ),
+        )}`,
     );
   const remaining = withReasons.length - shown.length;
 

--- a/src/cli/format/status.ts
+++ b/src/cli/format/status.ts
@@ -9,6 +9,7 @@ import type {
 } from "../../index.js";
 import type { RemoteEmbeddingAuthorizationStatus } from "../../authorization/types.js";
 import type { CliOptions } from "../types.js";
+import { formatContextLines, modelDownloadFailureMessage } from "../errors.js";
 import { shouldUseColor } from "./highlight.js";
 import { formatGreenProgressBar } from "./progress.js";
 import {
@@ -40,6 +41,7 @@ export type WorkspaceIndexState =
 type WorkspaceRootPath = WorkspaceIndexInfo["rootPaths"][number];
 
 type WorkspaceStatusView = {
+  debug?: boolean;
   root: string;
   indexPath: string;
   policy: "enabled" | "disabled" | "undecided";
@@ -63,6 +65,7 @@ type WorkspaceStatusView = {
   error?: {
     code: string;
     message: string;
+    context?: string;
   };
   failedReasons?: string;
 };
@@ -134,6 +137,7 @@ type ServerIndexInfo = {
     error?: {
       code: string;
       message: string;
+      context?: string;
     };
   };
 };
@@ -220,6 +224,7 @@ export function printWorkspaceInfo(
 
   const state = workspaceState(info);
   printWorkspaceIndexStatus(theme, {
+    debug: options.debug,
     root: info.root,
     indexPath: info.indexPath,
     policy: info.indexPolicy,
@@ -264,6 +269,7 @@ export function printServerIndexInfo(
   const completion = info.runtime?.completion;
 
   printWorkspaceIndexStatus(theme, {
+    debug: options.debug,
     root: info.root,
     indexPath: info.persistent.index_path,
     policy: info.index_policy,
@@ -388,17 +394,50 @@ function printWorkspaceIndexStatus(
 
   const diagnostics: string[] = [];
   if (view.error) {
+    const downloadFailure = modelDownloadFailureMessage(view.error);
     diagnostics.push(
-      ...formatStatusField(theme, "Error", [
-        theme.danger(view.error.code),
-        theme.danger(view.error.message),
-      ]),
+      ...formatStatusField(
+        theme,
+        "Error",
+        (downloadFailure
+          ? [downloadFailure, ...(view.debug ? [view.error.code] : [])]
+          : [view.error.code, view.error.message]
+        ).map((line) => theme.danger(line)),
+      ),
     );
+    if (view.error.context && (!downloadFailure || view.debug)) {
+      diagnostics.push(
+        ...formatStatusField(
+          theme,
+          "Details",
+          formatContextLines(view.error.context).map((line) =>
+            theme.danger(line),
+          ),
+        ),
+      );
+    }
   }
   if (view.failedReasons) {
+    const downloadFailure = modelDownloadFailureMessage({
+      code: "ZVEC_GREP.ENGINE.INDEXING.FILES_FAILED",
+      context: `failedReasons=${view.failedReasons}`,
+    });
     diagnostics.push(
-      ...formatStatusField(theme, "Problem", theme.danger(view.failedReasons)),
+      ...formatStatusField(
+        theme,
+        downloadFailure ? "Error" : "Problem",
+        theme.danger(downloadFailure ?? view.failedReasons),
+      ),
     );
+    if (downloadFailure && view.debug) {
+      diagnostics.push(
+        ...formatStatusField(
+          theme,
+          "Details",
+          theme.danger(view.failedReasons),
+        ),
+      );
+    }
   }
   if (view.suggestion) {
     diagnostics.push(

--- a/src/cli/format/status.ts
+++ b/src/cli/format/status.ts
@@ -63,6 +63,8 @@ type WorkspaceStatusView = {
   error?: {
     code: string;
     message: string;
+    context?: string;
+    cause?: string;
   };
   failedReasons?: string;
 };
@@ -134,6 +136,8 @@ type ServerIndexInfo = {
     error?: {
       code: string;
       message: string;
+      context?: string;
+      cause?: string;
     };
   };
 };
@@ -389,10 +393,11 @@ function printWorkspaceIndexStatus(
   const diagnostics: string[] = [];
   if (view.error) {
     diagnostics.push(
-      ...formatStatusField(theme, "Error", [
-        theme.danger(view.error.code),
-        theme.danger(view.error.message),
-      ]),
+      ...formatStatusField(
+        theme,
+        "Error",
+        formatStatusError(theme, view.error),
+      ),
     );
   }
   if (view.failedReasons) {
@@ -414,6 +419,25 @@ function printWorkspaceIndexStatus(
     console.log("");
     for (const line of section) console.log(line);
   }
+}
+
+function formatStatusError(
+  theme: StatusTheme,
+  error: NonNullable<WorkspaceStatusView["error"]>,
+): string[] {
+  const lines = [theme.danger(error.code), theme.danger(error.message)];
+  const context = error.context
+    ?.split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+  if (context && context.length > 0) {
+    lines.push(theme.label("Details:"));
+    lines.push(...context.map((line) => `  ${theme.danger(line)}`));
+  }
+  if (error.cause) {
+    lines.push(`${theme.label("Cause:")} ${theme.danger(error.cause)}`);
+  }
+  return lines;
 }
 
 function formatWorkspaceStatusHeading(

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -175,7 +175,7 @@ Index options:
   --rebuild                         Rebuild the existing index
   --drop                            Permanently remove the workspace index
   --yes                             Confirm --drop without prompting
-  --debug                           Print skipped-file diagnostics to stderr
+  --debug                           Print file-scan and model failure diagnostics
   --mode <direct|server|auto>       Select indexing transport
 
 Embedding options:
@@ -216,11 +216,12 @@ ${formatEnvironmentVariables([
 See zg help environment for precedence and Server-mode scope.`;
     case "status":
       return `Usage:
-  zg status [root] [--mode <direct|server|auto>] [--check-ready]
+  zg status [root] [--mode <direct|server|auto>] [--check-ready] [--debug]
 
 Shows the nearest workspace root, index policy, index state, embedding schema,
 stored paths, refresh status, and suggested next action.
 
+--debug includes model download failure details.
 --check-ready preserves the normal output and exits non-zero unless the
 Workspace index is ready.`;
     case "config":

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -13,9 +13,11 @@ void main();
 async function main(): Promise<void> {
   const args = process.argv.slice(2);
   const errorColor = colorModeFromArgs(args);
+  let debug = false;
 
   try {
     const parsed = parseArgs(args);
+    debug = parsed.options.debug === true;
 
     if (parsed.command === "version") {
       console.log(PACKAGE_VERSION);
@@ -32,7 +34,7 @@ async function main(): Promise<void> {
     await runParsedCommand(parsed);
     process.exitCode = 0;
   } catch (error) {
-    printError(error, { color: errorColor });
+    printError(error, { color: errorColor, debug });
     process.exitCode = 1;
   }
 }

--- a/src/daemon/backend.ts
+++ b/src/daemon/backend.ts
@@ -775,6 +775,9 @@ export class DaemonBackend implements ZvecGrepDaemonBackend {
     try {
       lease = await this.modelPool.acquire(modelLoadRequest);
     } catch (error) {
+      if (isEngineError(error)) {
+        throw error;
+      }
       throw new DaemonError(
         "MODEL_LOAD_FAILED",
         `Embedding model ${embeddingModelReference(model)} could not be created: ${error instanceof Error ? error.message : String(error)}`,

--- a/src/daemon/job-scheduler.ts
+++ b/src/daemon/job-scheduler.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { redactErrorText } from "../engine/errors.js";
 import type { IndexProgress } from "../engine/types.js";
 import { DaemonError } from "./errors.js";
 import { rootIdentity, type DaemonLogger } from "./logger.js";
@@ -478,7 +479,7 @@ function jobError(
 ): IndexJobError {
   return {
     code: safeErrorCode(code) ?? "INDEX_FAILED",
-    message: redactAndTruncate(message, 512),
+    message: redactErrorText(message, 512),
     ...(context ? { context } : {}),
     ...(cause ? { cause } : {}),
   };
@@ -494,7 +495,7 @@ function errorProperty(
   }
   const value = error[property];
   return typeof value === "string" && value.trim().length > 0
-    ? redactAndTruncate(value, maxLength)
+    ? redactErrorText(value, maxLength)
     : undefined;
 }
 
@@ -519,7 +520,7 @@ function errorCause(error: unknown): string | undefined {
     cause = nestedCause(cause);
   }
   return summaries.length > 0
-    ? redactAndTruncate(summaries.join("; "), 512)
+    ? redactErrorText(summaries.join("; "), 512)
     : undefined;
 }
 
@@ -560,27 +561,6 @@ function errorCodeProperty(error: unknown): string | undefined {
 }
 
 function safeErrorCode(code: string): string | undefined {
-  const value = redactAndTruncate(code.trim(), 128);
+  const value = redactErrorText(code.trim(), 128);
   return /^[A-Z][A-Z0-9_.-]{0,127}$/.test(value) ? value : undefined;
-}
-
-function redactAndTruncate(value: string, maxLength: number): string {
-  const redacted = value
-    .replace(
-      /(?<![a-z0-9+.-])([a-z][a-z0-9+.-]*:\/\/)[^/\s@]+@/gi,
-      "$1[redacted]@",
-    )
-    .replace(
-      /(["']?authorization["']?\s*[:=]\s*)(?:"(?:\\[\s\S]|[^"\\])*"|'(?:\\[\s\S]|[^'\\])*'|[^\r\n]+)/gi,
-      "$1[redacted]",
-    )
-    .replace(/\b(Bearer|Basic)\s+[^\s"',;]+/gi, "$1 [redacted]")
-    .replace(
-      /(["']?(?:api[_ -]?key|(?:access[_ -]?|refresh[_ -]?|id[_ -]?)?token|authorization|password|secret)["']?\s*[:=]\s*)(?:"(?:\\[\s\S]|[^"\\])*"|'(?:\\[\s\S]|[^'\\])*'|[^\s&]+)/gi,
-      "$1[redacted]",
-    )
-    .replace(/\bsk-[A-Za-z0-9_-]{8,}\b/gi, "sk-[redacted]");
-  return redacted.length <= maxLength
-    ? redacted
-    : `${redacted.slice(0, maxLength - 1)}…`;
 }

--- a/src/daemon/job-scheduler.ts
+++ b/src/daemon/job-scheduler.ts
@@ -8,6 +8,13 @@ export type JobState =
 export type JobReason =
   "watch" | "reconcile" | "background_reconcile" | "manual" | "fresh_query";
 
+export type IndexJobError = {
+  code: string;
+  message: string;
+  context?: string;
+  cause?: string;
+};
+
 export type IndexJobSnapshot = {
   id: string;
   canonicalRoot: string;
@@ -18,7 +25,7 @@ export type IndexJobSnapshot = {
   startedAt?: number;
   finishedAt?: number;
   progress?: IndexProgress;
-  error?: { code: string; message: string };
+  error?: IndexJobError;
 };
 
 export type SubmitIndexJob = {
@@ -435,9 +442,12 @@ function isRetryable(error: unknown): boolean {
   );
 }
 
-function errorInfo(error: unknown): { code: string; message: string } {
+function errorInfo(error: unknown): IndexJobError {
+  const context = errorProperty(error, "context", 4_096);
+  const cause = errorCause(error);
+
   if (error instanceof DaemonError) {
-    return { code: error.code, message: redactMessage(error.message) };
+    return jobError(error.code, error.message, context, cause);
   }
   if (
     error &&
@@ -445,27 +455,133 @@ function errorInfo(error: unknown): { code: string; message: string } {
     "code" in error &&
     typeof error.code === "string"
   ) {
-    return {
-      code: error.code,
-      message: redactMessage(
-        error instanceof Error ? error.message : String(error),
-      ),
-    };
-  }
-  return {
-    code: "INDEX_FAILED",
-    message: redactMessage(
+    return jobError(
+      error.code,
       error instanceof Error ? error.message : String(error),
-    ),
+      context,
+      cause,
+    );
+  }
+  return jobError(
+    "INDEX_FAILED",
+    error instanceof Error ? error.message : String(error),
+    context,
+    cause,
+  );
+}
+
+function jobError(
+  code: string,
+  message: string,
+  context: string | undefined,
+  cause: string | undefined,
+): IndexJobError {
+  return {
+    code: safeErrorCode(code) ?? "INDEX_FAILED",
+    message: redactAndTruncate(message, 512),
+    ...(context ? { context } : {}),
+    ...(cause ? { cause } : {}),
   };
 }
 
-function redactMessage(message: string): string {
-  return message
+function errorProperty(
+  error: unknown,
+  property: "context",
+  maxLength: number,
+): string | undefined {
+  if (!error || typeof error !== "object" || !(property in error)) {
+    return undefined;
+  }
+  const value = error[property];
+  return typeof value === "string" && value.trim().length > 0
+    ? redactAndTruncate(value, maxLength)
+    : undefined;
+}
+
+function errorCause(error: unknown): string | undefined {
+  if (!(error instanceof Error) || error.cause === undefined) {
+    return undefined;
+  }
+  const summaries: string[] = [];
+  const seen = new Set<object>();
+  let cause: unknown = error.cause;
+  for (let depth = 0; cause !== undefined && depth < 3; depth++) {
+    if (cause && typeof cause === "object") {
+      if (seen.has(cause)) {
+        break;
+      }
+      seen.add(cause);
+    }
+    const summary = causeSummary(cause);
+    if (summary && !summaries.includes(summary)) {
+      summaries.push(summary);
+    }
+    cause = nestedCause(cause);
+  }
+  return summaries.length > 0
+    ? redactAndTruncate(summaries.join("; "), 512)
+    : undefined;
+}
+
+function causeSummary(cause: unknown): string | undefined {
+  const message =
+    cause instanceof Error
+      ? cause.message
+      : typeof cause === "string" ||
+          typeof cause === "number" ||
+          typeof cause === "boolean"
+        ? String(cause)
+        : cause &&
+            typeof cause === "object" &&
+            "message" in cause &&
+            typeof cause.message === "string"
+          ? cause.message
+          : undefined;
+  const code = errorCodeProperty(cause);
+  if (!message || message.trim().length === 0) {
+    return code;
+  }
+  return code && !message.includes(code) ? `${code}: ${message}` : message;
+}
+
+function nestedCause(error: unknown): unknown {
+  return error && typeof error === "object" && "cause" in error
+    ? error.cause
+    : undefined;
+}
+
+function errorCodeProperty(error: unknown): string | undefined {
+  return error &&
+    typeof error === "object" &&
+    "code" in error &&
+    typeof error.code === "string"
+    ? safeErrorCode(error.code)
+    : undefined;
+}
+
+function safeErrorCode(code: string): string | undefined {
+  const value = redactAndTruncate(code.trim(), 128);
+  return /^[A-Z][A-Z0-9_.-]{0,127}$/.test(value) ? value : undefined;
+}
+
+function redactAndTruncate(value: string, maxLength: number): string {
+  const redacted = value
+    .replace(/(https?:\/\/)[^/\s:@]+:[^@\s/]+@/gi, "$1[redacted]@")
     .replace(/Bearer\s+\S+/gi, "Bearer [redacted]")
     .replace(
-      /(api[_ -]?key|token|authorization)\s*[:=]\s*\S+/gi,
-      "$1=[redacted]",
+      /(^|[\s{,?&])(["']?authorization["']?\s*[:=]\s*)[^\r\n,;]+/gim,
+      "$1$2[redacted]",
     )
-    .slice(0, 512);
+    .replace(
+      /(["']?(?:api[_ -]?key|access[_ -]?token|refresh[_ -]?token|token|authorization)["']?\s*[:=]\s*)(?:"[^"\r\n]*"|'[^'\r\n]*')/gi,
+      "$1[redacted]",
+    )
+    .replace(
+      /(["']?(?:api[_ -]?key|access[_ -]?token|refresh[_ -]?token|token|authorization)["']?\s*[:=]\s*)[^\s,;&]+/gi,
+      "$1[redacted]",
+    )
+    .replace(/\bsk-[A-Za-z0-9_-]{8,}\b/gi, "sk-[redacted]");
+  return redacted.length <= maxLength
+    ? redacted
+    : `${redacted.slice(0, maxLength - 1)}…`;
 }

--- a/src/daemon/job-scheduler.ts
+++ b/src/daemon/job-scheduler.ts
@@ -8,6 +8,12 @@ export type JobState =
 export type JobReason =
   "watch" | "reconcile" | "background_reconcile" | "manual" | "fresh_query";
 
+export type IndexJobError = {
+  code: string;
+  message: string;
+  context?: string;
+};
+
 export type IndexJobSnapshot = {
   id: string;
   canonicalRoot: string;
@@ -18,7 +24,7 @@ export type IndexJobSnapshot = {
   startedAt?: number;
   finishedAt?: number;
   progress?: IndexProgress;
-  error?: { code: string; message: string };
+  error?: IndexJobError;
 };
 
 export type SubmitIndexJob = {
@@ -435,9 +441,21 @@ function isRetryable(error: unknown): boolean {
   );
 }
 
-function errorInfo(error: unknown): { code: string; message: string } {
+function errorInfo(error: unknown): IndexJobError {
+  const context =
+    error &&
+    typeof error === "object" &&
+    "context" in error &&
+    typeof error.context === "string" &&
+    error.context.length > 0
+      ? { context: redactMessage(error.context, 4096) }
+      : {};
   if (error instanceof DaemonError) {
-    return { code: error.code, message: redactMessage(error.message) };
+    return {
+      code: error.code,
+      message: redactMessage(error.message),
+      ...context,
+    };
   }
   if (
     error &&
@@ -450,6 +468,7 @@ function errorInfo(error: unknown): { code: string; message: string } {
       message: redactMessage(
         error instanceof Error ? error.message : String(error),
       ),
+      ...context,
     };
   }
   return {
@@ -457,15 +476,17 @@ function errorInfo(error: unknown): { code: string; message: string } {
     message: redactMessage(
       error instanceof Error ? error.message : String(error),
     ),
+    ...context,
   };
 }
 
-function redactMessage(message: string): string {
+function redactMessage(message: string, maxLength = 512): string {
   return message
-    .replace(/Bearer\s+\S+/gi, "Bearer [redacted]")
+    .replace(/([a-z][a-z0-9+.-]*:\/\/)[^/\s@]+@/gi, "$1[redacted]@")
+    .replace(/\b(Bearer|Basic)\s+[^\s"',;]+/gi, "$1 [redacted]")
     .replace(
-      /(api[_ -]?key|token|authorization)\s*[:=]\s*\S+/gi,
-      "$1=[redacted]",
+      /(["']?(?:api[_ -]?key|(?:access[_ -]?|refresh[_ -]?|id[_ -]?)?token|authorization|password|secret)["']?\s*[:=]\s*)(?:"(?:\\[\s\S]|[^"\\])*"|'(?:\\[\s\S]|[^'\\])*'|[^\s&]+)/gi,
+      "$1[redacted]",
     )
-    .slice(0, 512);
+    .slice(0, maxLength);
 }

--- a/src/engine/errors.ts
+++ b/src/engine/errors.ts
@@ -57,7 +57,10 @@ export function redactErrorText(value: string, maxLength: number): string {
       /(["']?authorization["']?\s*[:=]\s*)(?:"(?:\\[\s\S]|[^"\\])*"|'(?:\\[\s\S]|[^'\\])*'|[^\r\n]+)/gi,
       "$1[redacted]",
     )
-    .replace(/\b(Bearer|Basic)\s+[^\s"',;]+/gi, "$1 [redacted]")
+    .replace(
+      /\b(Bearer|Basic)[^\S\r\n]+(?:"(?:\\[^\r\n]|[^"\\\r\n])*"|'(?:\\[^\r\n]|[^'\\\r\n])*'|[^\s"',;]+)/gi,
+      "$1 [redacted]",
+    )
     .replace(
       /(["']?(?:api[_ -]?key|(?:access[_ -]?|refresh[_ -]?|id[_ -]?)?token|authorization|password|secret)["']?\s*[:=]\s*)(?:"(?:\\[\s\S]|[^"\\])*"|'(?:\\[\s\S]|[^'\\])*'|[^\s&]+)/gi,
       "$1[redacted]",

--- a/src/engine/errors.ts
+++ b/src/engine/errors.ts
@@ -47,6 +47,27 @@ export function workspaceIndexDetail(name: string): ErrorDetailEntry {
   return detail("workspaceIndex", name);
 }
 
+export function redactErrorText(value: string, maxLength: number): string {
+  const redacted = value
+    .replace(
+      /(?<![a-z0-9+.-])([a-z][a-z0-9+.-]*:\/\/)[^/\s@]+@/gi,
+      "$1[redacted]@",
+    )
+    .replace(
+      /(["']?authorization["']?\s*[:=]\s*)(?:"(?:\\[\s\S]|[^"\\])*"|'(?:\\[\s\S]|[^'\\])*'|[^\r\n]+)/gi,
+      "$1[redacted]",
+    )
+    .replace(/\b(Bearer|Basic)\s+[^\s"',;]+/gi, "$1 [redacted]")
+    .replace(
+      /(["']?(?:api[_ -]?key|(?:access[_ -]?|refresh[_ -]?|id[_ -]?)?token|authorization|password|secret)["']?\s*[:=]\s*)(?:"(?:\\[\s\S]|[^"\\])*"|'(?:\\[\s\S]|[^'\\])*'|[^\s&]+)/gi,
+      "$1[redacted]",
+    )
+    .replace(/\bsk-[A-Za-z0-9_-]{8,}\b/gi, "sk-[redacted]");
+  return redacted.length <= maxLength
+    ? redacted
+    : `${redacted.slice(0, maxLength - 1)}…`;
+}
+
 function formatDetailEntry(entry: ErrorDetailEntry): string | null {
   if (entry === null || entry === undefined) {
     return null;

--- a/src/engine/models/backends/model2vec.ts
+++ b/src/engine/models/backends/model2vec.ts
@@ -13,6 +13,7 @@ import {
   type CreateEmbeddingModelOptions,
   type EmbeddingModelProgress,
   type EmbeddingModelInfo,
+  type EmbeddingOptions,
   type EmbeddingResult,
   type NormalizedEmbeddingOptions,
 } from "../embeddings.js";
@@ -138,6 +139,16 @@ export class Model2VecEmbeddingModel extends BaseEmbeddingModel {
     options: NormalizedEmbeddingOptions,
   ): Promise<EmbeddingResult> {
     return await this.embedBatch(contents, options);
+  }
+
+  async prepare(
+    options: Pick<EmbeddingOptions, "signal" | "onProgress"> = {},
+  ): Promise<void> {
+    options.signal?.throwIfAborted();
+    this.ensureNotDisposed();
+    await this.ensureLoaded(options.onProgress);
+    options.signal?.throwIfAborted();
+    this.ensureNotDisposed();
   }
 
   private async embedBatch(

--- a/src/engine/models/backends/model2vec.ts
+++ b/src/engine/models/backends/model2vec.ts
@@ -203,47 +203,68 @@ export class Model2VecEmbeddingModel extends BaseEmbeddingModel {
       [basename(this.entry.modelFile), basename(this.entry.tokenizerFile)],
     );
     downloadProgress.start();
-    const [modelPath, tokenizerSource] = await Promise.all([
-      this.resolveModelPath(downloadProgress),
-      this.resolveTokenizerSource(downloadProgress),
-    ]);
-    const staticTable = await this.dependencies.loadSafetensors(
-      modelPath,
-      this.entry.embeddingTensor,
-      this.info.dimension,
-    );
-    this.ensureNotDisposed();
-    if (this.useWorkerPool) {
-      const sharedTable = sharedStaticEmbeddingTable(staticTable);
-      const workerPool = new Model2VecWorkerPool({
-        tokenizerSource,
-        maxInputTokens: this.entry.maxInputTokens,
-        normalize: this.entry.normalize,
-        tableBuffer: sharedTable.data.buffer as SharedArrayBuffer,
-        dimension: sharedTable.dimension,
-        dtype: sharedTable.dtype,
-        rows: sharedTable.rows,
-      });
-      try {
-        await workerPool.start();
-        this.ensureNotDisposed();
-        this.workerPool = workerPool;
-      } catch (error) {
-        await workerPool.dispose();
-        throw error;
-      }
-    } else {
-      this.tokenizer = await this.dependencies.loadTokenizer(tokenizerSource, {
-        cache_dir: this.modelCacheDir,
-        revision: this.entry.revision,
-        ...(tokenizerSource !== this.entry.repo
-          ? { local_files_only: true }
-          : {}),
-      });
+    try {
+      const [modelPath, tokenizerSource] = await Promise.all([
+        this.resolveModelPath(downloadProgress),
+        this.resolveTokenizerSource(downloadProgress),
+      ]);
+      const staticTable = await this.dependencies.loadSafetensors(
+        modelPath,
+        this.entry.embeddingTensor,
+        this.info.dimension,
+      );
       this.ensureNotDisposed();
-      this.staticTable = staticTable;
+      if (this.useWorkerPool) {
+        const sharedTable = sharedStaticEmbeddingTable(staticTable);
+        const workerPool = new Model2VecWorkerPool({
+          tokenizerSource,
+          maxInputTokens: this.entry.maxInputTokens,
+          normalize: this.entry.normalize,
+          tableBuffer: sharedTable.data.buffer as SharedArrayBuffer,
+          dimension: sharedTable.dimension,
+          dtype: sharedTable.dtype,
+          rows: sharedTable.rows,
+        });
+        try {
+          await workerPool.start();
+          this.ensureNotDisposed();
+          this.workerPool = workerPool;
+        } catch (error) {
+          await workerPool.dispose();
+          throw error;
+        }
+      } else {
+        this.tokenizer = await this.dependencies.loadTokenizer(
+          tokenizerSource,
+          {
+            cache_dir: this.modelCacheDir,
+            revision: this.entry.revision,
+            ...(tokenizerSource !== this.entry.repo
+              ? { local_files_only: true }
+              : {}),
+          },
+        );
+        this.ensureNotDisposed();
+        this.staticTable = staticTable;
+      }
+      downloadProgress.finish();
+    } catch (cause) {
+      downloadProgress.warning(
+        "Unable to prepare the local embedding model. Check network access and the model cache.",
+      );
+      if (
+        cause instanceof EngineError &&
+        (cause.code === "ZVEC_GREP.ENGINE.MODELS.MODEL2VEC_DOWNLOAD_FAILED" ||
+          cause.code === "ZVEC_GREP.ENGINE.MODELS.MODEL2VEC_DISPOSED")
+      ) {
+        throw cause;
+      }
+      throw new EngineError("Unable to load Model2Vec model", {
+        code: "ZVEC_GREP.ENGINE.MODELS.MODEL2VEC_LOAD_FAILED",
+        context: `model=${this.entry.reference} repo=${this.entry.repo} revision=${this.entry.revision}`,
+        cause,
+      });
     }
-    downloadProgress.finish();
   }
 
   private async resolveModelPath(
@@ -302,6 +323,7 @@ export class Model2VecEmbeddingModel extends BaseEmbeddingModel {
     const partialPath = `${localPath}.part-${process.pid}-${Date.now()}`;
     const url = `https://huggingface.co/${this.entry.repo}/resolve/${this.entry.revision}/${remoteFile}`;
     try {
+      downloadProgress.begin(basename(remoteFile));
       await this.dependencies.download(url, partialPath, (progress) => {
         downloadProgress.report({
           artifact: basename(remoteFile),
@@ -317,7 +339,7 @@ export class Model2VecEmbeddingModel extends BaseEmbeddingModel {
       await rm(partialPath, { force: true });
       throw new EngineError("Unable to download Model2Vec model artifact", {
         code: "ZVEC_GREP.ENGINE.MODELS.MODEL2VEC_DOWNLOAD_FAILED",
-        context: `model=${this.entry.reference} url=${url}`,
+        context: `model=${this.entry.reference} repo=${this.entry.repo} revision=${this.entry.revision}`,
         cause,
       });
     }

--- a/src/engine/models/download-progress.ts
+++ b/src/engine/models/download-progress.ts
@@ -8,6 +8,7 @@ export type ModelArtifactDownloadProgress = {
 
 export type ModelDownloadProgressReporter = {
   start(): void;
+  begin(artifact: string): void;
   register(artifact: string): void;
   skip(artifact: string): void;
   report(progress: ModelArtifactDownloadProgress): void;
@@ -24,10 +25,45 @@ export function createModelDownloadProgressReporter(
     string,
     { downloadedBytes: number; totalBytes?: number }
   >(expectedArtifacts.map((artifact) => [artifact, { downloadedBytes: 0 }]));
+  let downloadStarted = false;
+
+  const reportDownload = (): void => {
+    const values = [...artifacts.values()];
+    const downloadedBytes = values.reduce(
+      (sum, artifact) => sum + artifact.downloadedBytes,
+      0,
+    );
+    const hasCompleteTotals =
+      values.length > 0 &&
+      values.every(
+        (artifact) =>
+          typeof artifact.totalBytes === "number" &&
+          Number.isFinite(artifact.totalBytes) &&
+          artifact.totalBytes >= 0,
+      );
+    const totalBytes = hasCompleteTotals
+      ? values.reduce((sum, artifact) => sum + (artifact.totalBytes ?? 0), 0)
+      : undefined;
+    onProgress?.({
+      stage: "downloading",
+      model,
+      downloadedBytes,
+      ...(totalBytes === undefined ? {} : { totalBytes }),
+    });
+  };
 
   return {
     start() {
       onProgress?.({ stage: "preparing", model });
+    },
+    begin(artifact) {
+      if (!artifacts.has(artifact)) {
+        artifacts.set(artifact, { downloadedBytes: 0 });
+      }
+      if (!downloadStarted) {
+        downloadStarted = true;
+        reportDownload();
+      }
     },
     register(artifact) {
       if (!artifacts.has(artifact)) {
@@ -42,28 +78,8 @@ export function createModelDownloadProgressReporter(
         downloadedBytes: progress.downloadedBytes,
         totalBytes: progress.totalBytes,
       });
-      const values = [...artifacts.values()];
-      const downloadedBytes = values.reduce(
-        (sum, artifact) => sum + artifact.downloadedBytes,
-        0,
-      );
-      const hasCompleteTotals =
-        values.length > 0 &&
-        values.every(
-          (artifact) =>
-            typeof artifact.totalBytes === "number" &&
-            Number.isFinite(artifact.totalBytes) &&
-            artifact.totalBytes >= 0,
-        );
-      const totalBytes = hasCompleteTotals
-        ? values.reduce((sum, artifact) => sum + (artifact.totalBytes ?? 0), 0)
-        : undefined;
-      onProgress?.({
-        stage: "downloading",
-        model,
-        downloadedBytes,
-        ...(totalBytes === undefined ? {} : { totalBytes }),
-      });
+      downloadStarted = true;
+      reportDownload();
     },
     warning(message) {
       if (!onProgress) {

--- a/src/engine/models/embeddings.ts
+++ b/src/engine/models/embeddings.ts
@@ -63,6 +63,11 @@ export type EmbeddingModelInfo = Readonly<{
 export interface EmbeddingModel {
   readonly info: EmbeddingModelInfo;
 
+  /** Prepare local resources before indexing queues any embedding batches. */
+  prepare?(
+    options?: Pick<EmbeddingOptions, "signal" | "onProgress">,
+  ): Promise<void>;
+
   embed(
     contents: readonly Content[],
     options?: EmbeddingOptions,

--- a/src/engine/pipeline/indexing/index.ts
+++ b/src/engine/pipeline/indexing/index.ts
@@ -719,6 +719,7 @@ async function indexFiles(
   );
   const embeddingTiming = new ConcurrentTiming(timings, "index_embedding");
   const runningEmbeddings = new Set<Promise<void>>();
+  let firstEmbeddingError: { error: unknown } | undefined;
   const prepareModel =
     ctx.embeddingModel.info.provider === "local"
       ? ctx.embeddingModel.prepare?.bind(ctx.embeddingModel)
@@ -730,8 +731,15 @@ async function indexFiles(
   ): void => {
     onProgress(currentStats, detail, embeddingScheduler.snapshot());
   };
+  const throwFirstEmbeddingError = (): void => {
+    const failure = firstEmbeddingError;
+    if (failure) {
+      throw failure.error;
+    }
+  };
 
   const flushBatch = async (): Promise<void> => {
+    throwFirstEmbeddingError();
     throwIfIndexCancelled(ctx);
     if (batchFiles.length === 0) {
       return;
@@ -756,6 +764,7 @@ async function indexFiles(
   const scheduleEmbeddingTask = async (
     task: () => Promise<void>,
   ): Promise<void> => {
+    throwFirstEmbeddingError();
     throwIfIndexCancelled(ctx);
     if (!modelPrepared && prepareModel) {
       // Finish shared initialization before any file or fragment batch is queued.
@@ -779,24 +788,36 @@ async function indexFiles(
       throwIfIndexCancelled(ctx);
     }
     modelPrepared = true;
-    const promise = task().finally(() => {
+    const cleanup = (): void => {
       runningEmbeddings.delete(promise);
-    });
+    };
+    const promise = Promise.resolve()
+      .then(task)
+      .then(cleanup, (error: unknown) => {
+        if (!firstEmbeddingError) {
+          firstEmbeddingError = { error };
+        }
+        cleanup();
+      });
 
     runningEmbeddings.add(promise);
 
     if (runningEmbeddings.size >= embeddingScheduler.taskConcurrency) {
       await Promise.race(runningEmbeddings);
     }
+    throwFirstEmbeddingError();
+    throwIfIndexCancelled(ctx);
   };
 
   try {
     for (const file of files) {
+      throwFirstEmbeddingError();
       throwIfIndexCancelled(ctx);
       onProgress(stats, `reading ${file.relativePath}`);
       const prepared = await timings.time("index_prepare", () =>
         prepareFile(file, ctx),
       );
+      throwFirstEmbeddingError();
       throwIfIndexCancelled(ctx);
 
       if ("failedReason" in prepared) {
@@ -849,6 +870,8 @@ async function indexFiles(
 
     await flushBatch();
     await Promise.all(runningEmbeddings);
+    throwFirstEmbeddingError();
+    throwIfIndexCancelled(ctx);
   } catch (error) {
     await Promise.allSettled(runningEmbeddings);
     throw error;

--- a/src/engine/pipeline/indexing/index.ts
+++ b/src/engine/pipeline/indexing/index.ts
@@ -105,6 +105,18 @@ const EMBEDDING_TRANSIENT_RETRY_MAX_DELAY_MS = 8000;
 const EMBEDDING_RATE_LIMIT_RETRY_MAX_DELAY_MS = 30000;
 const EMBEDDING_RETRY_JITTER_MS = 500;
 const EMBEDDING_SUCCESS_STREAK_MIN = 4;
+const PERMANENT_REMOTE_MODEL_PROVIDER_CODES = new Set([
+  "invalid_model",
+  "model_not_found",
+  "unsupported_model",
+  "invalid_dimension",
+  "invalid_dimensions",
+  "unsupported_dimension",
+  "unsupported_dimensions",
+  "dimension_out_of_range",
+  "invalid_embedding_dimension",
+  "unsupported_embedding_dimension",
+]);
 
 type EmbeddingScheduler = {
   readonly taskConcurrency: number;
@@ -264,31 +276,7 @@ async function indexWorkspaceUnchecked(
 
   if (result.filesFailed > 0) {
     report({ phase: "done", detail: "Indexing completed with failed files" });
-    throw new EngineError(
-      `Indexing completed with ${result.filesFailed} failed ${result.filesFailed === 1 ? "file" : "files"}`,
-      {
-        code: "ZVEC_GREP.ENGINE.INDEXING.FILES_FAILED",
-        context: errorDetails([
-          workspaceIndexDetail(ctx.workspaceIndex.name),
-          detail("filesFailed", result.filesFailed),
-          detail("filesScanned", result.filesScanned),
-          detail(
-            "failedFiles",
-            summarizeFailedFiles(finalPass.stats.failedFiles),
-          ),
-          detail(
-            "failedReasons",
-            summarizeFailedFiles(finalPass.stats.failedFileReasons),
-          ),
-          detail(
-            "hint",
-            passes.length > 1
-              ? "Retried failed files once automatically; if failures persist, fix the failed files or embedding configuration."
-              : "If the failure was transient, rerun the same indexing command; if it persists, fix the failed files or embedding configuration.",
-          ),
-        ]),
-      },
-    );
+    throw filesFailedError(ctx, result, finalPass, passes.length);
   }
 
   report({ phase: "done", detail: "Indexing complete" });
@@ -330,16 +318,43 @@ async function indexWorkspacePathsUnchecked(
   await timings.time("index_optimize", () => optimizeStorage(ctx));
   const result = buildIndexResult(ctx, passes, Date.now() - start, timings);
   if (result.filesFailed > 0) {
-    throw new EngineError(
-      `Indexing completed with ${result.filesFailed} failed files`,
-      {
-        code: "ZVEC_GREP.ENGINE.INDEXING.FILES_FAILED",
-        context: workspaceIndexContext(ctx.workspaceIndex),
-      },
-    );
+    throw filesFailedError(ctx, result, finalPass, passes.length);
   }
   report({ phase: "done", detail: "Indexing complete" });
   return result;
+}
+
+function filesFailedError(
+  ctx: IndexContext,
+  result: IndexResult,
+  finalPass: IndexPassResult,
+  passCount: number,
+): EngineError {
+  return new EngineError(
+    `Indexing completed with ${result.filesFailed} failed ${result.filesFailed === 1 ? "file" : "files"}`,
+    {
+      code: "ZVEC_GREP.ENGINE.INDEXING.FILES_FAILED",
+      context: errorDetails([
+        workspaceIndexDetail(ctx.workspaceIndex.name),
+        detail("filesFailed", result.filesFailed),
+        detail("filesScanned", result.filesScanned),
+        detail(
+          "failedFiles",
+          summarizeFailedFiles(finalPass.stats.failedFiles),
+        ),
+        detail(
+          "failedReasons",
+          summarizeFailedFiles(finalPass.stats.failedFileReasons),
+        ),
+        detail(
+          "hint",
+          passCount > 1
+            ? "Retried failed files once automatically; if failures persist, fix the failed files or embedding configuration."
+            : "If the failure was transient, rerun the same indexing command; if it persists, fix the failed files or embedding configuration.",
+        ),
+      ]),
+    },
+  );
 }
 
 async function runPathIndexPass(
@@ -1200,6 +1215,10 @@ async function embedFragments(
 
   const vectors: number[][] = new Array(fragments.length);
   const truncatedInputIndexes: number[] = [];
+  const batchAbortController = new AbortController();
+  const batchSignal = signal
+    ? AbortSignal.any([signal, batchAbortController.signal])
+    : batchAbortController.signal;
   const results = await Promise.allSettled(
     batches.map((batch) =>
       embedFragmentBatch(
@@ -1207,8 +1226,9 @@ async function embedFragments(
         model,
         batch.start,
         embeddingScheduler,
-        signal,
+        batchSignal,
         onModelProgress,
+        (error) => batchAbortController.abort(error),
       ),
     ),
   );
@@ -1246,6 +1266,7 @@ async function embedFragmentBatch(
   embeddingScheduler: EmbeddingScheduler,
   signal?: AbortSignal,
   onModelProgress?: (progress: EmbeddingModelProgress) => void,
+  onTerminalFailure?: (error: unknown) => void,
 ): Promise<EmbeddingResult> {
   const contents = fragments.map((fragment) => fragment.embeddingContent);
 
@@ -1256,6 +1277,7 @@ async function embedFragmentBatch(
       embeddingScheduler,
       signal,
       onModelProgress,
+      onTerminalFailure,
     );
   } catch (error) {
     if (fragments.length === 1 || shouldFailFastEmbeddingError(error, model)) {
@@ -1269,6 +1291,7 @@ async function embedFragmentBatch(
       embeddingScheduler,
       signal,
       onModelProgress,
+      onTerminalFailure,
     );
   }
 }
@@ -1280,6 +1303,7 @@ async function embedFragmentBatchOneByOne(
   embeddingScheduler: EmbeddingScheduler,
   signal?: AbortSignal,
   onModelProgress?: (progress: EmbeddingModelProgress) => void,
+  onTerminalFailure?: (error: unknown) => void,
 ): Promise<EmbeddingResult> {
   const vectors: number[][] = [];
   const truncatedInputIndexes: number[] = [];
@@ -1292,6 +1316,7 @@ async function embedFragmentBatchOneByOne(
         embeddingScheduler,
         signal,
         onModelProgress,
+        onTerminalFailure,
       );
       vectors.push(result.vectors[0]);
       if (result.truncated.length > 0) {
@@ -1331,6 +1356,7 @@ async function embedContentsWithRetry(
   embeddingScheduler: EmbeddingScheduler,
   signal?: AbortSignal,
   onModelProgress?: (progress: EmbeddingModelProgress) => void,
+  onTerminalFailure?: (error: unknown) => void,
 ): Promise<EmbeddingResult> {
   let attempt = 0;
 
@@ -1356,6 +1382,12 @@ async function embedContentsWithRetry(
               rateLimited: retry.rateLimited,
               delayMs,
             });
+          }
+          if (
+            retry.failFast &&
+            (!retry.retryable || attempt >= maxRetryAttempts(retry))
+          ) {
+            onTerminalFailure?.(error);
           }
         },
       );
@@ -1632,6 +1664,10 @@ function classifyEmbeddingRetry(
       /\b(?:invalid|missing|unauthorized|forbidden)[ _-]?(?:api[ _-]?)?key\b/i.test(
         text,
       ));
+  const permanentRemoteModelFailure =
+    remoteEmbedding &&
+    (codes.includes("ZVEC_GREP.ENGINE.MODELS.EMBEDDING_DIMENSION_MISMATCH") ||
+      (status === 400 && isPermanentRemoteModelBadRequest(text)));
 
   return {
     retryable,
@@ -1640,9 +1676,34 @@ function classifyEmbeddingRetry(
       retryable ||
       sharedLocalModelFailure ||
       remoteConfigurationFailure ||
+      permanentRemoteModelFailure ||
       (remoteEmbedding && requestFailure),
     retryAfterMs: retryAfterMsFromText(text),
   };
+}
+
+function isPermanentRemoteModelBadRequest(text: string): boolean {
+  const providerCode = /\bproviderCode=([^\s]+)/i.exec(text)?.[1];
+  const normalizedCode = providerCode
+    ?.replace(/[^a-z0-9]+/gi, "_")
+    .replace(/^_+|_+$/g, "")
+    .toLowerCase();
+  if (
+    normalizedCode &&
+    PERMANENT_REMOTE_MODEL_PROVIDER_CODES.has(normalizedCode)
+  ) {
+    return true;
+  }
+
+  const providerMessage = /\bproviderMessage=(.*?)(?=\s+ZVEC_GREP\.|$)/i.exec(
+    text,
+  )?.[1];
+  return (
+    providerMessage !== undefined &&
+    /(?:\b(?:invalid|unsupported|unknown)\b.{0,48}\bmodel\b|\bmodel\b.{0,48}\b(?:invalid|unsupported|unknown|not found|does not exist)\b|\b(?:invalid|unsupported|out of range)\b.{0,48}\bdimensions?\b|\bdimensions?\b.{0,48}\b(?:invalid|unsupported|not supported|out of range|must|should|expected|between|only supports?)\b)/i.test(
+      providerMessage,
+    )
+  );
 }
 
 function nonRetryableEmbeddingError(): EmbeddingRetryClassification {

--- a/src/engine/pipeline/indexing/index.ts
+++ b/src/engine/pipeline/indexing/index.ts
@@ -719,6 +719,11 @@ async function indexFiles(
   );
   const embeddingTiming = new ConcurrentTiming(timings, "index_embedding");
   const runningEmbeddings = new Set<Promise<void>>();
+  const prepareModel =
+    ctx.embeddingModel.info.provider === "local"
+      ? ctx.embeddingModel.prepare?.bind(ctx.embeddingModel)
+      : undefined;
+  let modelPrepared = false;
   const reportEmbeddingProgress = (
     currentStats: IndexStats,
     detail: string,
@@ -752,6 +757,28 @@ async function indexFiles(
     task: () => Promise<void>,
   ): Promise<void> => {
     throwIfIndexCancelled(ctx);
+    if (!modelPrepared && prepareModel) {
+      // Finish shared initialization before any file or fragment batch is queued.
+      try {
+        await embeddingTiming.time(() =>
+          prepareModel({
+            signal: ctx.signal,
+            onProgress: (progress) =>
+              reportModelDownloadProgress(
+                stats,
+                progress,
+                onProgress,
+                embeddingScheduler,
+              ),
+          }),
+        );
+      } catch (error) {
+        throwIfIndexCancelled(ctx);
+        throw error;
+      }
+      throwIfIndexCancelled(ctx);
+    }
+    modelPrepared = true;
     const promise = task().finally(() => {
       runningEmbeddings.delete(promise);
     });

--- a/src/engine/pipeline/indexing/index.ts
+++ b/src/engine/pipeline/indexing/index.ts
@@ -121,6 +121,7 @@ type EmbeddingScheduler = {
 type EmbeddingRetryClassification = {
   retryable: boolean;
   rateLimited: boolean;
+  failFast: boolean;
   retryAfterMs?: number;
 };
 
@@ -926,13 +927,8 @@ async function embedAndCommitBatch(
     if (indexIsCancelled(ctx)) {
       throw indexCancellationError(ctx);
     }
-    if (isRetryableEmbeddingError(error)) {
-      for (const file of files) {
-        const reason = markFileFailed(ctx, file.file, error, "embed");
-        recordFileFailed(stats, file.file, reason);
-        onProgress(stats, finishedFileDetail(false, file.file.relativePath));
-      }
-      return;
+    if (shouldFailFastEmbeddingError(error, ctx.embeddingModel)) {
+      throw error;
     }
 
     for (const file of files) {
@@ -994,6 +990,9 @@ async function embedAndCommitFile(
   } catch (error) {
     if (indexIsCancelled(ctx)) {
       throw indexCancellationError(ctx);
+    }
+    if (shouldFailFastEmbeddingError(error, ctx.embeddingModel)) {
+      throw error;
     }
     const reason = markFileFailed(ctx, file.file, error, "embed");
     recordFileFailed(stats, file.file, reason);
@@ -1209,7 +1208,7 @@ async function embedFragmentBatch(
       onModelProgress,
     );
   } catch (error) {
-    if (fragments.length === 1 || isRetryableEmbeddingError(error)) {
+    if (fragments.length === 1 || shouldFailFastEmbeddingError(error, model)) {
       throw error;
     }
 
@@ -1249,6 +1248,9 @@ async function embedFragmentBatchOneByOne(
         truncatedInputIndexes.push(index);
       }
     } catch (error) {
+      if (shouldFailFastEmbeddingError(error, model)) {
+        throw error;
+      }
       throw new EngineError(
         "Embedding entity fragment failed after one-by-one fallback",
         {
@@ -1297,7 +1299,7 @@ async function embedContentsWithRetry(
           }),
         signal,
         (error) => {
-          retry = classifyEmbeddingRetry(error);
+          retry = classifyEmbeddingRetry(error, model);
           delayMs = retryDelayMs(attempt, retry);
           if (retry.retryable) {
             embeddingScheduler.recordRetryableFailure({
@@ -1316,7 +1318,7 @@ async function embedContentsWithRetry(
           : new Error("Embedding was cancelled.");
       }
       if (!retry.retryable) {
-        retry = classifyEmbeddingRetry(error);
+        retry = classifyEmbeddingRetry(error, model);
         delayMs = retryDelayMs(attempt, retry);
       }
 
@@ -1529,27 +1531,66 @@ function oneLine(value: string): string {
   return value.replace(/\s+/g, " ").trim();
 }
 
-function isRetryableEmbeddingError(error: unknown): boolean {
-  return classifyEmbeddingRetry(error).retryable;
+function shouldFailFastEmbeddingError(
+  error: unknown,
+  model: EmbeddingModel,
+): boolean {
+  return classifyEmbeddingRetry(error, model).failFast;
 }
 
-function classifyEmbeddingRetry(error: unknown): EmbeddingRetryClassification {
-  const message = errorToMessage(error);
-  const context =
-    isEngineError(error) && error.context ? ` ${error.context}` : "";
-  const text = `${message}${context}`;
+function classifyEmbeddingRetry(
+  error: unknown,
+  model: EmbeddingModel,
+): EmbeddingRetryClassification {
+  const codes = errorCodes(error);
+  const text = errorChainText(error);
   const status = httpStatusFromText(text);
+  const remoteEmbedding = model.info.provider !== "local";
   const rateLimited =
-    status === 429 ||
-    /rate limit|quota exceeded|too many requests|request rate increased too quickly/i.test(
-      text,
-    );
+    remoteEmbedding &&
+    (status === 429 ||
+      /rate limit|quota exceeded|too many requests|request rate increased too quickly/i.test(
+        text,
+      ));
   const serverError =
-    typeof status === "number" && status >= 500 && status <= 599;
+    remoteEmbedding &&
+    typeof status === "number" &&
+    status >= 500 &&
+    status <= 599;
+  const requestTimeout = remoteEmbedding && status === 408;
+  const requestFailure = codes.some((code) => code.endsWith("_REQUEST_FAILED"));
+  const transientNetworkFailure =
+    remoteEmbedding && requestFailure && isTransientNetworkFailure(text);
+  const sharedLocalModelFailure = codes.some(
+    (code) =>
+      code === "ZVEC_GREP.ENGINE.MODELS.MODEL2VEC_DOWNLOAD_FAILED" ||
+      code === "ZVEC_GREP.ENGINE.MODELS.MODEL2VEC_LOAD_FAILED" ||
+      code === "ZVEC_GREP.ENGINE.MODELS.MODEL2VEC_DISPOSED",
+  );
+  const retryable =
+    !sharedLocalModelFailure &&
+    (rateLimited || serverError || requestTimeout || transientNetworkFailure);
+  const remoteConfigurationFailure =
+    remoteEmbedding &&
+    (codes.some(
+      (code) =>
+        code.endsWith("_MISSING_API_KEY") || code.endsWith("_MISSING_ENDPOINT"),
+    ) ||
+      status === 401 ||
+      status === 403 ||
+      status === 404 ||
+      /\b(?:invalid|missing|unauthorized|forbidden)[ _-]?(?:api[ _-]?)?key\b/i.test(
+        text,
+      ));
 
   return {
-    retryable: rateLimited || serverError,
+    retryable,
     rateLimited,
+    failFast:
+      retryable ||
+      sharedLocalModelFailure ||
+      remoteConfigurationFailure ||
+      (remoteEmbedding && requestFailure),
     retryAfterMs: retryAfterMsFromText(text),
   };
 }
@@ -1558,7 +1599,77 @@ function nonRetryableEmbeddingError(): EmbeddingRetryClassification {
   return {
     retryable: false,
     rateLimited: false,
+    failFast: false,
   };
+}
+
+function errorCodes(error: unknown): string[] {
+  const codes: string[] = [];
+
+  for (const current of errorChain(error)) {
+    if (
+      typeof current === "object" &&
+      current !== null &&
+      "code" in current &&
+      typeof current.code === "string"
+    ) {
+      codes.push(current.code);
+    }
+  }
+
+  return codes;
+}
+
+function errorChainText(error: unknown): string {
+  const parts: string[] = [];
+
+  for (const current of errorChain(error)) {
+    if (current instanceof Error) {
+      parts.push(current.name, current.message);
+    } else {
+      parts.push(String(current));
+    }
+    if (isEngineError(current) && current.context) {
+      parts.push(current.context);
+    }
+    if (
+      typeof current === "object" &&
+      current !== null &&
+      "code" in current &&
+      typeof current.code === "string"
+    ) {
+      parts.push(current.code);
+    }
+  }
+
+  return parts.join(" ");
+}
+
+function errorChain(error: unknown): unknown[] {
+  const chain: unknown[] = [];
+  const seen = new Set<unknown>();
+  let current: unknown = error;
+
+  while (current !== undefined && current !== null && !seen.has(current)) {
+    seen.add(current);
+    chain.push(current);
+    if (
+      typeof current !== "object" ||
+      !("cause" in current) ||
+      current.cause === undefined
+    ) {
+      break;
+    }
+    current = current.cause;
+  }
+
+  return chain;
+}
+
+function isTransientNetworkFailure(text: string): boolean {
+  return /\b(?:EAI_AGAIN|ECONNREFUSED|ECONNRESET|EHOSTUNREACH|ENETDOWN|ENETUNREACH|ENOTFOUND|ETIMEDOUT|UND_ERR_CONNECT_TIMEOUT|UND_ERR_HEADERS_TIMEOUT|UND_ERR_SOCKET|TimeoutError)\b|connection (?:reset|timed out)|network connection (?:failed|was lost)|socket hang up|temporary failure/i.test(
+    text,
+  );
 }
 
 function maxRetryAttempts(retry: EmbeddingRetryClassification): number {

--- a/src/mcp/schemas.ts
+++ b/src/mcp/schemas.ts
@@ -310,8 +310,10 @@ const jobStateSchema = z.enum([
   "cancelled",
 ]);
 const jobErrorSchema = z.object({
-  code: z.string(),
+  code: z.string().regex(/^[A-Z][A-Z0-9_.-]{0,127}$/),
   message: z.string(),
+  context: z.string().max(4_096).optional(),
+  cause: z.string().max(512).optional(),
 });
 const rangeSchema = z.union([
   z.object({ kind: z.literal("file") }),

--- a/src/mcp/schemas.ts
+++ b/src/mcp/schemas.ts
@@ -312,6 +312,7 @@ const jobStateSchema = z.enum([
 const jobErrorSchema = z.object({
   code: z.string(),
   message: z.string(),
+  context: z.string().optional(),
 });
 const rangeSchema = z.union([
   z.object({ kind: z.literal("file") }),

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -72,6 +72,13 @@ import {
 export type IndexJobState =
   "queued" | "running" | "succeeded" | "failed" | "cancelled";
 
+export type ZvecGrepIndexError = {
+  code: string;
+  message: string;
+  context?: string;
+  cause?: string;
+};
+
 export type ZvecGrepIndexResult = {
   root: string;
   jobId: string;
@@ -79,7 +86,7 @@ export type ZvecGrepIndexResult = {
   reused: boolean;
   action?: "index" | "drop";
   dropped?: boolean;
-  error?: { code: string; message: string };
+  error?: ZvecGrepIndexError;
   scanDiagnostics?: FileScanDiagnostics;
 };
 
@@ -165,7 +172,7 @@ export type ZvecGrepIndexStatusResult = {
       completed: number;
       total: number;
     };
-    error?: { code: string; message: string };
+    error?: ZvecGrepIndexError;
   };
 };
 
@@ -405,6 +412,12 @@ export function registerZvecGrepTools(
                   ? [
                       `error_code: ${result.error.code}`,
                       `error_message: ${result.error.message}`,
+                      ...(result.error.context
+                        ? [`error_context: ${result.error.context}`]
+                        : []),
+                      ...(result.error.cause
+                        ? [`error_cause: ${result.error.cause}`]
+                        : []),
                     ]
                   : []),
                 ...(result.scanDiagnostics

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -79,7 +79,7 @@ export type ZvecGrepIndexResult = {
   reused: boolean;
   action?: "index" | "drop";
   dropped?: boolean;
-  error?: { code: string; message: string };
+  error?: { code: string; message: string; context?: string };
   scanDiagnostics?: FileScanDiagnostics;
 };
 
@@ -165,7 +165,7 @@ export type ZvecGrepIndexStatusResult = {
       completed: number;
       total: number;
     };
-    error?: { code: string; message: string };
+    error?: { code: string; message: string; context?: string };
   };
 };
 
@@ -405,6 +405,9 @@ export function registerZvecGrepTools(
                   ? [
                       `error_code: ${result.error.code}`,
                       `error_message: ${result.error.message}`,
+                      ...(result.error.context
+                        ? [`error_context: ${result.error.context}`]
+                        : []),
                     ]
                   : []),
                 ...(result.scanDiagnostics

--- a/test/daemon-backend.test.mjs
+++ b/test/daemon-backend.test.mjs
@@ -45,6 +45,77 @@ test("index releases its model lease when service creation fails", async () => {
   }
 });
 
+test("index preserves Qwen model creation diagnostics when the API key is missing", async () => {
+  const temporaryDirectory = await mkdtemp(
+    join(tmpdir(), "zvec-grep-backend-qwen-missing-key-"),
+  );
+  const root = join(temporaryDirectory, "repo");
+  await mkdir(root);
+  const backend = new DaemonBackend({
+    version: "1.0.0",
+    serviceOptions: { apiKey: "" },
+    watchManagerFactory: noopWatchManagerFactory,
+  });
+
+  try {
+    const result = await backend.index({
+      root,
+      embedding: "qwen/text-embedding-v4",
+      wait: true,
+    });
+
+    assert.equal(result.state, "failed");
+    assert.equal(
+      result.error.code,
+      "ZVEC_GREP.ENGINE.MODELS.QWEN_TEXT_EMBEDDING_V4_MISSING_API_KEY",
+    );
+    assert.equal(
+      result.error.message,
+      "Qwen text-embedding-v4 model requires an API key",
+    );
+    assert.match(result.error.context, /model=qwen\/text-embedding-v4/);
+    assert.match(result.error.context, /hint=Pass --api-key/);
+  } finally {
+    await backend.close();
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  }
+});
+
+test("index wraps unstructured model creation failures", async () => {
+  const temporaryDirectory = await mkdtemp(
+    join(tmpdir(), "zvec-grep-backend-model-create-failure-"),
+  );
+  const root = join(temporaryDirectory, "repo");
+  await mkdir(root);
+  const backend = new DaemonBackend({
+    version: "1.0.0",
+    modelPoolOptions: {
+      createModel: () => {
+        throw new Error("fixture model creation failure");
+      },
+    },
+    watchManagerFactory: noopWatchManagerFactory,
+  });
+
+  try {
+    const result = await backend.index({
+      root,
+      embedding: "test/deterministic",
+      wait: true,
+    });
+
+    assert.equal(result.state, "failed");
+    assert.deepEqual(result.error, {
+      code: "MODEL_LOAD_FAILED",
+      message:
+        "[MODEL_LOAD_FAILED] Embedding model test/deterministic could not be created: fixture model creation failure",
+    });
+  } finally {
+    await backend.close();
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  }
+});
+
 test("index returns scan diagnostics only when debug is requested", async () => {
   const temporaryDirectory = await mkdtemp(
     join(tmpdir(), "zvec-grep-backend-debug-"),

--- a/test/e2e/cli.test.mjs
+++ b/test/e2e/cli.test.mjs
@@ -98,6 +98,65 @@ test("direct and server indexes report aggregate local model download progress",
   );
 });
 
+test("direct-mode debug index reports a redacted local model download failure", async (t) => {
+  const temporaryDirectory = await createTemporaryDirectory(
+    t,
+    "zvec-grep-direct-model-download-failure-",
+  );
+  const root = join(temporaryDirectory, "repo");
+  const home = join(temporaryDirectory, "home");
+  const modelCache = join(temporaryDirectory, "models");
+  await mkdir(join(root, "src"), { recursive: true });
+  await writeFile(
+    join(root, "src", "example.ts"),
+    "export const DirectModelDownloadFailure = 1;\n",
+  );
+
+  const preload = pathToFileURL(
+    resolve("test/helpers/failing-model-download.mjs"),
+  ).href;
+  const env = {
+    HOME: home,
+    USERPROFILE: home,
+    NO_COLOR: "1",
+    NODE_OPTIONS: `--import=${preload}`,
+    ZVEC_GREP_HOME: home,
+  };
+
+  await assert.rejects(
+    runCli(
+      [
+        "index",
+        "--mode",
+        "direct",
+        "--embedding",
+        "local/potion-code-16m-v2",
+        "--model-cache",
+        modelCache,
+        "--debug",
+        root,
+      ],
+      { cwd: root, env, timeout: 120_000 },
+    ),
+    (error) => {
+      assert.match(
+        error.stderr,
+        /Code:\s+ZVEC_GREP\.ENGINE\.MODELS\.MODEL2VEC_DOWNLOAD_FAILED/,
+      );
+      assert.match(
+        error.stderr,
+        /Cause:\s+simulated model download network failure/,
+      );
+      assert.match(error.stderr, /\[redacted\]/);
+      assert.doesNotMatch(
+        `${error.stdout}\n${error.stderr}`,
+        /model-download-secret/,
+      );
+      return true;
+    },
+  );
+});
+
 test("server-mode debug index reports a redacted local model download failure", async (t) => {
   const temporaryDirectory = await createTemporaryDirectory(
     t,

--- a/test/e2e/cli.test.mjs
+++ b/test/e2e/cli.test.mjs
@@ -98,6 +98,75 @@ test("direct and server indexes report aggregate local model download progress",
   );
 });
 
+test("server-mode index reports a redacted local model download failure", async (t) => {
+  const temporaryDirectory = await createTemporaryDirectory(
+    t,
+    "zvec-grep-server-model-download-failure-",
+    { cleanup: false },
+  );
+  const root = join(temporaryDirectory, "repo");
+  const home = join(temporaryDirectory, "home");
+  const modelCache = join(temporaryDirectory, "models");
+  await mkdir(join(root, "src"), { recursive: true });
+  await writeFile(
+    join(root, "src", "example.ts"),
+    "export const ModelDownloadFailure = 1;\n",
+  );
+
+  const preload = pathToFileURL(
+    resolve("test/helpers/failing-model-download.mjs"),
+  ).href;
+  const port = await availablePort();
+  const env = {
+    HOME: home,
+    USERPROFILE: home,
+    NO_COLOR: "1",
+    NODE_OPTIONS: `--import=${preload}`,
+    ZVEC_GREP_HOME: home,
+    ZVEC_GREP_MODEL_CACHE: modelCache,
+    ZVEC_GREP_SERVER_URL: `http://127.0.0.1:${port}/mcp`,
+  };
+  t.after(async () => {
+    await runCli(["server", "off", "--home", home], {
+      cwd: root,
+      env,
+    }).catch(() => undefined);
+    await removeTemporaryDirectory(temporaryDirectory);
+  });
+  await runCli(
+    ["server", "on", "--listen", `127.0.0.1:${port}`, "--home", home],
+    { cwd: root, env },
+  );
+
+  await assert.rejects(
+    runCli(
+      [
+        "index",
+        "--mode",
+        "server",
+        "--embedding",
+        "local/potion-code-16m-v2",
+        root,
+      ],
+      { cwd: root, env, timeout: 120_000 },
+    ),
+    (error) => {
+      assert.match(error.stdout, /Workspace index: failed/);
+      assert.match(
+        error.stderr,
+        /Code:\s+ZVEC_GREP\.ENGINE\.MODELS\.MODEL2VEC_DOWNLOAD_FAILED/,
+      );
+      assert.match(
+        error.stderr,
+        /Cause:\s+simulated model download network failure/,
+      );
+      assert.match(error.stderr, /\[redacted\]/);
+      assert.doesNotMatch(error.stderr, /model-download-secret/);
+      return true;
+    },
+  );
+});
+
 test("server-mode index reports Workspace progress", async (t) => {
   const temporaryDirectory = await createTemporaryDirectory(
     t,

--- a/test/e2e/cli.test.mjs
+++ b/test/e2e/cli.test.mjs
@@ -98,6 +98,142 @@ test("direct and server indexes report aggregate local model download progress",
   );
 });
 
+test("direct and server indexes summarize model download failures unless debugging", async (t) => {
+  const temporaryDirectory = await createTemporaryDirectory(
+    t,
+    "zvec-grep-local-download-failure-",
+    { cleanup: false },
+  );
+  const directRoot = join(temporaryDirectory, "direct-repo");
+  const serverRoot = join(temporaryDirectory, "server-repo");
+  const home = join(temporaryDirectory, "home");
+  for (const root of [directRoot, serverRoot]) {
+    await mkdir(root, { recursive: true });
+    await writeFile(join(root, "README.md"), "# Model download failure\n");
+  }
+  const preload = pathToFileURL(
+    resolve("test/helpers/fake-model-download.mjs"),
+  ).href;
+  const port = await availablePort();
+  const clientEnv = {
+    NO_COLOR: "1",
+    ZVEC_GREP_HOME: home,
+    ZVEC_GREP_SERVER_URL: `http://127.0.0.1:${port}/mcp`,
+    ZVEC_GREP_SERVER_TOKEN: undefined,
+    ZVEC_GREP_SERVER_TOKEN_FILE: undefined,
+  };
+  const downloadEnv = {
+    ...clientEnv,
+    NODE_OPTIONS: `--import=${preload}`,
+    ZVEC_GREP_TEST_MODEL_DOWNLOAD_FAILURE: "1",
+  };
+  t.after(async () => {
+    await runCli(["server", "off", "--home", home], {
+      env: clientEnv,
+    }).catch(() => undefined);
+    await removeTemporaryDirectory(temporaryDirectory);
+  });
+
+  const conciseMessage = 'Failed to download model "local/potion-code-16m-v2".';
+  const conciseError = `Error: ${conciseMessage}`;
+  const assertConciseOutput = (output) => {
+    assert.ok(output.includes(conciseMessage), output);
+    assert.doesNotMatch(
+      output,
+      /ZVEC_GREP\.|MODEL2VEC_DOWNLOAD_FAILED|Code:|Details:|huggingface\.co/,
+    );
+  };
+  const assertDebugOutput = (output) => {
+    assert.ok(output.includes(conciseMessage), output);
+    assert.match(output, /^\s*Details(?:\s|:)/m);
+    assert.match(output, /MODEL2VEC_DOWNLOAD_FAILED/);
+    assert.match(output, /Unable to download Model2Vec model artifact/);
+    assert.match(output, /model=local\/potion-code-16m-v2/);
+    assert.match(output, /huggingface\.co\/minishlab\/potion-code-16M-v2/);
+  };
+  const assertDownloadFailure = (debug) => (error) => {
+    assert.equal(error.code, 1);
+    assert.ok(error.stderr.split("\n").includes(conciseError), error.stderr);
+    if (debug) {
+      assert.match(error.stderr, /^Code:/m);
+      assertDebugOutput(error.stderr);
+    } else {
+      assert.equal(error.stderr.trimEnd().split("\n").at(-1), conciseError);
+      assertConciseOutput(error.stderr);
+    }
+    return true;
+  };
+  for (const debug of [false, true]) {
+    await assert.rejects(
+      runCli(
+        [
+          "index",
+          directRoot,
+          "--mode",
+          "direct",
+          "--embedding",
+          "local/potion-code-16m-v2",
+          "--model-cache",
+          join(temporaryDirectory, "direct-models"),
+          ...(debug ? ["--debug"] : []),
+        ],
+        { env: downloadEnv, timeout: 120_000 },
+      ),
+      assertDownloadFailure(debug),
+    );
+  }
+
+  await runCli(
+    ["server", "on", "--listen", `127.0.0.1:${port}`, "--home", home],
+    {
+      env: {
+        ...downloadEnv,
+        ZVEC_GREP_MODEL_CACHE: join(temporaryDirectory, "server-models"),
+      },
+    },
+  );
+  for (const debug of [false, true]) {
+    await assert.rejects(
+      runCli(
+        [
+          "index",
+          serverRoot,
+          "--mode",
+          "server",
+          "--embedding",
+          "local/potion-code-16m-v2",
+          ...(debug ? ["--debug"] : []),
+        ],
+        { env: clientEnv, timeout: 120_000 },
+      ),
+      assertDownloadFailure(debug),
+    );
+  }
+  const ready = await runCli(["server", "status", "--check-ready"], {
+    env: clientEnv,
+  });
+  assert.match(ready.stdout, /Server: ready/);
+  const status = await runCli(["status", serverRoot, "--mode", "server"], {
+    env: clientEnv,
+  });
+  assert.match(status.stdout, /Workspace index failed/);
+  assert.match(
+    status.stdout,
+    /^\s*Error\s+Failed to download model "local\/potion-code-16m-v2"\.$/m,
+  );
+  assertConciseOutput(status.stdout);
+  const debugStatus = await runCli(
+    ["status", serverRoot, "--mode", "server", "--debug"],
+    { env: clientEnv },
+  );
+  assert.match(debugStatus.stdout, /Workspace index failed/);
+  assert.match(
+    debugStatus.stdout,
+    /^\s*Error\s+Failed to download model "local\/potion-code-16m-v2"\.$/m,
+  );
+  assertDebugOutput(debugStatus.stdout);
+});
+
 test("server-mode index reports Workspace progress", async (t) => {
   const temporaryDirectory = await createTemporaryDirectory(
     t,

--- a/test/helpers/failing-model-download.mjs
+++ b/test/helpers/failing-model-download.mjs
@@ -1,0 +1,15 @@
+const originalFetch = globalThis.fetch;
+
+globalThis.fetch = async (input, init) => {
+  const url =
+    typeof Request !== "undefined" && input instanceof Request
+      ? input.url
+      : String(input);
+  if (!url.startsWith("https://huggingface.co/")) {
+    return await originalFetch(input, init);
+  }
+
+  throw new Error(
+    "simulated model download network failure token=model-download-secret",
+  );
+};

--- a/test/helpers/fake-model-download.mjs
+++ b/test/helpers/fake-model-download.mjs
@@ -9,6 +9,13 @@ globalThis.fetch = async (input, init) => {
     return await originalFetch(input, init);
   }
 
+  if (process.env.ZVEC_GREP_TEST_MODEL_DOWNLOAD_FAILURE === "1") {
+    return new Response("Injected model download failure", {
+      status: 503,
+      statusText: "Service Unavailable",
+    });
+  }
+
   const size = url.endsWith("/tokenizer.json") ? 128 : 1024;
   const bytes = new Uint8Array(size);
   bytes.fill(1);

--- a/test/integration/service.test.mjs
+++ b/test/integration/service.test.mjs
@@ -50,6 +50,28 @@ class SharedFailureEmbeddingModel extends FakeEmbeddingModel {
   }
 }
 
+class ImmediateAuthenticationFailureEmbeddingModel extends FakeEmbeddingModel {
+  calls = 0;
+
+  constructor() {
+    super();
+    this.info = {
+      ...this.info,
+      provider: "qwen",
+      defaultConcurrency: 4,
+      limits: { maxBatchSize: 1 },
+    };
+  }
+
+  async doEmbed() {
+    const call = ++this.calls;
+    throw new EngineError(`fixture authentication failure call=${call}`, {
+      code: "ZVEC_GREP.ENGINE.MODELS.QWEN_TEXT_EMBEDDING_API_ERROR",
+      context: `status=401 providerCode=invalid_api_key call=${call}`,
+    });
+  }
+}
+
 class RecoveringRemoteEmbeddingModel extends FakeEmbeddingModel {
   calls = 0;
 
@@ -433,6 +455,50 @@ test("service fails fast on permanent remote authentication failures", async (t)
       error.code === "ZVEC_GREP.ENGINE.MODELS.QWEN_TEXT_EMBEDDING_API_ERROR",
   );
   assert.equal(model.calls, 1);
+});
+
+test("service stops scheduling multi-file embedding batches after the first fatal rejection", async (t) => {
+  const temporaryDirectory = await createTemporaryDirectory(
+    t,
+    "zvec-grep-fast-reject-multi-file-",
+    { cleanup: false },
+  );
+  const root = join(temporaryDirectory, "repo");
+  await mkdir(root, { recursive: true });
+  await Promise.all(
+    Array.from({ length: 20 }, (_, index) =>
+      writeFile(join(root, `file-${index}.txt`), `unique content ${index}\n`),
+    ),
+  );
+  const model = new ImmediateAuthenticationFailureEmbeddingModel();
+  const service = await createZvecGrep({ root, embeddingModel: model });
+  t.after(async () => {
+    await service.close();
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  });
+
+  const unhandledRejections = [];
+  const onUnhandledRejection = (reason) => unhandledRejections.push(reason);
+  process.on("unhandledRejection", onUnhandledRejection);
+  try {
+    await assert.rejects(
+      service.index({ embeddingConcurrency: 4 }),
+      (error) =>
+        error.code ===
+          "ZVEC_GREP.ENGINE.MODELS.QWEN_TEXT_EMBEDDING_API_ERROR" &&
+        error.message === "fixture authentication failure call=1",
+    );
+    await new Promise((resolve) => setImmediate(resolve));
+  } finally {
+    process.off("unhandledRejection", onUnhandledRejection);
+  }
+
+  assert.ok(model.calls >= 1);
+  assert.ok(
+    model.calls <= 4,
+    `expected at most the active concurrency, received ${model.calls} calls`,
+  );
+  assert.deepEqual(unhandledRejections, []);
 });
 
 test("service stops after bounded remote retries without a failed-file pass", async (t) => {

--- a/test/integration/service.test.mjs
+++ b/test/integration/service.test.mjs
@@ -457,6 +457,43 @@ test("service fails fast on permanent remote authentication failures", async (t)
   assert.equal(model.calls, 1);
 });
 
+for (const [name, context] of [
+  [
+    "invalid model",
+    "status=400 providerCode=invalid_model providerType=invalid_request_error providerMessage=Model does not exist",
+  ],
+  [
+    "invalid dimensions",
+    "status=400 providerCode=InvalidParameter providerType=invalid_request_error providerMessage=dimensions must be between 1 and 4096",
+  ],
+]) {
+  test(`service fails fast on permanent remote ${name} failures`, async (t) => {
+    const temporaryDirectory = await createTemporaryDirectory(
+      t,
+      "zvec-grep-remote-configuration-failure-",
+    );
+    const root = join(temporaryDirectory, "repo");
+    await mkdir(root, { recursive: true });
+    await writeFile(join(root, "example.ts"), "export const Example = 1;\n");
+    const model = new SharedFailureEmbeddingModel({
+      provider: "qwen",
+      code: "ZVEC_GREP.ENGINE.MODELS.QWEN_TEXT_EMBEDDING_API_ERROR",
+      context,
+    });
+    const service = await createZvecGrep({ root, embeddingModel: model });
+    t.after(() => service.close());
+
+    await assert.rejects(
+      service.index(),
+      (error) =>
+        error.code ===
+          "ZVEC_GREP.ENGINE.MODELS.QWEN_TEXT_EMBEDDING_API_ERROR" &&
+        error.context === context,
+    );
+    assert.equal(model.calls, 1);
+  });
+}
+
 test("service stops scheduling multi-file embedding batches after the first fatal rejection", async (t) => {
   const temporaryDirectory = await createTemporaryDirectory(
     t,
@@ -499,6 +536,37 @@ test("service stops scheduling multi-file embedding batches after the first fata
     `expected at most the active concurrency, received ${model.calls} calls`,
   );
   assert.deepEqual(unhandledRejections, []);
+});
+
+test("service stops scheduling remaining fragment batches after a fatal rejection", async (t) => {
+  const temporaryDirectory = await createTemporaryDirectory(
+    t,
+    "zvec-grep-fast-reject-multi-fragment-",
+    { cleanup: false },
+  );
+  const root = join(temporaryDirectory, "repo");
+  await mkdir(root, { recursive: true });
+  await writeFile(
+    join(root, "large.ts"),
+    Array.from(
+      { length: 12 },
+      (_, index) => `export function Fragment${index}() { return ${index}; }\n`,
+    ).join(""),
+  );
+  const model = new ImmediateAuthenticationFailureEmbeddingModel();
+  const service = await createZvecGrep({ root, embeddingModel: model });
+  t.after(async () => {
+    await service.close();
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  });
+
+  await assert.rejects(
+    service.index({ embeddingConcurrency: 1 }),
+    (error) =>
+      error.code === "ZVEC_GREP.ENGINE.MODELS.QWEN_TEXT_EMBEDDING_API_ERROR" &&
+      error.message === "fixture authentication failure call=1",
+  );
+  assert.equal(model.calls, 1);
 });
 
 test("service stops after bounded remote retries without a failed-file pass", async (t) => {
@@ -948,4 +1016,34 @@ test("service records failed files, retries them, deletes stale records, and reb
   const rebuilt = await service.index({ rebuild: true });
   assert.equal(rebuilt.filesScanned, 1);
   assert.equal(rebuilt.filesAdded, 1);
+});
+
+test("changedPaths preserves request-specific embedding failure details", async (t) => {
+  const temporaryDirectory = await createTemporaryDirectory(
+    t,
+    "zvec-grep-path-failure-details-",
+  );
+  const root = join(temporaryDirectory, "repo");
+  await mkdir(root, { recursive: true });
+  const changedPath = join(root, "changed.ts");
+  await writeFile(changedPath, "export const InitialNeedle = 1;\n");
+  const service = await createZvecGrep({
+    root,
+    embeddingModel: new SelectivelyFailingEmbeddingModel(),
+  });
+  t.after(() => service.close());
+  await service.index();
+
+  await writeFile(changedPath, "export const FailureNeedle = 2;\n");
+  await assert.rejects(
+    service.index({ changedPaths: [changedPath] }),
+    (error) =>
+      error.code === "ZVEC_GREP.ENGINE.INDEXING.FILES_FAILED" &&
+      /failedFiles=changed\.ts/.test(error.context) &&
+      /QWEN_TEXT_EMBEDDING_API_ERROR/.test(error.context) &&
+      /fixture embedding failure/.test(error.context) &&
+      /status=400/.test(error.context) &&
+      /providerCode=invalid_input/.test(error.context) &&
+      /Retried failed files once automatically/.test(error.context),
+  );
 });

--- a/test/integration/service.test.mjs
+++ b/test/integration/service.test.mjs
@@ -2,12 +2,18 @@ import assert from "node:assert/strict";
 import { access, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import test from "node:test";
+import { EngineError } from "../../dist/engine/errors.js";
 import { CURRENT_INDEX_VERSION } from "../../dist/engine/types.js";
 import { createZvecGrep } from "../../dist/index.js";
 import { createTemporaryDirectory } from "../helpers/fixtures.mjs";
 import { FakeEmbeddingModel } from "../helpers/fake-embedding.mjs";
 
 class SelectivelyFailingEmbeddingModel extends FakeEmbeddingModel {
+  constructor() {
+    super();
+    this.info = { ...this.info, provider: "qwen" };
+  }
+
   async doEmbed(contents) {
     if (
       contents.some(
@@ -15,7 +21,47 @@ class SelectivelyFailingEmbeddingModel extends FakeEmbeddingModel {
           content.kind === "text" && content.text.includes("FailureNeedle"),
       )
     ) {
-      throw new Error("fixture embedding failure");
+      throw new EngineError("fixture embedding failure", {
+        code: "ZVEC_GREP.ENGINE.MODELS.QWEN_TEXT_EMBEDDING_API_ERROR",
+        context: "status=400 providerCode=invalid_input",
+      });
+    }
+    return super.doEmbed(contents);
+  }
+}
+
+class SharedFailureEmbeddingModel extends FakeEmbeddingModel {
+  calls = 0;
+
+  constructor({ provider, code, context }) {
+    super();
+    this.info = { ...this.info, provider };
+    this.code = code;
+    this.context = context;
+  }
+
+  async doEmbed() {
+    this.calls++;
+    throw new EngineError("shared embedding failure", {
+      code: this.code,
+      context: this.context,
+    });
+  }
+}
+
+class RecoveringRemoteEmbeddingModel extends FakeEmbeddingModel {
+  calls = 0;
+
+  constructor(failure) {
+    super();
+    this.info = { ...this.info, provider: "qwen" };
+    this.failure = failure;
+  }
+
+  async doEmbed(contents) {
+    this.calls++;
+    if (this.calls < 3) {
+      throw this.failure();
     }
     return super.doEmbed(contents);
   }
@@ -112,6 +158,161 @@ test("service exposes embedding model download progress while indexing", async (
       .slice(preparingIndex, readyIndex + 1)
       .some((progress) => progress.embedding?.stage === undefined),
   );
+});
+
+test("service fails fast when a shared local embedding model cannot be prepared", async (t) => {
+  const temporaryDirectory = await createTemporaryDirectory(
+    t,
+    "zvec-grep-local-model-failure-",
+  );
+  const root = join(temporaryDirectory, "repo");
+  await mkdir(root, { recursive: true });
+  await writeFile(join(root, "first.ts"), "export const First = 1;\n");
+  await writeFile(join(root, "second.ts"), "export const Second = 2;\n");
+  const model = new SharedFailureEmbeddingModel({
+    provider: "local",
+    code: "ZVEC_GREP.ENGINE.MODELS.MODEL2VEC_DOWNLOAD_FAILED",
+    context: "model=local/test-potion repo=test/potion status=503",
+  });
+  const service = await createZvecGrep({ root, embeddingModel: model });
+  t.after(() => service.close());
+  const progressEvents = [];
+
+  await assert.rejects(
+    service.index({
+      onProgress: (progress) => progressEvents.push(progress),
+    }),
+    (error) =>
+      error.code === "ZVEC_GREP.ENGINE.MODELS.MODEL2VEC_DOWNLOAD_FAILED",
+  );
+
+  assert.equal(model.calls, 1);
+  assert.equal(
+    progressEvents.some((progress) =>
+      progress.detail?.toLowerCase().includes("retrying"),
+    ),
+    false,
+  );
+});
+
+test("service fails fast on permanent remote authentication failures", async (t) => {
+  const temporaryDirectory = await createTemporaryDirectory(
+    t,
+    "zvec-grep-remote-auth-failure-",
+  );
+  const root = join(temporaryDirectory, "repo");
+  await mkdir(root, { recursive: true });
+  await writeFile(join(root, "first.ts"), "export const First = 1;\n");
+  await writeFile(join(root, "second.ts"), "export const Second = 2;\n");
+  const model = new SharedFailureEmbeddingModel({
+    provider: "qwen",
+    code: "ZVEC_GREP.ENGINE.MODELS.QWEN_TEXT_EMBEDDING_API_ERROR",
+    context: "status=401 providerCode=invalid_api_key",
+  });
+  const service = await createZvecGrep({ root, embeddingModel: model });
+  t.after(() => service.close());
+
+  await assert.rejects(
+    service.index(),
+    (error) =>
+      error.code === "ZVEC_GREP.ENGINE.MODELS.QWEN_TEXT_EMBEDDING_API_ERROR",
+  );
+  assert.equal(model.calls, 1);
+});
+
+test("service stops after bounded remote retries without a failed-file pass", async (t) => {
+  const temporaryDirectory = await createTemporaryDirectory(
+    t,
+    "zvec-grep-remote-retry-exhausted-",
+  );
+  const root = join(temporaryDirectory, "repo");
+  await mkdir(root, { recursive: true });
+  await writeFile(join(root, "example.ts"), "export const Example = 1;\n");
+  const model = new SharedFailureEmbeddingModel({
+    provider: "qwen",
+    code: "ZVEC_GREP.ENGINE.MODELS.QWEN_TEXT_EMBEDDING_API_ERROR",
+    context: "status=503 retryAfterMs=0",
+  });
+  const service = await createZvecGrep({ root, embeddingModel: model });
+  t.after(() => service.close());
+  const progressEvents = [];
+
+  await assert.rejects(
+    service.index({
+      onProgress: (progress) => progressEvents.push(progress),
+    }),
+    (error) =>
+      error.code === "ZVEC_GREP.ENGINE.MODELS.QWEN_TEXT_EMBEDDING_API_ERROR",
+  );
+
+  assert.equal(model.calls, 4);
+  assert.equal(
+    progressEvents.some((progress) =>
+      progress.detail?.toLowerCase().includes("retrying"),
+    ),
+    false,
+  );
+});
+
+test("service retries bounded remote HTTP and network failures before recovery", async (t) => {
+  const fixtures = [
+    {
+      name: "rate-limit",
+      failure: () =>
+        new EngineError("remote rate limit", {
+          code: "ZVEC_GREP.ENGINE.MODELS.QWEN_TEXT_EMBEDDING_API_ERROR",
+          context: "status=429 retryAfterMs=0",
+        }),
+    },
+    {
+      name: "request-timeout",
+      failure: () =>
+        new EngineError("remote request timeout", {
+          code: "ZVEC_GREP.ENGINE.MODELS.QWEN_TEXT_EMBEDDING_API_ERROR",
+          context: "status=408 retryAfterMs=0",
+        }),
+    },
+    {
+      name: "server",
+      failure: () =>
+        new EngineError("remote server unavailable", {
+          code: "ZVEC_GREP.ENGINE.MODELS.QWEN_TEXT_EMBEDDING_API_ERROR",
+          context: "status=503 retryAfterMs=0",
+        }),
+    },
+    {
+      name: "network",
+      failure: () => {
+        const cause = new Error("connection timed out");
+        cause.code = "ETIMEDOUT";
+        return new EngineError("remote request failed", {
+          code: "ZVEC_GREP.ENGINE.MODELS.QWEN_TEXT_EMBEDDING_REQUEST_FAILED",
+          context: "model=qwen/test endpoint=https://example.test",
+          cause,
+        });
+      },
+    },
+  ];
+
+  for (const fixture of fixtures) {
+    await t.test(fixture.name, async (t) => {
+      const temporaryDirectory = await createTemporaryDirectory(
+        t,
+        `zvec-grep-remote-${fixture.name}-recovery-`,
+      );
+      const root = join(temporaryDirectory, "repo");
+      await mkdir(root, { recursive: true });
+      await writeFile(join(root, "example.ts"), "export const Example = 1;\n");
+      const model = new RecoveringRemoteEmbeddingModel(fixture.failure);
+      const service = await createZvecGrep({ root, embeddingModel: model });
+      t.after(() => service.close());
+
+      const result = await service.index();
+
+      assert.equal(result.filesFailed, 0);
+      assert.equal(model.calls, 3);
+    });
+  }
 });
 
 test("service indexes, searches, refreshes, and drops a workspace index", async (t) => {

--- a/test/integration/service.test.mjs
+++ b/test/integration/service.test.mjs
@@ -3,6 +3,7 @@ import { access, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import test from "node:test";
 import { EngineError } from "../../dist/engine/errors.js";
+import { Model2VecEmbeddingModel } from "../../dist/engine/models/backends/model2vec.js";
 import { CURRENT_INDEX_VERSION } from "../../dist/engine/types.js";
 import { createZvecGrep } from "../../dist/index.js";
 import { createTemporaryDirectory } from "../helpers/fixtures.mjs";
@@ -107,6 +108,117 @@ class DownloadProgressEmbeddingModel extends FakeEmbeddingModel {
   }
 }
 
+function multiBatchModel2Vec(modelCacheDir, failure) {
+  const calls = {
+    downloads: [],
+    loads: [],
+    batches: [],
+    completedBatches: [],
+    events: [],
+    activeBatches: 0,
+    maxActiveBatches: 0,
+    failure,
+  };
+  let releaseFailedDownload;
+  let releaseFirstBatch;
+  const firstBatchMayComplete = new Promise((resolve) => {
+    releaseFirstBatch = resolve;
+  });
+  class TrackedModel2Vec extends Model2VecEmbeddingModel {
+    async doEmbed(contents, options) {
+      const batch = calls.batches.length;
+      calls.batches.push(contents.map((content) => content.text));
+      calls.events.push("embed");
+      calls.activeBatches++;
+      calls.maxActiveBatches = Math.max(
+        calls.maxActiveBatches,
+        calls.activeBatches,
+      );
+      try {
+        const result = await super.doEmbed(contents, options);
+        if (batch === 0) {
+          // Complete a later batch first to exercise vector/fragment ordering.
+          await firstBatchMayComplete;
+        } else if (batch === 1) {
+          releaseFirstBatch();
+        }
+        calls.completedBatches.push(batch);
+        return result;
+      } finally {
+        calls.activeBatches--;
+      }
+    }
+  }
+  const model = new TrackedModel2Vec(
+    {
+      backend: "model2vec",
+      reference: "local/test-multi-batch-potion",
+      provider: "local",
+      model: "test-multi-batch-potion",
+      repo: "test/multi-batch-potion",
+      revision: "0123456789abcdef",
+      modelFile: "model.safetensors",
+      embeddingTensor: "embeddings",
+      tokenizerFile: "tokenizer.json",
+      dimension: 3,
+      metric: "cosine",
+      normalize: true,
+      maxInputTokens: 512,
+      maxBatchSize: 256,
+      defaultConcurrency: 2,
+    },
+    { modelCacheDir },
+    {
+      async download(url, destination) {
+        calls.downloads.push(url.split("/").at(-1));
+        calls.events.push("download");
+        if (calls.failure === "download") {
+          // Both artifacts belong to one preparation attempt. Let both start
+          // before failing so the count does not depend on filesystem timing.
+          if (calls.downloads.length % 2 === 1) {
+            await new Promise((resolve) => {
+              releaseFailedDownload = resolve;
+            });
+          } else {
+            releaseFailedDownload();
+          }
+          throw new Error("HTTP 503 Service Unavailable");
+        }
+        await writeFile(destination, "fixture model asset");
+      },
+      async loadSafetensors() {
+        calls.loads.push("table");
+        calls.events.push("load:table");
+        if (calls.failure === "load") {
+          throw new Error("invalid model tensor");
+        }
+        return {
+          data: Float32Array.from(
+            Array.from({ length: 770 }, (_, id) => [
+              Math.cos(id / 250),
+              Math.sin(id / 250),
+              1,
+            ]).flat(),
+          ),
+          dimension: 3,
+          dtype: "F32",
+          rows: 770,
+        };
+      },
+      async loadTokenizer() {
+        calls.loads.push("tokenizer");
+        calls.events.push("load:tokenizer");
+        return async (text) => ({
+          input_ids: {
+            data: [Number(/\bFragment(\d+)\b/.exec(text)?.[1] ?? 769)],
+          },
+        });
+      },
+    },
+  );
+  return { model, calls };
+}
+
 test("service exposes embedding model download progress while indexing", async (t) => {
   const temporaryDirectory = await createTemporaryDirectory(
     t,
@@ -193,6 +305,109 @@ test("service fails fast when a shared local embedding model cannot be prepared"
     ),
     false,
   );
+});
+
+test("service prepares Model2Vec once before queuing a large file and can recover on a later index", async (t) => {
+  for (const failure of ["download", "load"]) {
+    await t.test(failure, { timeout: 60_000 }, async (t) => {
+      const temporaryDirectory = await createTemporaryDirectory(
+        t,
+        "zvec-grep-multi-batch-model-preparation-",
+      );
+      const root = join(temporaryDirectory, "repo");
+      await mkdir(root, { recursive: true });
+      await writeFile(
+        join(root, "large.ts"),
+        Array.from(
+          { length: 769 },
+          (_, index) =>
+            `export function Fragment${index}() { return ${index}; }\n`,
+        ).join(""),
+      );
+      const { model, calls } = multiBatchModel2Vec(
+        join(temporaryDirectory, "models"),
+        failure,
+      );
+      const service = await createZvecGrep({ root, embeddingModel: model });
+      t.after(() => service.close());
+
+      await assert.rejects(
+        service.index({ embeddingConcurrency: 2 }),
+        (error) =>
+          error.code ===
+          `ZVEC_GREP.ENGINE.MODELS.MODEL2VEC_${failure.toUpperCase()}_FAILED`,
+      );
+      assert.deepEqual(calls.downloads.toSorted(), [
+        "model.safetensors",
+        "tokenizer.json",
+      ]);
+      assert.deepEqual(calls.loads, failure === "load" ? ["table"] : []);
+      assert.deepEqual(calls.batches, []);
+
+      calls.failure = null;
+      calls.events.length = 0;
+      const recovered = await service.index({ embeddingConcurrency: 2 });
+
+      assert.equal(recovered.filesFailed, 0);
+      assert.equal(recovered.filesScanned, 1);
+      assert.ok(recovered.entitiesCreated >= 769);
+      assert.equal(calls.downloads.length, failure === "download" ? 4 : 2);
+      assert.deepEqual(
+        calls.loads,
+        failure === "load"
+          ? ["table", "table", "tokenizer"]
+          : ["table", "tokenizer"],
+      );
+      assert.ok(calls.batches.length >= 4);
+      assert.equal(calls.batches[0].length, 256);
+      assert.equal(calls.maxActiveBatches, 2);
+      assert.notEqual(calls.completedBatches[0], 0);
+      assert.ok(
+        calls.events.indexOf("load:tokenizer") < calls.events.indexOf("embed"),
+      );
+
+      for (const index of [0, 256, 512, 768]) {
+        const result = await service.context({
+          routes: [{ mode: "vector", query: `Fragment${index}` }],
+          autoUpdate: false,
+          limit: 1,
+        });
+        assert.equal(result.items[0]?.metadata?.symbolName, `Fragment${index}`);
+      }
+    });
+  }
+});
+
+test("service only prepares local models for changed embeddable content", async (t) => {
+  for (const provider of ["local", "qwen"]) {
+    await t.test(provider, async (t) => {
+      const temporaryDirectory = await createTemporaryDirectory(
+        t,
+        "zvec-grep-lazy-model-preparation-",
+      );
+      const root = join(temporaryDirectory, "repo");
+      await mkdir(root, { recursive: true });
+      const model = new FakeEmbeddingModel();
+      model.info = { ...model.info, provider };
+      let preparations = 0;
+      model.prepare = async () => {
+        preparations++;
+      };
+      const service = await createZvecGrep({ root, embeddingModel: model });
+      t.after(() => service.close());
+
+      await service.index();
+      assert.equal(preparations, 0);
+      await writeFile(join(root, "empty.ts"), "");
+      await service.index();
+      assert.equal(preparations, 0);
+      await writeFile(join(root, "example.ts"), "export const Example = 1;\n");
+      await service.index();
+      assert.equal(preparations, provider === "local" ? 1 : 0);
+      await service.index();
+      assert.equal(preparations, provider === "local" ? 1 : 0);
+    });
+  }
 });
 
 test("service fails fast on permanent remote authentication failures", async (t) => {

--- a/test/job-scheduler.test.mjs
+++ b/test/job-scheduler.test.mjs
@@ -363,7 +363,7 @@ test("scheduler redacts credentials from failure context", async (t) => {
     reason: "manual",
     run: async () => {
       throw new EngineError(
-        "Indexing completed with 1 failed file secret=message-secret",
+        "Indexing completed with 1 failed file secret=message-secret Bearer \"message-bearer-secret\" status=401 Basic 'message-basic-secret'",
         {
           code: "ZVEC_GREP.ENGINE.INDEXING.FILES_FAILED",
           context: [
@@ -380,6 +380,8 @@ test("scheduler redacts credentials from failure context", async (t) => {
               authorization: 'Negotiate quoted-auth-start, quoted-auth-end"',
             }),
             "Basic standalone-basic-secret",
+            'Bearer "context-bearer-secret" status=403',
+            "Basic 'context-basic-secret' retryable=false",
             "id_token=id-secret refresh_token=refresh-secret",
             "downloadUrl=https://models.example/tokenizer.json?token=url-secret",
             "downloadUrl=https://user-secret:password-secret@models.example/tokenizer.json?access_token=access-secret&other=retained",
@@ -387,7 +389,7 @@ test("scheduler redacts credentials from failure context", async (t) => {
             "downloadUrl=custom.scheme+v1://scheme-user-secret@models.example/tokenizer.json",
           ].join("\n"),
           cause: new Error(
-            'fetch failed password="cause password secret" id_token=cause-id-secret',
+            'fetch failed password="cause password secret" id_token=cause-id-secret Bearer "cause-bearer-secret" causeCode=AUTH Basic \'cause-basic-secret\'',
           ),
         },
       );
@@ -399,9 +401,21 @@ test("scheduler redacts credentials from failure context", async (t) => {
   assert.match(result.error.context, /MODEL2VEC_DOWNLOAD_FAILED/);
   assert.match(result.error.context, /model=local\/potion-code-16m-v2/);
   assert.match(result.error.context, /\[redacted\]/);
+  assert.match(
+    result.error.message,
+    /Bearer \[redacted\] status=401 Basic \[redacted\]/,
+  );
+  assert.match(result.error.context, /Bearer \[redacted\]/);
+  assert.match(result.error.context, /Basic \[redacted\]/);
+  assert.match(result.error.context, /status=403/);
+  assert.match(result.error.context, /retryable=false/);
+  assert.match(
+    result.error.cause,
+    /Bearer \[redacted\] causeCode=AUTH Basic \[redacted\]/,
+  );
   assert.doesNotMatch(
     JSON.stringify(result.error),
-    /message-secret|bearer-secret|camel-secret|snake-secret|token-secret|json-secret|quoted-token-start|quoted-token-end|escaped-prefix|escaped-tail|single-prefix|single-tail|basic-secret|negotiate-secret|quoted-auth-start|quoted-auth-end|standalone-basic-secret|id-secret|refresh-secret|url-secret|user-secret|password-secret|access-secret|userinfo-secret|scheme-user-secret|cause password secret|cause-id-secret/,
+    /message-secret|message-bearer-secret|message-basic-secret|bearer-secret|camel-secret|snake-secret|token-secret|json-secret|quoted-token-start|quoted-token-end|escaped-prefix|escaped-tail|single-prefix|single-tail|basic-secret|negotiate-secret|quoted-auth-start|quoted-auth-end|standalone-basic-secret|context-bearer-secret|context-basic-secret|id-secret|refresh-secret|url-secret|user-secret|password-secret|access-secret|userinfo-secret|scheme-user-secret|cause password secret|cause-id-secret|cause-bearer-secret|cause-basic-secret/,
   );
   assert.match(result.error.context, /models\.example\/tokenizer\.json/);
   assert.match(result.error.context, /&other=retained/);

--- a/test/job-scheduler.test.mjs
+++ b/test/job-scheduler.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { DaemonError } from "../dist/daemon/errors.js";
 import { JobScheduler } from "../dist/daemon/job-scheduler.js";
+import { EngineError } from "../dist/engine/errors.js";
 
 test("scheduler reuses same-root jobs and enforces global concurrency", async () => {
   const scheduler = new JobScheduler({ concurrency: 1 });
@@ -245,15 +246,66 @@ test("scheduler status redacts credentials from failures", async () => {
     canonicalRoot: "/repo",
     reason: "manual",
     run: async () => {
-      throw new Error(
+      const error = new Error(
         "provider failed api_key=top-secret token:another-secret",
       );
+      error.code = "AUTH_FAILED apiKey=code-secret";
+      throw error;
     },
   });
   const result = await scheduler.wait(submitted.job.id);
   assert.equal(result.state, "failed");
+  assert.equal(result.error.code, "INDEX_FAILED");
   assert.match(result.error.message, /\[redacted\]/);
-  assert.doesNotMatch(result.error.message, /top-secret|another-secret/);
+  assert.doesNotMatch(
+    `${result.error.code}\n${result.error.message}`,
+    /top-secret|another-secret|code-secret/,
+  );
+  await scheduler.close();
+});
+
+test("scheduler preserves bounded EngineError diagnostics without credentials", async () => {
+  const scheduler = new JobScheduler({ maxAttempts: 1 });
+  const submitted = scheduler.submit({
+    canonicalRoot: "/repo",
+    reason: "manual",
+    run: async () => {
+      const networkCause = new Error(
+        "self-signed certificate in certificate chain token=nested-secret",
+      );
+      networkCause.code = "SELF_SIGNED_CERT_IN_CHAIN";
+      throw new EngineError("Indexing completed with 1 failed file", {
+        code: "ZVEC_GREP.ENGINE.INDEXING.FILES_FAILED",
+        context:
+          "failedReasons=src/a.ts: ZVEC_GREP.ENGINE.MODELS.QWEN_API_ERROR model=qwen/text-embedding-v4 status=403 providerCode=InvalidApiKey endpoint=https://user:password@example.test/embeddings?api_key=context-secret Authorization: Bearer context-bearer\n" +
+          "Authorization: Basic basic-secret\ndetail=" +
+          "x".repeat(5_000),
+        cause: new TypeError(
+          "fetch failed token=cause-secret apiKey='quoted-secret' sk-secretvalue123",
+          { cause: networkCause },
+        ),
+      });
+    },
+  });
+
+  const result = await scheduler.wait(submitted.job.id);
+  assert.equal(result.state, "failed");
+  assert.equal(result.error.code, "ZVEC_GREP.ENGINE.INDEXING.FILES_FAILED");
+  assert.match(result.error.context, /status=403/);
+  assert.match(result.error.context, /providerCode=InvalidApiKey/);
+  assert.match(result.error.context, /MODEL.*QWEN_API_ERROR/);
+  assert.match(result.error.context, /\[redacted\]/);
+  assert.match(result.error.cause, /fetch failed/);
+  assert.match(result.error.cause, /SELF_SIGNED_CERT_IN_CHAIN/);
+  assert.match(result.error.cause, /self-signed certificate/);
+  assert.match(result.error.cause, /\[redacted\]/);
+  assert.equal(result.error.context.length, 4_096);
+  assert.match(result.error.context, /…$/);
+  assert.ok(result.error.cause.length <= 512);
+  assert.doesNotMatch(
+    `${result.error.message}\n${result.error.context}\n${result.error.cause}`,
+    /context-secret|context-bearer|basic-secret|cause-secret|nested-secret|quoted-secret|secretvalue123|user:password/,
+  );
   await scheduler.close();
 });
 

--- a/test/job-scheduler.test.mjs
+++ b/test/job-scheduler.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { DaemonError } from "../dist/daemon/errors.js";
 import { JobScheduler } from "../dist/daemon/job-scheduler.js";
+import { EngineError } from "../dist/engine/errors.js";
 
 test("scheduler reuses same-root jobs and enforces global concurrency", async () => {
   const scheduler = new JobScheduler({ concurrency: 1 });
@@ -255,6 +256,159 @@ test("scheduler status redacts credentials from failures", async () => {
   assert.match(result.error.message, /\[redacted\]/);
   assert.doesNotMatch(result.error.message, /top-secret|another-secret/);
   await scheduler.close();
+});
+
+test("scheduler preserves model download failure context in job snapshots", async (t) => {
+  const scheduler = new JobScheduler({ maxAttempts: 1 });
+  t.after(() => scheduler.close());
+  const context = [
+    "failedFiles=1",
+    "failedReasons=[ZVEC_GREP.ENGINE.MODELS.MODEL2VEC_DOWNLOAD_FAILED] Failed to download Model2Vec model",
+    "model=local/potion-code-16m-v2",
+    "downloadUrl=https://models.example/potion-code-16m-v2/tokenizer.json",
+    "status=503",
+  ].join("\n");
+  const expectedError = {
+    code: "ZVEC_GREP.ENGINE.INDEXING.FILES_FAILED",
+    message: "Indexing completed with 1 failed file",
+    context,
+  };
+  const submitted = scheduler.submit({
+    canonicalRoot: "/repo-model-download",
+    reason: "manual",
+    run: async () => {
+      throw new EngineError(expectedError.message, {
+        code: expectedError.code,
+        context,
+      });
+    },
+  });
+
+  const completed = await scheduler.wait(submitted.job.id);
+  const byId = scheduler.get(submitted.job.id);
+  const byRoot = scheduler.getByRoot("/repo-model-download");
+  for (const result of [completed, byId, byRoot]) {
+    assert.equal(result.state, "failed");
+    assert.deepEqual(result.error, expectedError);
+  }
+  assert.notStrictEqual(completed.error, byId.error);
+  assert.notStrictEqual(byId.error, byRoot.error);
+
+  completed.error.context = "changed completion";
+  byId.error.context = "changed lookup";
+  byRoot.error.message = "changed root lookup";
+  assert.deepEqual(scheduler.get(submitted.job.id).error, expectedError);
+  assert.deepEqual(
+    scheduler.getByRoot("/repo-model-download").error,
+    expectedError,
+  );
+});
+
+test("scheduler redacts credentials from failure context", async (t) => {
+  const scheduler = new JobScheduler({ maxAttempts: 1 });
+  t.after(() => scheduler.close());
+  const submitted = scheduler.submit({
+    canonicalRoot: "/repo-model-download",
+    reason: "manual",
+    run: async () => {
+      throw new EngineError("Indexing completed with 1 failed file", {
+        code: "ZVEC_GREP.ENGINE.INDEXING.FILES_FAILED",
+        context: [
+          "failedReasons=MODEL2VEC_DOWNLOAD_FAILED",
+          "model=local/potion-code-16m-v2",
+          "authorization=Bearer bearer-secret",
+          "apiKey=camel-secret api_key=snake-secret token:token-secret",
+          '{"api_key":"json-secret","token":"quoted-token-start quoted-token-end"}',
+          JSON.stringify({ password: 'escaped-prefix"escaped-tail' }),
+          "secret='single-prefix\\'single-tail'",
+          "Authorization: Basic basic-secret",
+          "downloadUrl=https://models.example/tokenizer.json?token=url-secret",
+          "downloadUrl=https://user-secret:password-secret@models.example/tokenizer.json?access_token=access-secret&other=retained",
+        ].join("\n"),
+      });
+    },
+  });
+
+  const result = await scheduler.wait(submitted.job.id);
+  assert.equal(result.state, "failed");
+  assert.match(result.error.context, /MODEL2VEC_DOWNLOAD_FAILED/);
+  assert.match(result.error.context, /model=local\/potion-code-16m-v2/);
+  assert.match(result.error.context, /\[redacted\]/);
+  assert.doesNotMatch(
+    JSON.stringify(result.error),
+    /bearer-secret|camel-secret|snake-secret|token-secret|json-secret|quoted-token-start|quoted-token-end|escaped-prefix|escaped-tail|single-prefix|single-tail|basic-secret|url-secret|user-secret|password-secret|access-secret/,
+  );
+  assert.match(result.error.context, /models\.example\/tokenizer\.json/);
+  assert.match(result.error.context, /&other=retained/);
+  assert.deepEqual(scheduler.get(submitted.job.id).error, result.error);
+  assert.deepEqual(
+    scheduler.getByRoot("/repo-model-download").error,
+    result.error,
+  );
+});
+
+test("scheduler bounds failure context without losing the initial cause", async (t) => {
+  const scheduler = new JobScheduler({ maxAttempts: 1 });
+  t.after(() => scheduler.close());
+  const cause = [
+    "failedReasons=MODEL2VEC_DOWNLOAD_FAILED",
+    "model=local/potion-code-16m-v2",
+  ].join("\n");
+  const submitted = scheduler.submit({
+    canonicalRoot: "/repo-long-failure",
+    reason: "manual",
+    run: async () => {
+      throw new EngineError("Indexing completed with 1 failed file", {
+        code: "ZVEC_GREP.ENGINE.INDEXING.FILES_FAILED",
+        context: `${cause}\ndetail=${"x".repeat(6000)}\ntoken=tail-secret`,
+      });
+    },
+  });
+
+  const result = await scheduler.wait(submitted.job.id);
+  assert.equal(result.state, "failed");
+  assert.equal(result.error.context.startsWith(cause), true);
+  assert.ok(result.error.context.length > 512);
+  assert.ok(result.error.context.length <= 4096);
+  assert.doesNotMatch(result.error.context, /tail-secret/);
+});
+
+test("scheduler keeps failures without context backward compatible", async (t) => {
+  const cases = [
+    {
+      error: new EngineError("Indexing failed", {
+        code: "ZVEC_GREP.ENGINE.INDEXING.FILES_FAILED",
+      }),
+      expected: {
+        code: "ZVEC_GREP.ENGINE.INDEXING.FILES_FAILED",
+        message: "Indexing failed",
+      },
+    },
+    {
+      error: new DaemonError("INDEX_BUSY", "busy", false),
+      expected: { code: "INDEX_BUSY", message: "[INDEX_BUSY] busy" },
+    },
+    {
+      error: new Error("Indexing failed"),
+      expected: { code: "INDEX_FAILED", message: "Indexing failed" },
+    },
+  ];
+  for (const { error, expected } of cases) {
+    await t.test(error.name, async (t) => {
+      const scheduler = new JobScheduler({ maxAttempts: 1 });
+      t.after(() => scheduler.close());
+      const submitted = scheduler.submit({
+        canonicalRoot: "/repo",
+        reason: "manual",
+        run: async () => {
+          throw error;
+        },
+      });
+      const result = await scheduler.wait(submitted.job.id);
+      assert.equal(result.state, "failed");
+      assert.deepEqual(result.error, expected);
+    });
+  }
 });
 
 async function waitFor(predicate) {

--- a/test/mcp-contract.test.mjs
+++ b/test/mcp-contract.test.mjs
@@ -544,8 +544,11 @@ test("index result includes an immediately available failure reason", async (t) 
     state: "failed",
     reused: false,
     error: {
-      code: "MODEL_LOAD_FAILED",
-      message: "Embedding schema could not be resolved.",
+      code: "ZVEC_GREP.ENGINE.MODELS.MODEL2VEC_DOWNLOAD_FAILED",
+      message: "Unable to download Model2Vec model artifact",
+      context:
+        "model=local/potion-code-16m-v2 url=https://huggingface.co/minishlab/potion-code-16M-v2 status=503",
+      cause: "fetch failed",
     },
   });
   const { client, server } = await connectFull(backend);
@@ -560,14 +563,22 @@ test("index result includes an immediately available failure reason", async (t) 
   });
   assert.equal(result.isError, undefined);
   assert.deepEqual(result.structuredContent.error, {
-    code: "MODEL_LOAD_FAILED",
-    message: "Embedding schema could not be resolved.",
+    code: "ZVEC_GREP.ENGINE.MODELS.MODEL2VEC_DOWNLOAD_FAILED",
+    message: "Unable to download Model2Vec model artifact",
+    context:
+      "model=local/potion-code-16m-v2 url=https://huggingface.co/minishlab/potion-code-16M-v2 status=503",
+    cause: "fetch failed",
   });
-  assert.match(result.content[0].text, /error_code: MODEL_LOAD_FAILED/);
   assert.match(
     result.content[0].text,
-    /Embedding schema could not be resolved/,
+    /error_code: ZVEC_GREP\.ENGINE\.MODELS\.MODEL2VEC_DOWNLOAD_FAILED/,
   );
+  assert.match(
+    result.content[0].text,
+    /Unable to download Model2Vec model artifact/,
+  );
+  assert.match(result.content[0].text, /error_context: .*status=503/);
+  assert.match(result.content[0].text, /error_cause: fetch failed/);
 });
 
 test("index streams daemon progress through MCP", async (t) => {

--- a/test/mcp-contract.test.mjs
+++ b/test/mcp-contract.test.mjs
@@ -14,6 +14,10 @@ import {
   resolveMcpToolset,
 } from "../dist/mcp/toolset.js";
 import { EMBEDDING_ENVIRONMENT_META_KEY } from "../dist/mcp/request-metadata.js";
+import {
+  zvecGrepIndexOutputSchema,
+  zvecGrepIndexStatusOutputSchema,
+} from "../dist/mcp/schemas.js";
 import { indexProgressFromMessage } from "../dist/index-progress.js";
 import { formatAgentContextResult } from "../dist/cli/format/context.js";
 import { ZVEC_GREP_WORKSPACE_EVIDENCE_RULES } from "../dist/prompts/zvec-grep-guidance.js";
@@ -564,10 +568,65 @@ test("index result includes an immediately available failure reason", async (t) 
     message: "Embedding schema could not be resolved.",
   });
   assert.match(result.content[0].text, /error_code: MODEL_LOAD_FAILED/);
+  assert.doesNotMatch(result.content[0].text, /error_context:/);
   assert.match(
     result.content[0].text,
     /Embedding schema could not be resolved/,
   );
+});
+
+test("index and status preserve the underlying job failure context", async (t) => {
+  const error = {
+    code: "ZVEC_GREP.ENGINE.INDEXING.FILES_FAILED",
+    message: "Indexing completed with 1 failed file",
+    context:
+      "failedReasons=fail.ts: MODEL2VEC_DOWNLOAD_FAILED: Failed to download Potion model (HTTP 503)",
+  };
+  const backend = createBackend();
+  backend.index = async (input) => ({
+    root: input.root,
+    jobId: "job-failed",
+    state: "failed",
+    reused: false,
+    error,
+  });
+  backend.indexStatus = async (input) => {
+    const result = await createBackend().indexStatus(input);
+    return {
+      ...result,
+      runtime: { ...result.runtime, jobState: "failed", error },
+    };
+  };
+  const { client, server } = await connectFull(backend);
+  t.after(async () => {
+    await client.close();
+    await server.close();
+  });
+
+  const index = await client.callTool({
+    name: "zvec_grep_index",
+    arguments: { root, wait: true },
+  });
+  assert.equal(index.isError, undefined);
+  assert.deepEqual(index.structuredContent.error, error);
+  assert.deepEqual(
+    zvecGrepIndexOutputSchema.parse(index.structuredContent).error,
+    error,
+  );
+  assert.ok(index.content[0].text.includes(`error_context: ${error.context}`));
+
+  const status = await client.callTool({
+    name: "zvec_grep_index_status",
+    arguments: { root },
+  });
+  assert.equal(status.isError, undefined);
+  assert.deepEqual(status.structuredContent.runtime.error, error);
+  assert.deepEqual(
+    zvecGrepIndexStatusOutputSchema.parse(status.structuredContent).runtime
+      .error,
+    error,
+  );
+  assert.deepEqual(JSON.parse(status.content[0].text).runtime.error, error);
 });
 
 test("index streams daemon progress through MCP", async (t) => {

--- a/test/server-http.test.mjs
+++ b/test/server-http.test.mjs
@@ -587,9 +587,9 @@ test("Streamable HTTP indexes and searches with qwen text-embedding-v4", async (
   assert.equal(unsupported.isError, undefined);
   assert.equal(unsupported.structuredContent.state, "failed");
   assert.deepEqual(unsupported.structuredContent.error, {
-    code: "MODEL_LOAD_FAILED",
-    message:
-      "[MODEL_LOAD_FAILED] Embedding model qwen/unsupported-embedding could not be created: Embedding model is not in the zvec-grep catalog",
+    code: "ZVEC_GREP.ENGINE.MODELS.EMBEDDING_CATALOG_MODEL_NOT_FOUND",
+    message: "Embedding model is not in the zvec-grep catalog",
+    context: "embedding=qwen/unsupported-embedding",
   });
   assert.match(unsupported.content[0].text, /qwen\/unsupported-embedding/);
   const unsupportedStatus = await client.callTool({
@@ -599,7 +599,7 @@ test("Streamable HTTP indexes and searches with qwen text-embedding-v4", async (
   assert.equal(unsupportedStatus.structuredContent.indexed, false);
   assert.equal(
     unsupportedStatus.structuredContent.runtime.error.code,
-    "MODEL_LOAD_FAILED",
+    "ZVEC_GREP.ENGINE.MODELS.EMBEDDING_CATALOG_MODEL_NOT_FOUND",
   );
   await assert.rejects(access(join(unsupportedRoot, ".zvec-grep", "index")));
 });

--- a/test/unit/cli-format.test.mjs
+++ b/test/unit/cli-format.test.mjs
@@ -207,7 +207,7 @@ test("direct workspace status summarizes stored model download failures unless d
           indexStatus: {
             indexedTime: null,
             entityCount: 0,
-            error: `embed: ${downloadCode}: Unable to download Model2vec model artifact (model=local/potion-code-16m-v2 url=https://huggingface.co/model/config.json)`,
+            error: `embed: ${downloadCode}: Unable to download Model2vec model artifact (model=local/potion-code-16m-v2 url=https://huggingface.co/model/config.json) Authorization: Bearer direct-status-secret`,
           },
         },
       ],
@@ -237,6 +237,8 @@ test("direct workspace status summarizes stored model download failures unless d
   assert.match(debugText, /Details\s+README\.md: embed:/);
   assert.match(debugText, /MODEL2VEC_DOWNLOAD_FAILED/);
   assert.match(debugText, /https:\/\/huggingface\.co\/model\/config\.json/);
+  assert.match(debugText, /Authorization: \[redacted\]/);
+  assert.doesNotMatch(debugText, /direct-status-secret/);
 });
 
 function contextResult(overrides = {}) {

--- a/test/unit/cli-format.test.mjs
+++ b/test/unit/cli-format.test.mjs
@@ -1602,12 +1602,14 @@ test("model download summary does not mistake unrelated errors or fields for dow
 test("error formatter keeps direct and aggregated model download failures to one line by default", async () => {
   const downloadCode = "ZVEC_GREP.ENGINE.MODELS.MODEL2VEC_DOWNLOAD_FAILED";
   const downloadContext =
-    "model=local/potion-code-16m-v2 url=https://huggingface.co/model/config.json";
+    "model=local/potion-code-16m-v2 url=https://huggingface.co/model/config.json token=model-download-secret";
   const cases = [
     new EngineError("Unable to download Model2vec model artifact", {
       code: downloadCode,
       context: downloadContext,
-      cause: new Error("HTTP 503 Service Unavailable"),
+      cause: new Error(
+        "HTTP 503 Service Unavailable token=model-download-secret",
+      ),
     }),
     new EngineError("Indexing completed with 1 failed file", {
       code: "ZVEC_GREP.ENGINE.INDEXING.FILES_FAILED",
@@ -1629,8 +1631,14 @@ test("error formatter keeps direct and aggregated model download failures to one
     assert.ok(debug.errors.includes(`Code: ${error.code}`));
     assert.ok(debug.errors.includes("Details:"));
     assert.match(debug.errors.join("\n"), /https:\/\/huggingface\.co/);
+    assert.match(debug.errors.join("\n"), /\[redacted\]/);
+    assert.doesNotMatch(debug.errors.join("\n"), /model-download-secret/);
     if (error.cause) {
-      assert.ok(debug.errors.includes("Cause: HTTP 503 Service Unavailable"));
+      assert.ok(
+        debug.errors.includes(
+          "Cause: HTTP 503 Service Unavailable token=[redacted]",
+        ),
+      );
     }
   }
 

--- a/test/unit/cli-format.test.mjs
+++ b/test/unit/cli-format.test.mjs
@@ -918,8 +918,11 @@ test("status formatters cover workspace states, failures, filters, and color", a
         runtime: {
           job_state: "failed",
           error: {
-            code: "MODEL_LOAD_FAILED",
-            message: "Embedding schema could not be resolved.",
+            code: "ZVEC_GREP.ENGINE.MODELS.MODEL2VEC_DOWNLOAD_FAILED",
+            message: "Unable to download Model2Vec model artifact",
+            context:
+              "model=local/potion-code-16m-v2 status=503\nrepo=minishlab/potion-code-16M-v2",
+            cause: "fetch failed",
           },
         },
       },
@@ -938,11 +941,17 @@ test("status formatters cover workspace states, failures, filters, and color", a
       `◐ Workspace index is updating[\\s\\S]*Coverage\\s+${progressBar(15, 5)}\\s+75%\\s+3 / 4 files`,
     ),
   );
-  assert.match(output.logs.join("\n"), /Error\s+MODEL_LOAD_FAILED/);
   assert.match(
     output.logs.join("\n"),
-    /Embedding schema could not be resolved/,
+    /Error\s+ZVEC_GREP\.ENGINE\.MODELS\.MODEL2VEC_DOWNLOAD_FAILED/,
   );
+  assert.match(
+    output.logs.join("\n"),
+    /Unable to download Model2Vec model artifact/,
+  );
+  assert.match(output.logs.join("\n"), /Details:/);
+  assert.match(output.logs.join("\n"), /status=503/);
+  assert.match(output.logs.join("\n"), /Cause:\s+fetch failed/);
 
   for (const stateInfo of [
     {

--- a/test/unit/cli-format.test.mjs
+++ b/test/unit/cli-format.test.mjs
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import path from "node:path";
 import test from "node:test";
-import { printError } from "../../dist/cli/errors.js";
+import {
+  modelDownloadFailureMessage,
+  printError,
+} from "../../dist/cli/errors.js";
 import {
   contextWarningLines,
   formatAgentContextResult,
@@ -101,6 +104,138 @@ function workspaceIndex(overrides = {}) {
     ...overrides,
   };
 }
+
+function failedServerIndexInfo(error) {
+  return {
+    root: "/failed-repo",
+    indexed: false,
+    index_policy: "undecided",
+    source: "unindexed",
+    persistent: {
+      home: "/failed-repo/.zvec-grep",
+      index_path: "/failed-repo/.zvec-grep/index.zvec",
+    },
+    runtime: { job_state: "failed", error },
+  };
+}
+
+test("server status displays non-download job error context as readable details", async () => {
+  const error = {
+    code: "ZVEC_GREP.ENGINE.INDEXING.FILES_FAILED",
+    message: "Indexing completed with 1 failed file",
+  };
+  const info = failedServerIndexInfo(error);
+  const withoutContext = await captureConsole(() =>
+    printServerIndexInfo(info, { color: "never" }),
+  );
+  assert.doesNotMatch(withoutContext.logs.join("\n"), /Details/);
+  assert.deepEqual(withoutContext.logs.slice(-2), [
+    `  Error       ${error.code}`,
+    `              ${error.message}`,
+  ]);
+
+  error.context =
+    "failedReasons=fail.ts: PARSE_FAILED: Unable to parse file\n" +
+    "file=fail.ts stage=parsing";
+  const withContext = await captureConsole(() =>
+    printServerIndexInfo(info, { color: "never" }),
+  );
+  assert.deepEqual(withContext.logs, [
+    ...withoutContext.logs,
+    "  Details     failedReasons: fail.ts: PARSE_FAILED: Unable to parse file",
+    "              file: fail.ts",
+    "              stage: parsing",
+  ]);
+});
+
+test("server status summarizes model download failures unless debug details are requested", async () => {
+  const downloadCode = "ZVEC_GREP.ENGINE.MODELS.MODEL2VEC_DOWNLOAD_FAILED";
+  const error = {
+    code: "ZVEC_GREP.ENGINE.INDEXING.FILES_FAILED",
+    message: "Indexing completed with 1 failed file",
+    context:
+      `failedReasons=README.md: embed: ${downloadCode}: Unable to download Model2vec model artifact (model=local/potion-code-16m-v2 url=https://huggingface.co/model/model.safetensors)\n` +
+      "filesFailed=1",
+  };
+  const info = failedServerIndexInfo(error);
+  const normal = await captureConsole(() =>
+    printServerIndexInfo(info, { color: "never" }),
+  );
+  assert.equal(
+    normal.logs.at(-1),
+    '  Error       Failed to download model "local/potion-code-16m-v2".',
+  );
+  assert.doesNotMatch(
+    normal.logs.join("\n"),
+    /FILES_FAILED|MODEL2VEC_DOWNLOAD_FAILED|Details|huggingface|failedReasons/,
+  );
+
+  const debug = await captureConsole(() =>
+    printServerIndexInfo(info, { color: "never", debug: true }),
+  );
+  const debugText = debug.logs.join("\n");
+  assert.match(
+    debugText,
+    /Failed to download model "local\/potion-code-16m-v2"\./,
+  );
+  assert.match(debugText, /ZVEC_GREP\.ENGINE\.INDEXING\.FILES_FAILED/);
+  assert.match(debugText, /Details\s+failedReasons:/);
+  assert.match(debugText, /MODEL2VEC_DOWNLOAD_FAILED/);
+  assert.match(
+    debugText,
+    /https:\/\/huggingface\.co\/model\/model\.safetensors/,
+  );
+});
+
+test("direct workspace status summarizes stored model download failures unless debug details are requested", async () => {
+  const downloadCode = "ZVEC_GREP.ENGINE.MODELS.MODEL2VEC_DOWNLOAD_FAILED";
+  const info = {
+    root: "/repo",
+    indexed: true,
+    indexPolicy: "enabled",
+    source: "index",
+    home: "/repo/.zvec-grep",
+    indexPath: "/repo/.zvec-grep/index.zvec",
+    workspaceIndex: workspaceIndex(),
+    status: status({
+      filesPending: 0,
+      failedFiles: [
+        {
+          relativePath: "README.md",
+          indexStatus: {
+            indexedTime: null,
+            entityCount: 0,
+            error: `embed: ${downloadCode}: Unable to download Model2vec model artifact (model=local/potion-code-16m-v2 url=https://huggingface.co/model/config.json)`,
+          },
+        },
+      ],
+    }),
+  };
+  const normal = await captureConsole(() =>
+    printWorkspaceInfo(info, { color: "never" }),
+  );
+  assert.ok(
+    normal.logs.includes(
+      '  Error       Failed to download model "local/potion-code-16m-v2".',
+    ),
+  );
+  assert.doesNotMatch(
+    normal.logs.join("\n"),
+    /MODEL2VEC_DOWNLOAD_FAILED|Details|huggingface|Unable to download/,
+  );
+
+  const debug = await captureConsole(() =>
+    printWorkspaceInfo(info, { color: "never", debug: true }),
+  );
+  const debugText = debug.logs.join("\n");
+  assert.match(
+    debugText,
+    /Error\s+Failed to download model "local\/potion-code-16m-v2"\./,
+  );
+  assert.match(debugText, /Details\s+README\.md: embed:/);
+  assert.match(debugText, /MODEL2VEC_DOWNLOAD_FAILED/);
+  assert.match(debugText, /https:\/\/huggingface\.co\/model\/config\.json/);
+});
 
 function contextResult(overrides = {}) {
   const lines = Array.from(
@@ -1374,6 +1509,129 @@ test("error formatter renders engine context, causes, plain values, and color", 
   assert.match(text, /string cause/);
   assert.match(text, /plain value/);
   assert.match(text, /\x1b\[/);
+});
+
+test("model download summary recognizes direct and aggregated download errors", () => {
+  const downloadCode = "ZVEC_GREP.ENGINE.MODELS.MODEL2VEC_DOWNLOAD_FAILED";
+  const expected = 'Failed to download model "local/potion-code-16m-v2".';
+  const direct = new EngineError(
+    "Unable to download Model2vec model artifact",
+    {
+      code: downloadCode,
+      context:
+        "model=local/potion-code-16m-v2\nurl=https://huggingface.co/model/config.json",
+    },
+  );
+  const aggregated = {
+    code: "ZVEC_GREP.ENGINE.INDEXING.FILES_FAILED",
+    message: "Indexing completed with 1 failed file",
+    context:
+      `failedReasons=README.md: embed: ${downloadCode}: Unable to download Model2vec model artifact (model=local/potion-code-16m-v2 url=https://huggingface.co/model/config.json)\n` +
+      "hint=Retried failed files once automatically",
+  };
+  assert.equal(modelDownloadFailureMessage(direct), expected);
+  assert.equal(modelDownloadFailureMessage(aggregated), expected);
+  assert.equal(
+    modelDownloadFailureMessage({
+      code: downloadCode,
+      context: "model=local/potion-code-16m-v2",
+    }),
+    expected,
+  );
+  assert.equal(
+    modelDownloadFailureMessage({ code: downloadCode }),
+    "Failed to download model.",
+  );
+  assert.equal(
+    modelDownloadFailureMessage({
+      code: aggregated.code,
+      context: `failedReasons=README.md: embed: ${downloadCode}: Download failed`,
+    }),
+    "Failed to download model.",
+  );
+});
+
+test("model download summary does not mistake unrelated errors or fields for download failures", () => {
+  const downloadCode = "ZVEC_GREP.ENGINE.MODELS.MODEL2VEC_DOWNLOAD_FAILED";
+  const filesFailedCode = "ZVEC_GREP.ENGINE.INDEXING.FILES_FAILED";
+  const unrelatedErrors = [
+    undefined,
+    null,
+    downloadCode,
+    new Error(downloadCode),
+    {
+      code: `${downloadCode}_RETRY`,
+      context: "model=local/potion-code-16m-v2",
+    },
+    {
+      code: "ZVEC_GREP.ENGINE.TEST.FAILURE",
+      context: `failedReasons=${downloadCode}: model=local/potion-code-16m-v2`,
+    },
+    {
+      code: filesFailedCode,
+      message: downloadCode,
+      context: "model=local/potion-code-16m-v2",
+    },
+    {
+      code: filesFailedCode,
+      context: `hint=${downloadCode}\nmodel=local/potion-code-16m-v2`,
+    },
+    {
+      code: filesFailedCode,
+      context:
+        `failedFiles=${downloadCode}.ts\n` +
+        "failedReasons=README.md: PARSE_FAILED: Unable to parse file",
+    },
+  ];
+  for (const error of unrelatedErrors) {
+    assert.equal(modelDownloadFailureMessage(error), undefined);
+  }
+});
+
+test("error formatter keeps direct and aggregated model download failures to one line by default", async () => {
+  const downloadCode = "ZVEC_GREP.ENGINE.MODELS.MODEL2VEC_DOWNLOAD_FAILED";
+  const downloadContext =
+    "model=local/potion-code-16m-v2 url=https://huggingface.co/model/config.json";
+  const cases = [
+    new EngineError("Unable to download Model2vec model artifact", {
+      code: downloadCode,
+      context: downloadContext,
+      cause: new Error("HTTP 503 Service Unavailable"),
+    }),
+    new EngineError("Indexing completed with 1 failed file", {
+      code: "ZVEC_GREP.ENGINE.INDEXING.FILES_FAILED",
+      context: `failedReasons=README.md: embed: ${downloadCode}: Unable to download Model2vec model artifact (${downloadContext})`,
+    }),
+  ];
+  for (const error of cases) {
+    const normal = await captureConsole(() =>
+      printError(error, { color: "never" }),
+    );
+    assert.deepEqual(normal.errors, [
+      'Error: Failed to download model "local/potion-code-16m-v2".',
+    ]);
+
+    const debug = await captureConsole(() =>
+      printError(error, { color: "never", debug: true }),
+    );
+    assert.equal(debug.errors[0], normal.errors[0]);
+    assert.ok(debug.errors.includes(`Code: ${error.code}`));
+    assert.ok(debug.errors.includes("Details:"));
+    assert.match(debug.errors.join("\n"), /https:\/\/huggingface\.co/);
+    if (error.cause) {
+      assert.ok(debug.errors.includes("Cause: HTTP 503 Service Unavailable"));
+    }
+  }
+
+  const unknownModel = await captureConsole(() =>
+    printError(
+      new EngineError("Unable to download Model2vec model artifact", {
+        code: downloadCode,
+      }),
+      { color: "never" },
+    ),
+  );
+  assert.deepEqual(unknownModel.errors, ["Error: Failed to download model."]);
 });
 
 test("progress reporter covers TTY and non-TTY phases, counters, truncation, and idempotent finish", () => {

--- a/test/unit/core.test.mjs
+++ b/test/unit/core.test.mjs
@@ -20,6 +20,7 @@ import {
   EngineError,
   errorDetails,
   isEngineError,
+  redactErrorText,
 } from "../../dist/engine/errors.js";
 import { makeEntityId } from "../../dist/engine/extraction/ids.js";
 import { detectFileType } from "../../dist/engine/file-type.js";
@@ -615,6 +616,10 @@ test("color, range, highlighting, and error helpers are deterministic", () => {
   });
   assert.equal(isEngineError(error), true);
   assert.equal(isEngineError(new Error("failed")), false);
+  assert.equal(
+    redactErrorText("fetch failed token=model-download-secret", 512),
+    "fetch failed token=[redacted]",
+  );
 });
 
 test("file, model, content, and entity helpers classify inputs", () => {

--- a/test/unit/core.test.mjs
+++ b/test/unit/core.test.mjs
@@ -403,6 +403,32 @@ test("CLI parser covers utility commands, provider controls, routes, and equals 
   assert.equal(parseArgs(["index", "--debug"]).options.debug, true);
 });
 
+test("CLI parser limits debug output to query, index, and workspace status", () => {
+  const supported = [
+    ["query", "--debug", "needle"],
+    ["index", "--debug"],
+    ["status", "--debug"],
+    ["status", "--check-ready", "--debug"],
+  ];
+  for (const args of supported) {
+    assert.equal(parseArgs(args).options.debug, true, args.join(" "));
+  }
+
+  const unsupported = [
+    ["install", "--debug"],
+    ["uninstall", "--debug"],
+    ["server", "start", "--debug"],
+    ["server", "status", "--debug"],
+  ];
+  for (const args of unsupported) {
+    assert.throws(
+      () => parseArgs(args),
+      /--debug can only be used with/,
+      args.join(" "),
+    );
+  }
+});
+
 test("CLI parser covers managed rg long and short compatibility options", () => {
   const long = parseArgs([
     "query",

--- a/test/unit/models/model2vec.test.mjs
+++ b/test/unit/models/model2vec.test.mjs
@@ -149,6 +149,11 @@ test("Model2Vec downloads pinned Safetensors assets and performs normalized stat
     {
       stage: "downloading",
       model: "local/test-potion",
+      downloadedBytes: 0,
+    },
+    {
+      stage: "downloading",
+      model: "local/test-potion",
       downloadedBytes: 4,
     },
     {
@@ -318,6 +323,11 @@ test("Model2Vec excludes cached artifacts from overall download progress", async
     {
       stage: "downloading",
       model: "local/test-potion",
+      downloadedBytes: 0,
+    },
+    {
+      stage: "downloading",
+      model: "local/test-potion",
       downloadedBytes: 4,
       totalBytes: 8,
     },
@@ -327,6 +337,83 @@ test("Model2Vec excludes cached artifacts from overall download progress", async
     },
   ]);
   await model.dispose();
+});
+
+test("Model2Vec reports download failures without exposing artifact names", async (t) => {
+  const root = await createTemporaryDirectory(t, "zvec-model2vec-failure-");
+  const progress = [];
+  const model = new Model2VecEmbeddingModel(
+    entry(),
+    { modelCacheDir: root },
+    {
+      async loadTokenizer() {
+        throw new Error("tokenizer should not load after a download failure");
+      },
+      async loadSafetensors() {
+        throw new Error("table should not load after a download failure");
+      },
+      async download() {
+        throw new Error("network unavailable");
+      },
+    },
+  );
+
+  let failure;
+  await assert.rejects(
+    model.embed([{ kind: "text", text: "download failure" }], {
+      onProgress: (event) => progress.push(event),
+    }),
+    (error) => {
+      failure = error;
+      return error.code === "ZVEC_GREP.ENGINE.MODELS.MODEL2VEC_DOWNLOAD_FAILED";
+    },
+  );
+
+  assert.deepEqual(
+    progress.map(({ stage }) => stage),
+    ["preparing", "downloading", "warning"],
+  );
+  assert.deepEqual(progress[1], {
+    stage: "downloading",
+    model: "local/test-potion",
+    downloadedBytes: 0,
+  });
+  assert.match(progress[2].message, /network access.*model cache/i);
+  assert.doesNotMatch(
+    JSON.stringify(progress),
+    /model\.safetensors|tokenizer\.json/,
+  );
+  assert.doesNotMatch(failure.context, /model\.safetensors|tokenizer\.json/);
+});
+
+test("Model2Vec classifies table preparation errors as model load failures", async (t) => {
+  const root = await createTemporaryDirectory(t, "zvec-model2vec-load-");
+  const progress = [];
+  const model = new Model2VecEmbeddingModel(
+    entry(),
+    { modelCacheDir: root },
+    {
+      async loadTokenizer() {
+        throw new Error("tokenizer should not load after a table failure");
+      },
+      async loadSafetensors() {
+        throw new Error("invalid static table");
+      },
+      async download(_url, destination) {
+        await writeFile(destination, "asset");
+      },
+    },
+  );
+
+  await assert.rejects(
+    model.embed([{ kind: "text", text: "load failure" }], {
+      onProgress: (event) => progress.push(event),
+    }),
+    (error) =>
+      error.code === "ZVEC_GREP.ENGINE.MODELS.MODEL2VEC_LOAD_FAILED" &&
+      error.cause?.message === "invalid static table",
+  );
+  assert.equal(progress.at(-1)?.stage, "warning");
 });
 
 test("Model2Vec reports and truncates inputs beyond the model token limit", async (t) => {

--- a/test/unit/models/model2vec.test.mjs
+++ b/test/unit/models/model2vec.test.mjs
@@ -112,6 +112,15 @@ test("Model2Vec downloads pinned Safetensors assets and performs normalized stat
     dependencies,
   );
   assert.equal(model.info.defaultConcurrency, 2);
+  await model.prepare({
+    onProgress: (progress) => downloadProgress.push(progress),
+  });
+  assert.equal(calls.tokenizerCalls, undefined);
+  assert.equal(calls.tableLoads.length, 1);
+  assert.equal(calls.tokenizerLoads.length, 1);
+  await model.prepare({
+    onProgress: (progress) => downloadProgress.push(progress),
+  });
   const { vectors } = await model.embed(
     [
       { kind: "text", text: "both tokens" },
@@ -191,6 +200,34 @@ test("Model2Vec downloads pinned Safetensors assets and performs normalized stat
   await assert.rejects(
     model.embed([{ kind: "text", text: "after dispose" }]),
     /disposed/,
+  );
+});
+
+test("Model2Vec preparation respects cancellation and disposal before loading", async () => {
+  const model = new Model2VecEmbeddingModel(
+    entry(),
+    { modelCacheDir: "/unused" },
+    {
+      async download() {
+        assert.fail("cancelled or disposed preparation must not download");
+      },
+    },
+  );
+  const cancelled = new Error("cancelled before model preparation");
+  const progress = [];
+  await assert.rejects(
+    model.prepare({
+      signal: AbortSignal.abort(cancelled),
+      onProgress: (event) => progress.push(event),
+    }),
+    (error) => error === cancelled,
+  );
+  assert.deepEqual(progress, []);
+
+  await model.dispose();
+  await assert.rejects(
+    model.prepare(),
+    (error) => error.code === "ZVEC_GREP.ENGINE.MODELS.MODEL2VEC_DISPOSED",
   );
 });
 


### PR DESCRIPTION
## Summary
- surface sanitized embedding error context and nested causes through the daemon, MCP, and CLI
- fail fast for shared local Potion setup/download failures and permanent remote authentication/configuration failures
- keep bounded retries for transient remote HTTP/network failures and per-input fallback for request-specific 400 responses
- report local model download progress before the first byte arrives
- merge dev/server-index-error-details: concise model download errors by default, detailed diagnostics with --debug, workspace status support, and README troubleshooting tips
- preserve both branches of credential redaction, including nested causes and quoted Authorization values

## Why
When the local Potion model download fails, server-mode indexing can retry the same shared failure for each file and finish with only INDEXING.FILES_FAILED. The original model/network cause is also lost across daemon job serialization.

Remote embeddings retain bounded retry behavior for 408, 429, 5xx, and transient network failures. Authentication/configuration failures stop early, while input-specific 400 responses keep batch-to-file-to-fragment isolation.

## Testing after merge
- npm run build
- npm run lint
- npm run format:check
- npm run typecheck
- npm run test:run:unit (112 passed)
- npm run test:run:integration (15 passed)
- node --test test/job-scheduler.test.mjs test/mcp-contract.test.mjs (39 passed on the final build)
- node --test --test-concurrency=1 test/e2e/cli.test.mjs (8 passed)
- manual direct/server CLI smoke using an isolated workspace, cache, and daemon with injected HTTP 503; verified normal output, --debug details, and server status

Fixes #64