### PR TITLE
chore(deps): upgrade web-tree-sitter and switch grammar source

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,11 +15,11 @@
         "@modelcontextprotocol/core": "2.0.0",
         "@modelcontextprotocol/node": "2.0.0",
         "@modelcontextprotocol/server": "2.0.0",
+        "@repomix/tree-sitter-wasms": "^0.1.17",
         "@vscode/ripgrep": "^1.18.0",
         "@zvec/zvec": "^0.7.0",
         "jsonc-parser": "^3.3.1",
-        "tree-sitter-wasms": "^0.1.13",
-        "web-tree-sitter": "^0.20.8",
+        "web-tree-sitter": "^0.27.0",
         "zod": "4.2.0"
       },
       "bin": {
@@ -1572,6 +1572,12 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@repomix/tree-sitter-wasms": {
+      "version": "0.1.17",
+      "resolved": "https://registry.npmjs.org/@repomix/tree-sitter-wasms/-/tree-sitter-wasms-0.1.17.tgz",
+      "integrity": "sha512-tc3HnFqdMF1pXhIMzG3aTaBDpIiHK2tPfn3fwqA6P3WTbHa+1EuuTubbKshvmN7xCHP5Ojz0/VW4R+XvR88KOw==",
+      "license": "Unlicense"
+    },
     "node_modules/@simple-git/args-pathspec": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@simple-git/args-pathspec/-/args-pathspec-1.0.3.tgz",
@@ -2056,9 +2062,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2071,9 +2074,6 @@
       "integrity": "sha512-tgxDQGOkBEjz9ANw4Y74pDCXLX6wOxziYHe+zbIRGKPDgIqVSdUxhwz3z5VOFWzCKzyCeiboA6XSPhuLFlMbtQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2088,9 +2088,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2103,9 +2100,6 @@
       "integrity": "sha512-zJeQqWTpPcFY7ICikh+MqsxBmpPz6L2txEDdxb139+Y5JAY6BT13iin8AdyQ95YM8ajFWxKKRLr5XIG2VgmDZw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -5496,15 +5490,6 @@
         "node": ">=0.6"
       }
     },
-    "node_modules/tree-sitter-wasms": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/tree-sitter-wasms/-/tree-sitter-wasms-0.1.13.tgz",
-      "integrity": "sha512-wT+cR6DwaIz80/vho3AvSF0N4txuNx/5bcRKoXouOfClpxh/qqrF4URNLQXbbt8MaAxeksZcZd1j8gcGjc+QxQ==",
-      "license": "Unlicense",
-      "dependencies": {
-        "tree-sitter-wasms": "^0.1.11"
-      }
-    },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -5717,9 +5702,9 @@
       }
     },
     "node_modules/web-tree-sitter": {
-      "version": "0.20.8",
-      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.20.8.tgz",
-      "integrity": "sha512-weOVgZ3aAARgdnb220GqYuh7+rZU0Ka9k9yfKtGAzEYMa6GgiCzW9JjQRJyCJakvibQW+dfjJdihjInKuuCAUQ==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.27.0.tgz",
+      "integrity": "sha512-XK08gj6RwTMQatAG7uVRP8MunqotL/XC19vHgkSPKmELgbGPBj4ECvB8haHOUnyj6ls2B8t42UTro14zxGgAHg==",
       "license": "MIT"
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -73,11 +73,11 @@
     "@modelcontextprotocol/core": "2.0.0",
     "@modelcontextprotocol/node": "2.0.0",
     "@modelcontextprotocol/server": "2.0.0",
+    "@repomix/tree-sitter-wasms": "^0.1.17",
     "@vscode/ripgrep": "^1.18.0",
     "@zvec/zvec": "^0.7.0",
     "jsonc-parser": "^3.3.1",
-    "tree-sitter-wasms": "^0.1.13",
-    "web-tree-sitter": "^0.20.8",
+    "web-tree-sitter": "^0.27.0",
     "zod": "4.2.0"
   },
   "optionalDependencies": {

--- a/src/engine/extraction/code/languages/go.ts
+++ b/src/engine/extraction/code/languages/go.ts
@@ -10,7 +10,7 @@ export const GO_ADAPTER: LanguageAdapter = {
   format: "go",
   entityTypes: new Set([
     "function_declaration",
-    "method_spec",
+    "method_elem",
     "method_declaration",
     "type_alias",
     "type_spec",
@@ -56,7 +56,7 @@ export const GO_ADAPTER: LanguageAdapter = {
       return "alias";
     }
 
-    if (node.type === "method_spec") {
+    if (node.type === "method_elem") {
       return "function";
     }
 

--- a/src/engine/extraction/code/tree-sitter/grammar.ts
+++ b/src/engine/extraction/code/tree-sitter/grammar.ts
@@ -1,6 +1,6 @@
 import { createRequire } from "node:module";
 import { join } from "node:path";
-import Parser from "web-tree-sitter";
+import { Language, Parser } from "web-tree-sitter";
 
 const require = createRequire(import.meta.url);
 
@@ -18,7 +18,7 @@ const LANGUAGE_WASM_MAP: Record<string, string> = {
 };
 
 let parserReady = false;
-const grammarCache = new Map<string, Parser.Language>();
+const grammarCache = new Map<string, Language>();
 
 export async function ensureParser(): Promise<void> {
   if (!parserReady) {
@@ -27,9 +27,7 @@ export async function ensureParser(): Promise<void> {
   }
 }
 
-export async function loadGrammar(
-  format: string,
-): Promise<Parser.Language | null> {
+export async function loadGrammar(format: string): Promise<Language | null> {
   const cached = grammarCache.get(format);
   if (cached) {
     return cached;
@@ -44,12 +42,12 @@ export async function loadGrammar(
 
   try {
     const wasmsDir = join(
-      require.resolve("tree-sitter-wasms/package.json"),
+      require.resolve("@repomix/tree-sitter-wasms/package.json"),
       "..",
       "out",
     );
     const wasmPath = join(wasmsDir, `tree-sitter-${wasmName}.wasm`);
-    const grammar = await Parser.Language.load(wasmPath);
+    const grammar = await Language.load(wasmPath);
     grammarCache.set(format, grammar);
 
     return grammar;

--- a/src/engine/extraction/code/tree-sitter/nodes.ts
+++ b/src/engine/extraction/code/tree-sitter/nodes.ts
@@ -1,6 +1,6 @@
-import type Parser from "web-tree-sitter";
+import type { Node } from "web-tree-sitter";
 
-export type TSNode = Parser.SyntaxNode;
+export type TSNode = Node;
 
 export function findIdentifierLeaf(node: TSNode): TSNode | null {
   const wrappers = new Set([

--- a/src/engine/extraction/code/tree-sitter/parser.ts
+++ b/src/engine/extraction/code/tree-sitter/parser.ts
@@ -1,10 +1,10 @@
-import Parser from "web-tree-sitter";
+import { Parser, type Tree } from "web-tree-sitter";
 import { ensureParser, loadGrammar } from "./grammar.js";
 
 export async function withParser<T>(
   source: string,
   format: string,
-  fn: (tree: Parser.Tree) => T | Promise<T>,
+  fn: (tree: Tree) => T | Promise<T>,
 ): Promise<T | null> {
   await ensureParser();
 
@@ -16,7 +16,7 @@ export async function withParser<T>(
   const parser = new Parser();
   parser.setLanguage(grammar);
 
-  let tree: Parser.Tree | null;
+  let tree: Tree | null;
 
   try {
     tree = parser.parse(source);


### PR DESCRIPTION
web-tree-sitter 0.20.8 rejects grammars built with tree-sitter CLI 0.24 and newer ("Incompatible language version 15. Compatibility range 13 through 14"), which pins every grammar to its 2024 revision.

Move the runtime to 0.27 and take grammars from @repomix/tree-sitter-wasms, a maintained fork of tree-sitter-wasms whose last release still ships tree-sitter-php 0.22 and tree-sitter-cli 0.20.8. All ten formats the extractor supports are present in the fork with the same output layout.

The 0.25 module restructure renames SyntaxNode to Node and moves Language out of the Parser namespace. Go renamed the interface method node from method_spec to method_elem, which the extraction test for Go scopes covers.

Second step to support more languages in code extraction. See issue #88. All new tests from PR #89 are passing. 