### PR TITLE
fix: use per-directory watchers on all Linux versions

### DIFF
--- a/src/daemon/watch-manager.ts
+++ b/src/daemon/watch-manager.ts
@@ -20,7 +20,6 @@ export type WatchManagerOptions = {
   resumeCheckIntervalMs?: number;
   resumeThresholdMs?: number;
   platform?: NodeJS.Platform;
-  nodeVersion?: string;
   getRootPaths?: () => readonly RootPath[] | undefined;
 };
 
@@ -312,12 +311,7 @@ export class WatchManager {
     if (this.closed) {
       return;
     }
-    if (
-      requiresDirectoryWatchers(
-        this.options.platform ?? process.platform,
-        this.options.nodeVersion ?? process.versions.node,
-      )
-    ) {
+    if (requiresDirectoryWatchers(this.options.platform ?? process.platform)) {
       void this.watchDirectoryTree(this.options.root, factory);
       return;
     }
@@ -444,13 +438,10 @@ export class WatchManager {
   }
 }
 
-function requiresDirectoryWatchers(
-  platform: NodeJS.Platform,
-  nodeVersion: string,
-): boolean {
-  if (platform !== "linux") {
-    return false;
-  }
-  const [major, minor] = nodeVersion.split(".", 2).map(Number);
-  return major === 22 && minor === 0;
+// Linux always uses per-directory watchers. Node's recursive watcher is not
+// native on Linux: it walks the whole tree and registers an inotify watch for
+// every file and directory, ignoring index exclusions, which exhausts the
+// per-user fs.inotify.max_user_watches quota for the whole machine.
+function requiresDirectoryWatchers(platform: NodeJS.Platform): boolean {
+  return platform === "linux";
 }

--- a/test/watch-manager.test.mjs
+++ b/test/watch-manager.test.mjs
@@ -43,7 +43,7 @@ test("watch manager debounces file changes and reports overflow reconciliation",
   }
 });
 
-test("watch manager uses per-directory watchers on Linux Node 22.0", async () => {
+test("watch manager uses per-directory watchers on Linux", async () => {
   const temporaryDirectory = await mkdtemp(
     join(tmpdir(), "zvec-grep-watch-fallback-"),
   );
@@ -57,7 +57,6 @@ test("watch manager uses per-directory watchers on Linux Node 22.0", async () =>
   const manager = new WatchManager({
     root,
     platform: "linux",
-    nodeVersion: "22.0.0",
     debounceMs: 5,
     maxWaitMs: 20,
     reconcileIntervalMs: 0,
@@ -145,7 +144,6 @@ test("fallback watcher prunes ignored directories and restores newly included on
   const manager = new WatchManager({
     root,
     platform: "linux",
-    nodeVersion: "22.0.0",
     debounceMs: 5,
     maxWaitMs: 20,
     reconcileIntervalMs: 0,
@@ -185,7 +183,6 @@ test("fallback watcher honors noIgnore when selecting directories", async () => 
   const manager = new WatchManager({
     root,
     platform: "linux",
-    nodeVersion: "22.0.0",
     reconcileIntervalMs: 0,
     getRootPaths: () => [
       { absolutePath: root, recursive: true, noIgnore: true },
@@ -229,7 +226,6 @@ test("fallback watcher mirrors scanner hidden-directory selection", async () => 
     const manager = new WatchManager({
       root,
       platform: "linux",
-      nodeVersion: "22.0.0",
       reconcileIntervalMs: 0,
       getRootPaths: () => [rootPath],
       watchFactory: (directory, options) => {
@@ -454,7 +450,6 @@ test("directory watcher retries are independent", async () => {
   const manager = new WatchManager({
     root,
     platform: "linux",
-    nodeVersion: "22.0.0",
     debounceMs: 5,
     maxWaitMs: 20,
     reconcileIntervalMs: 0,

--- a/test/watch-manager.test.mjs
+++ b/test/watch-manager.test.mjs
@@ -17,6 +17,7 @@ test("watch manager debounces file changes and reports overflow reconciliation",
   const batches = [];
   const manager = new WatchManager({
     root,
+    platform: "darwin",
     debounceMs: 5,
     maxWaitMs: 20,
     reconcileIntervalMs: 0,
@@ -103,6 +104,7 @@ test("watch manager drops ignored file events before creating a change batch", a
   const pending = [];
   const manager = new WatchManager({
     root,
+    platform: "darwin",
     debounceMs: 5,
     maxWaitMs: 20,
     reconcileIntervalMs: 0,
@@ -289,6 +291,7 @@ test("watch manager compacts an exact event storm into one directory scan", asyn
   const batches = [];
   const manager = new WatchManager({
     root,
+    platform: "darwin",
     debounceMs: 10,
     maxWaitMs: 30,
     reconcileIntervalMs: 0,
@@ -372,6 +375,7 @@ test("resume drift requests reconciliation and pending state spans debounce", as
   const reasons = [];
   const manager = new WatchManager({
     root,
+    platform: "darwin",
     debounceMs: 20,
     maxWaitMs: 40,
     reconcileIntervalMs: 0,
@@ -410,6 +414,7 @@ test("watcher errors trigger reconciliation and replace the failed watcher", asy
   const reasons = [];
   const manager = new WatchManager({
     root,
+    platform: "darwin",
     debounceMs: 5,
     maxWaitMs: 20,
     reconcileIntervalMs: 0,
@@ -496,6 +501,7 @@ test("close waits for an in-flight async change callback", async () => {
   watcher.close = () => {};
   const manager = new WatchManager({
     root,
+    platform: "darwin",
     debounceMs: 5,
     maxWaitMs: 20,
     reconcileIntervalMs: 0,


### PR DESCRIPTION
Fixes #85.

## Problem

On Linux, `startPrimaryWatcher()` uses `fs.watch(root, { recursive: true })` for every Node version except exactly 22.0. Node's recursive watcher is not native on Linux — it walks the whole tree and registers an inotify watch per file and per directory, with no knowledge of the index exclusions.

The ignore check in `recordPath()` runs only after an event arrives, so it filters indexing work but cannot prevent the watch from being registered in the first place.

In the reported workspace this meant 64,133 inotify watches for an index of 402 files: ~41.5k under `node_modules`, ~15.3k under `.jj`, ~5.8k under `.git`. That saturated the user's `fs.inotify.max_user_watches` (65,536), leaving 7 watches for every other process on the machine and causing `ENOSPC` in unrelated editors and dev servers. The server also logged 13 `watcher.overflow` events in about 50 minutes while the quota was saturated.

## Change

`requiresDirectoryWatchers()` now returns `true` for all of Linux instead of only Node 22.0:

```ts
function requiresDirectoryWatchers(platform: NodeJS.Platform): boolean {
  return platform === "linux";
}
```

This routes Linux through the existing `watchDirectoryTree()`, which already calls `shouldTrackPath(directory, true)` before descending and creates non-recursive per-directory watches — so ignored trees are never opened and watch count scales with tracked directories rather than with every file on disk.

The `nodeVersion` option becomes unused and is removed from `WatchManagerOptions` and its call site, along with the now-meaningless `nodeVersion: "22.0.0"` entries in the tests.

macOS and Windows are unaffected and keep the recursive path, where `fs.watch` recursion is native and does not carry this cost.

## Alternatives considered

A registration-time `ignore` option on `fs.watch` would also work, but it is not available across the full supported range (the package targets Node >= 22), so it would reintroduce a version gate. Reusing `watchDirectoryTree()` needs no new code and is already covered by tests.

## Trade-off

Per-directory watching does a tree walk at activation instead of handing recursion to Node. On very large workspaces that walk is marginally slower, but since ignored trees are now skipped entirely rather than descended into, the net work should be lower in practice — and the watch count drops by orders of magnitude.

## Testing

- `test/watch-manager.test.mjs` — all 12 tests pass. The existing per-directory coverage (ignored-directory pruning, `noIgnore`, hidden-directory selection, independent retries) now exercises the default Linux path rather than a Node-22.0-only branch.
- `npm run check` passes locally (lint, format:check, typecheck, coverage, package tests).

No new test was added: the behavior is now the single Linux path that the existing suite already covers end to end, and the removed branch had no remaining distinct behavior to assert.