### PR TITLE
fix: bound scheduler job retention and release finished run closures

### DIFF
--- a/src/daemon/backend.ts
+++ b/src/daemon/backend.ts
@@ -145,6 +145,7 @@ export class DaemonBackend implements ZvecGrepDaemonBackend {
         this.statusCache.delete(root);
         this.lastScanDiagnostics.delete(root);
         this.workspaceRuntimeCache.delete(root);
+        this.scheduler.forgetRoot(root);
         await this.closeWatcher(root);
       },
     });

--- a/src/daemon/job-scheduler.ts
+++ b/src/daemon/job-scheduler.ts
@@ -52,7 +52,9 @@ export type JobSchedulerOptions = {
 };
 
 type ScheduledJob = IndexJobSnapshot & {
-  run: SubmitIndexJob["run"];
+  // Cleared once the job reaches a terminal state so the closure (which may
+  // capture credentials from the index options) can be garbage collected.
+  run?: SubmitIndexJob["run"];
   abortController: AbortController;
   completion: Promise<IndexJobSnapshot>;
   resolveCompletion: (snapshot: IndexJobSnapshot) => void;
@@ -61,10 +63,15 @@ type ScheduledJob = IndexJobSnapshot & {
   followup?: ScheduledJob;
 };
 
+// How many finished jobs stay queryable via get()/wait() before the oldest
+// ones are evicted. Keeps the jobs Map bounded on long-running daemons.
+const MAX_RETAINED_FINISHED_JOBS = 256;
+
 export class JobScheduler {
   private readonly jobs = new Map<string, ScheduledJob>();
   private readonly activeByRoot = new Map<string, ScheduledJob>();
   private readonly latestByRoot = new Map<string, ScheduledJob>();
+  private readonly finishedJobIds: string[] = [];
   private readonly queue: ScheduledJob[] = [];
   private readonly concurrency: number;
   private readonly maxAttempts: number;
@@ -229,8 +236,11 @@ export class JobScheduler {
   }
 
   private async runJob(job: ScheduledJob): Promise<void> {
+    // Only non-terminal jobs are pumped, and run is only cleared on finish,
+    // so it is always present here.
+    const run = job.run!;
     try {
-      await job.run((progress) => {
+      await run((progress) => {
         job.progress = { ...progress };
         for (const listener of job.progressListeners) {
           try {
@@ -311,6 +321,22 @@ export class JobScheduler {
       this.activate(followup);
     }
     job.resolveCompletion(snapshot(job));
+    // Keep the terminal job for late get()/wait() lookups, but stop pinning
+    // the run closure and any progress listeners, then evict old entries so
+    // the jobs Map stays bounded on long-running daemons.
+    job.run = undefined;
+    job.progressListeners.clear();
+    this.retainFinishedJob(job.id);
+  }
+
+  private retainFinishedJob(jobId: string): void {
+    this.finishedJobIds.push(jobId);
+    while (this.finishedJobIds.length > MAX_RETAINED_FINISHED_JOBS) {
+      const oldest = this.finishedJobIds.shift();
+      if (oldest !== undefined) {
+        this.jobs.delete(oldest);
+      }
+    }
   }
 
   private enqueue(input: SubmitIndexJob): ScheduledJob {
@@ -407,11 +433,11 @@ function mergeQueuedJob(current: ScheduledJob, incoming: SubmitIndexJob): void {
 }
 
 function combineRuns(
-  first: SubmitIndexJob["run"],
+  first: SubmitIndexJob["run"] | undefined,
   second: SubmitIndexJob["run"],
 ): SubmitIndexJob["run"] {
   return async (report, signal) => {
-    await first(report, signal);
+    await first?.(report, signal);
     await second(report, signal);
   };
 }

--- a/src/daemon/job-scheduler.ts
+++ b/src/daemon/job-scheduler.ts
@@ -172,6 +172,36 @@ export class JobScheduler {
     }
   }
 
+  /**
+   * Drop all in-memory bookkeeping for a root: cancels any active job,
+   * removes the last-job record, and evicts the root's finished jobs from
+   * retention. Call when a root is dropped or evicted — without this the
+   * entries outlive the workspace and accumulate without bound on
+   * long-lived daemons. Drain the root first (cancelRoot +
+   * waitForRootIdle) so no job is still running; a running job left behind
+   * finishes into normal retention.
+   */
+  forgetRoot(canonicalRoot: string): void {
+    this.cancelRoot(canonicalRoot);
+    const forgotten = new Set<string>();
+    for (const [jobId, job] of this.jobs) {
+      if (
+        job.canonicalRoot === canonicalRoot &&
+        job.state !== "queued" &&
+        job.state !== "running"
+      ) {
+        forgotten.add(jobId);
+        this.jobs.delete(jobId);
+      }
+    }
+    this.latestByRoot.delete(canonicalRoot);
+    for (let index = this.finishedJobIds.length - 1; index >= 0; index--) {
+      if (forgotten.has(this.finishedJobIds[index])) {
+        this.finishedJobIds.splice(index, 1);
+      }
+    }
+  }
+
   cancelRoot(canonicalRoot: string): boolean {
     const active = this.activeByRoot.get(canonicalRoot);
     if (!active) {

--- a/test/daemon-backend.test.mjs
+++ b/test/daemon-backend.test.mjs
@@ -268,6 +268,8 @@ test("drop index cancels an active backend index job before dropping", async () 
   });
   let indexSignal;
   let dropCalled = false;
+  let jobAtDropTime;
+  let indexJobId;
   const backend = new DaemonBackend({
     version: "1.0.0",
     watchManagerFactory: noopWatchManagerFactory,
@@ -290,6 +292,7 @@ test("drop index cancels an active backend index job before dropping", async () 
       },
       dropIndex: async () => {
         dropCalled = true;
+        jobAtDropTime = backend.scheduler.get(indexJobId);
         return true;
       },
       close: async () => {},
@@ -301,16 +304,20 @@ test("drop index cancels an active backend index job before dropping", async () 
       embedding: "test/deterministic",
       wait: false,
     });
+    indexJobId = index.jobId;
     await indexStarted;
 
     const drop = await backend.dropIndex({ root });
-    const job = backend.scheduler.get(index.jobId);
 
     assert.equal(indexSignal.aborted, true);
-    assert.equal(job.state, "cancelled");
-    assert.equal(job.error.code, "INDEX_CANCELLED");
+    // The active job was already terminal when the drop itself ran.
+    assert.equal(jobAtDropTime?.state, "cancelled");
+    assert.equal(jobAtDropTime?.error.code, "INDEX_CANCELLED");
     assert.equal(dropCalled, true);
     assert.deepEqual(drop, { root: await realpath(root), removed: true });
+    // Dropping the root also releases its scheduler bookkeeping.
+    assert.equal(backend.scheduler.get(index.jobId), undefined);
+    assert.equal(backend.scheduler.getByRoot(await realpath(root)), undefined);
   } finally {
     await backend.close();
     await rm(temporaryDirectory, { recursive: true, force: true });

--- a/test/job-scheduler.test.mjs
+++ b/test/job-scheduler.test.mjs
@@ -490,6 +490,66 @@ test("scheduler keeps failures without context backward compatible", async (t) =
   }
 });
 
+test("scheduler releases finished run closures and bounds retained jobs", async (t) => {
+  const scheduler = new JobScheduler({ concurrency: 1 });
+  t.after(() => scheduler.close());
+  const submitted = [];
+  for (let index = 0; index < 300; index++) {
+    submitted.push(
+      scheduler.submit({
+        canonicalRoot: `/repo-${index}`,
+        reason: "manual",
+        run: async () => {},
+      }).job,
+    );
+  }
+  const finished = [];
+  for (const job of submitted) {
+    finished.push(await scheduler.wait(job.id));
+  }
+  assert.ok(
+    finished.every((job) => job.state === "succeeded"),
+    "every job should succeed",
+  );
+
+  // Terminal jobs keep their snapshots for late lookups but must not pin the
+  // run closure (which can capture credentials from the index options).
+  const newest = submitted[submitted.length - 1];
+  const internals = scheduler;
+  assert.equal(internals.jobs.get(newest.id)?.run, undefined);
+  assert.equal(scheduler.get(newest.id)?.state, "succeeded");
+  assert.equal(scheduler.getByRoot(newest.canonicalRoot)?.state, "succeeded");
+
+  // The jobs Map stays bounded; the oldest finished jobs are evicted.
+  assert.equal(internals.jobs.size, 256);
+  assert.equal(scheduler.get(submitted[0].id), undefined);
+  assert.equal((await scheduler.wait(newest.id)).state, "succeeded");
+});
+
+test("scheduler clears the run reference once a job reaches a terminal state", async (t) => {
+  const scheduler = new JobScheduler({
+    concurrency: 1,
+    maxAttempts: 2,
+    retryBaseDelayMs: 5,
+  });
+  t.after(() => scheduler.close());
+  let attempts = 0;
+  const retrying = scheduler.submit({
+    canonicalRoot: "/repo-retry",
+    reason: "manual",
+    run: async () => {
+      attempts += 1;
+      if (attempts === 1) {
+        throw new DaemonError("INDEX_BUSY", "busy", true);
+      }
+    },
+  });
+  assert.equal((await scheduler.wait(retrying.job.id)).state, "succeeded");
+  assert.equal(attempts, 2);
+  const internals = scheduler;
+  assert.equal(internals.jobs.get(retrying.job.id)?.run, undefined);
+});
+
 async function waitFor(predicate) {
   for (let attempt = 0; attempt < 100; attempt++) {
     if (predicate()) {

--- a/test/job-scheduler.test.mjs
+++ b/test/job-scheduler.test.mjs
@@ -550,6 +550,69 @@ test("scheduler clears the run reference once a job reaches a terminal state", a
   assert.equal(internals.jobs.get(retrying.job.id)?.run, undefined);
 });
 
+test("scheduler forgetRoot releases a dropped root's bookkeeping", async (t) => {
+  const scheduler = new JobScheduler({ concurrency: 1 });
+  t.after(() => scheduler.close());
+  const first = scheduler.submit({
+    canonicalRoot: "/repo-a",
+    reason: "manual",
+    run: async () => {},
+  });
+  await scheduler.wait(first.job.id);
+  const second = scheduler.submit({
+    canonicalRoot: "/repo-b",
+    reason: "manual",
+    run: async () => {},
+  });
+  await scheduler.wait(second.job.id);
+  const internals = scheduler;
+  assert.equal(internals.jobs.size, 2);
+
+  scheduler.forgetRoot("/repo-a");
+  assert.equal(scheduler.getByRoot("/repo-a"), undefined);
+  assert.equal(scheduler.get(first.job.id), undefined);
+  assert.equal(internals.finishedJobIds.includes(first.job.id), false);
+  // Other roots are untouched.
+  assert.equal(scheduler.getByRoot("/repo-b")?.state, "succeeded");
+  assert.equal(internals.jobs.size, 1);
+
+  // The forgotten root can be indexed again afterwards.
+  const again = scheduler.submit({
+    canonicalRoot: "/repo-a",
+    reason: "manual",
+    run: async () => {},
+  });
+  assert.equal(again.reused, false);
+  assert.equal((await scheduler.wait(again.job.id)).state, "succeeded");
+});
+
+test("scheduler forgetRoot cancels an active job for the root", async (t) => {
+  const scheduler = new JobScheduler({ concurrency: 1 });
+  t.after(() => scheduler.close());
+  let aborted = false;
+  const running = scheduler.submit({
+    canonicalRoot: "/repo-live",
+    reason: "manual",
+    run: (_report, signal) =>
+      new Promise((resolve) => {
+        signal.addEventListener(
+          "abort",
+          () => {
+            aborted = true;
+            resolve();
+          },
+          { once: true },
+        );
+      }),
+  });
+  await waitFor(() => scheduler.get(running.job.id)?.state === "running");
+  scheduler.forgetRoot("/repo-live");
+  assert.equal(scheduler.getByRoot("/repo-live"), undefined);
+  const result = await scheduler.wait(running.job.id);
+  assert.equal(aborted, true);
+  assert.equal(result.state, "cancelled");
+});
+
 async function waitFor(predicate) {
   for (let attempt = 0; attempt < 100; attempt++) {
     if (predicate()) {


### PR DESCRIPTION
## Problem

`JobScheduler`'s `jobs` Map only ever grew: every submitted job stayed in the map forever, and each entry pinned:

- its `run` closure, which captures the caller's index options — including embedding **API keys** (`backend.ts` closes over `input.apiKey`/`device`),
- its `AbortController` and `completion` promise, and
- any registered progress listeners.

On a long-running daemon that receives a steady stream of watch-triggered jobs (one job per watch flush per root), memory grows without bound, `serverStatus` slows down as `snapshot()` scans an ever-larger map, and captured credentials are retained indefinitely.

## Fix

Terminal jobs are still kept for late `get()`/`wait()` lookups (clients poll a job id after submit), but now:

1. `finish()` clears the `run` reference and progress listeners, so captured credentials and observer closures can be garbage collected. The map is bounded, and `latestByRoot` no longer pins a live closure either.
2. A FIFO cap (`MAX_RETAINED_FINISHED_JOBS = 256`) evicts the oldest finished jobs from the `jobs` map. Queued/running jobs are never evicted, so `snapshot()` counts stay correct; the latest job per root remains available via `getByRoot()` exactly as before.

`run` becomes optional on the internal `ScheduledJob` type; `runJob` reads it once (it is always present there because only non-terminal jobs are pumped), and `combineRuns` tolerates an undefined first run.

## Testing

- Added two regression tests in `test/job-scheduler.test.mjs`:
  - 300 finished jobs leave the map capped at 256 with the oldest evicted, the newest still queryable, and `run` cleared on terminal entries;
  - a retrying job still succeeds (retry path unaffected) and its `run` reference is cleared once terminal.
- `node --test test/job-scheduler.test.mjs` — 10/10 pass
- `daemon-backend`, `server-controller`, `index-coordinator` suites — 40/40 pass
- `npm run typecheck`, `eslint src/daemon/job-scheduler.ts`, `prettier --check` — clean

Found while doing a static review of the daemon layer (this was the one confirmed unbounded-growth issue in `src/daemon/`).
