### PR TITLE
fix(windows): preserve managed rg path separators

### DIFF
--- a/src/cli/managed-rg.ts
+++ b/src/cli/managed-rg.ts
@@ -101,7 +101,14 @@ function scanManagedRgCommand(command: string): string[] {
       continue;
     }
     if (character === "\\") {
-      escaping = true;
+      // Backslashes are path separators in Windows shells, rather than generic
+      // escape characters. Keep them so copied rg paths such as `src\\cli`
+      // continue to point at the intended directory.
+      if (process.platform === "win32") {
+        token += character;
+      } else {
+        escaping = true;
+      }
       tokenStarted = true;
       continue;
     }

--- a/test/unit/core.test.mjs
+++ b/test/unit/core.test.mjs
@@ -230,6 +230,19 @@ test("MCP rg command normalization preserves quoted patterns, paths, and globs",
 });
 
 test(
+  "MCP rg command normalization preserves unquoted Windows path separators",
+  { skip: process.platform !== "win32" },
+  () => {
+    const normalized = contextOptionsFromRgInput({
+      root: process.cwd(),
+      command: String.raw`rg needle src\cli`,
+    });
+
+    assert.deepEqual(normalized.rgPaths, [String.raw`src\cli`]);
+  },
+);
+
+test(
   "MCP rg command normalization rejects paths that escape through symlinks",
   { skip: process.platform === "win32" },
   async (t) => {


### PR DESCRIPTION
## Summary

Fix managed `rg` command parsing on Windows so unquoted backslash path separators are preserved.

Previously, a command such as:

```text
rg needle src\cli