### PR TITLE
feat: extract php symbols with structure awareness

### DIFF
--- a/docs/04-pipeline.md
+++ b/docs/04-pipeline.md
@@ -82,9 +82,9 @@ participate in indexed search.
 
 | Files | Formats | Extractor | Indexed representation |
 | --- | --- | --- | --- |
-| Structure-aware code | C/C++ (`.c`, `.cc`, `.cpp`, `.cxx`, `.h`, `.hpp`), Go, Java, JavaScript/JSX, TypeScript/TSX, Python, Rust | `CodeExtractor` | Symbols, signatures, breadcrumbs, and surrounding source |
+| Structure-aware code | C/C++ (`.c`, `.cc`, `.cpp`, `.cxx`, `.h`, `.hpp`), Go, Java, JavaScript/JSX, TypeScript/TSX, PHP, Python, Rust | `CodeExtractor` | Symbols, signatures, breadcrumbs, and surrounding source |
 | Component scripts | `.vue`, `.svelte` | `CodeExtractor` | JavaScript or TypeScript `<script>` blocks; plain-text fallback when no structure is found |
-| Other recognized code | Ruby, PHP, Swift, Kotlin, C#, Scala, shell, SQL, CSS/SCSS/Less, `Dockerfile`, `Makefile` | `CodeExtractor` | Plain-text chunks until a structural grammar is available |
+| Other recognized code | Ruby, Swift, Kotlin, C#, Scala, shell, SQL, CSS/SCSS/Less, `Dockerfile`, `Makefile` | `CodeExtractor` | Plain-text chunks until a structural grammar is available |
 | Markdown | `.md`, `.mdx` | `MarkdownExtractor` | Heading sections and breadcrumbs; plain-text fallback for documents without headings |
 | Text documents | `.txt`, `.rst`, `.html`, `.htm`, `.xml` | `TextExtractor` | Plain-text chunks |
 | Text data | `.csv`, `.json`, `.jsonc`, `.toml`, `.yaml`, `.yml` | `TextExtractor` | Plain-text chunks |

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,11 +15,11 @@
         "@modelcontextprotocol/core": "2.0.0",
         "@modelcontextprotocol/node": "2.0.0",
         "@modelcontextprotocol/server": "2.0.0",
+        "@repomix/tree-sitter-wasms": "^0.1.17",
         "@vscode/ripgrep": "^1.18.0",
         "@zvec/zvec": "^0.7.0",
         "jsonc-parser": "^3.3.1",
-        "tree-sitter-wasms": "^0.1.13",
-        "web-tree-sitter": "^0.20.8",
+        "web-tree-sitter": "^0.27.0",
         "zod": "4.2.0"
       },
       "bin": {
@@ -1572,6 +1572,12 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@repomix/tree-sitter-wasms": {
+      "version": "0.1.17",
+      "resolved": "https://registry.npmjs.org/@repomix/tree-sitter-wasms/-/tree-sitter-wasms-0.1.17.tgz",
+      "integrity": "sha512-tc3HnFqdMF1pXhIMzG3aTaBDpIiHK2tPfn3fwqA6P3WTbHa+1EuuTubbKshvmN7xCHP5Ojz0/VW4R+XvR88KOw==",
+      "license": "Unlicense"
+    },
     "node_modules/@simple-git/args-pathspec": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@simple-git/args-pathspec/-/args-pathspec-1.0.3.tgz",
@@ -2056,9 +2062,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2071,9 +2074,6 @@
       "integrity": "sha512-tgxDQGOkBEjz9ANw4Y74pDCXLX6wOxziYHe+zbIRGKPDgIqVSdUxhwz3z5VOFWzCKzyCeiboA6XSPhuLFlMbtQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2088,9 +2088,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2103,9 +2100,6 @@
       "integrity": "sha512-zJeQqWTpPcFY7ICikh+MqsxBmpPz6L2txEDdxb139+Y5JAY6BT13iin8AdyQ95YM8ajFWxKKRLr5XIG2VgmDZw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -5496,15 +5490,6 @@
         "node": ">=0.6"
       }
     },
-    "node_modules/tree-sitter-wasms": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/tree-sitter-wasms/-/tree-sitter-wasms-0.1.13.tgz",
-      "integrity": "sha512-wT+cR6DwaIz80/vho3AvSF0N4txuNx/5bcRKoXouOfClpxh/qqrF4URNLQXbbt8MaAxeksZcZd1j8gcGjc+QxQ==",
-      "license": "Unlicense",
-      "dependencies": {
-        "tree-sitter-wasms": "^0.1.11"
-      }
-    },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -5717,9 +5702,9 @@
       }
     },
     "node_modules/web-tree-sitter": {
-      "version": "0.20.8",
-      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.20.8.tgz",
-      "integrity": "sha512-weOVgZ3aAARgdnb220GqYuh7+rZU0Ka9k9yfKtGAzEYMa6GgiCzW9JjQRJyCJakvibQW+dfjJdihjInKuuCAUQ==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.27.0.tgz",
+      "integrity": "sha512-XK08gj6RwTMQatAG7uVRP8MunqotL/XC19vHgkSPKmELgbGPBj4ECvB8haHOUnyj6ls2B8t42UTro14zxGgAHg==",
       "license": "MIT"
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -73,11 +73,11 @@
     "@modelcontextprotocol/core": "2.0.0",
     "@modelcontextprotocol/node": "2.0.0",
     "@modelcontextprotocol/server": "2.0.0",
+    "@repomix/tree-sitter-wasms": "^0.1.17",
     "@vscode/ripgrep": "^1.18.0",
     "@zvec/zvec": "^0.7.0",
     "jsonc-parser": "^3.3.1",
-    "tree-sitter-wasms": "^0.1.13",
-    "web-tree-sitter": "^0.20.8",
+    "web-tree-sitter": "^0.27.0",
     "zod": "4.2.0"
   },
   "optionalDependencies": {

--- a/src/engine/code-formats.ts
+++ b/src/engine/code-formats.ts
@@ -5,6 +5,7 @@ export const STRUCTURED_CODE_FORMATS = [
   "java",
   "javascript",
   "jsx",
+  "php",
   "python",
   "rust",
   "tsx",

--- a/src/engine/extraction/code/adapter.ts
+++ b/src/engine/extraction/code/adapter.ts
@@ -6,6 +6,7 @@ import { CPP_ADAPTER } from "./languages/cpp.js";
 import { GO_ADAPTER } from "./languages/go.js";
 import { JAVA_ADAPTER } from "./languages/java.js";
 import { JAVASCRIPT_ADAPTER } from "./languages/javascript.js";
+import { PHP_ADAPTER } from "./languages/php.js";
 import { PYTHON_ADAPTER } from "./languages/python.js";
 import { RUST_ADAPTER } from "./languages/rust.js";
 import { TYPESCRIPT_ADAPTER } from "./languages/typescript.js";
@@ -40,6 +41,7 @@ const ADAPTERS = {
   java: JAVA_ADAPTER,
   javascript: JAVASCRIPT_ADAPTER,
   jsx: JAVASCRIPT_ADAPTER,
+  php: PHP_ADAPTER,
   python: PYTHON_ADAPTER,
   rust: RUST_ADAPTER,
   tsx: TYPESCRIPT_ADAPTER,

--- a/src/engine/extraction/code/languages/go.ts
+++ b/src/engine/extraction/code/languages/go.ts
@@ -10,7 +10,7 @@ export const GO_ADAPTER: LanguageAdapter = {
   format: "go",
   entityTypes: new Set([
     "function_declaration",
-    "method_spec",
+    "method_elem",
     "method_declaration",
     "type_alias",
     "type_spec",
@@ -56,7 +56,7 @@ export const GO_ADAPTER: LanguageAdapter = {
       return "alias";
     }
 
-    if (node.type === "method_spec") {
+    if (node.type === "method_elem") {
       return "function";
     }
 

--- a/src/engine/extraction/code/languages/php.ts
+++ b/src/engine/extraction/code/languages/php.ts
@@ -1,0 +1,133 @@
+import type { CodeEntityModifier } from "../../../types.js";
+import type { TSNode } from "../tree-sitter/nodes.js";
+import type { LanguageAdapter } from "../adapter.js";
+import {
+  extractGenericSignature,
+  extractPrecedingDoc,
+} from "../families/metadata.js";
+
+const MULTI_ELEMENT_TYPES = new Set([
+  "const_declaration",
+  "property_declaration",
+]);
+
+const ELEMENT_TYPES = new Set(["const_element", "property_element"]);
+
+const VALUE_TYPES = new Set([...ELEMENT_TYPES, "property_promotion_parameter"]);
+
+export const PHP_ADAPTER: LanguageAdapter = {
+  format: "php",
+  entityTypes: new Set([
+    "class_declaration",
+    "const_declaration",
+    "enum_case",
+    "enum_declaration",
+    "function_definition",
+    "interface_declaration",
+    "method_declaration",
+    "namespace_definition",
+    "property_declaration",
+    "trait_declaration",
+  ]),
+  scopeTypes: new Set([
+    "class_declaration",
+    "enum_declaration",
+    "interface_declaration",
+    "namespace_definition",
+    "trait_declaration",
+  ]),
+  resolveEntities(node) {
+    if (MULTI_ELEMENT_TYPES.has(node.type)) {
+      const elements = node.namedChildren.filter((child) =>
+        ELEMENT_TYPES.has(child.type),
+      );
+
+      return elements.length > 0 ? elements : [node];
+    }
+
+    return [node, ...promotedProperties(node)];
+  },
+  extractName(node) {
+    if (!VALUE_TYPES.has(node.type)) {
+      return node.childForFieldName("name")?.text;
+    }
+
+    const variable = node.namedChildren.find(
+      (child) => child.type === "variable_name",
+    );
+
+    return (variable ?? node).namedChildren.find(
+      (child) => child.type === "name",
+    )?.text;
+  },
+  classifyNode(node) {
+    return VALUE_TYPES.has(node.type) || node.type === "enum_case"
+      ? "value"
+      : undefined;
+  },
+  extractSignature(node) {
+    const declaration = declarationOf(node);
+
+    return declaration.childForFieldName("body")
+      ? extractGenericSignature(declaration)
+      : compactSignature(declaration);
+  },
+  extractDoc(node) {
+    return extractPrecedingDoc(declarationOf(node));
+  },
+  extractModifiers(node) {
+    const modifiers = new Set<CodeEntityModifier>();
+
+    for (const child of declarationOf(node).namedChildren) {
+      if (child.type === "static_modifier") {
+        modifiers.add("static");
+        continue;
+      }
+
+      if (child.type === "visibility_modifier") {
+        modifiers.add(visibilityOf(child));
+      }
+    }
+
+    return [...modifiers];
+  },
+};
+
+// Declarations without a body carry no line structure worth keeping, and the
+// shared helper would truncate a wrapped one to its first line. Property hooks
+// are cut instead, so a hook body never reaches the signature.
+function compactSignature(node: TSNode): string | undefined {
+  const hooks = node.namedChildren.find(
+    (child) => child.type === "property_hook_list",
+  );
+  const text = hooks
+    ? node.text.slice(0, hooks.startIndex - node.startIndex)
+    : node.text;
+  const normalized = text
+    .replace(/\s+/g, " ")
+    .replace(/\s*[{;]\s*$/, "")
+    .trim();
+
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+// Promoted parameters declare properties, so they are indexed beside the
+// constructor rather than through it: the walk never descends into an entity.
+function promotedProperties(node: TSNode): readonly TSNode[] {
+  return (
+    node
+      .childForFieldName("parameters")
+      ?.namedChildren.filter(
+        (child) => child.type === "property_promotion_parameter",
+      ) ?? []
+  );
+}
+
+function declarationOf(node: TSNode): TSNode {
+  return ELEMENT_TYPES.has(node.type) ? (node.parent ?? node) : node;
+}
+
+// PHP 8.4 asymmetric visibility reads as "private(set)"; the set half is dropped.
+function visibilityOf(node: TSNode): CodeEntityModifier {
+  return node.text.split("(")[0].trim() as CodeEntityModifier;
+}

--- a/src/engine/extraction/code/tree-sitter/grammar.ts
+++ b/src/engine/extraction/code/tree-sitter/grammar.ts
@@ -1,6 +1,6 @@
 import { createRequire } from "node:module";
 import { join } from "node:path";
-import Parser from "web-tree-sitter";
+import { Language, Parser } from "web-tree-sitter";
 
 const require = createRequire(import.meta.url);
 
@@ -18,7 +18,7 @@ const LANGUAGE_WASM_MAP: Record<string, string> = {
 };
 
 let parserReady = false;
-const grammarCache = new Map<string, Parser.Language>();
+const grammarCache = new Map<string, Language>();
 
 export async function ensureParser(): Promise<void> {
   if (!parserReady) {
@@ -27,9 +27,7 @@ export async function ensureParser(): Promise<void> {
   }
 }
 
-export async function loadGrammar(
-  format: string,
-): Promise<Parser.Language | null> {
+export async function loadGrammar(format: string): Promise<Language | null> {
   const cached = grammarCache.get(format);
   if (cached) {
     return cached;
@@ -44,12 +42,12 @@ export async function loadGrammar(
 
   try {
     const wasmsDir = join(
-      require.resolve("tree-sitter-wasms/package.json"),
+      require.resolve("@repomix/tree-sitter-wasms/package.json"),
       "..",
       "out",
     );
     const wasmPath = join(wasmsDir, `tree-sitter-${wasmName}.wasm`);
-    const grammar = await Parser.Language.load(wasmPath);
+    const grammar = await Language.load(wasmPath);
     grammarCache.set(format, grammar);
 
     return grammar;

--- a/src/engine/extraction/code/tree-sitter/grammar.ts
+++ b/src/engine/extraction/code/tree-sitter/grammar.ts
@@ -11,6 +11,7 @@ const LANGUAGE_WASM_MAP: Record<string, string> = {
   java: "java",
   javascript: "javascript",
   jsx: "javascript",
+  php: "php",
   python: "python",
   rust: "rust",
   tsx: "tsx",

--- a/src/engine/extraction/code/tree-sitter/nodes.ts
+++ b/src/engine/extraction/code/tree-sitter/nodes.ts
@@ -1,6 +1,6 @@
-import type Parser from "web-tree-sitter";
+import type { Node } from "web-tree-sitter";
 
-export type TSNode = Parser.SyntaxNode;
+export type TSNode = Node;
 
 export function findIdentifierLeaf(node: TSNode): TSNode | null {
   const wrappers = new Set([

--- a/src/engine/extraction/code/tree-sitter/parser.ts
+++ b/src/engine/extraction/code/tree-sitter/parser.ts
@@ -1,10 +1,10 @@
-import Parser from "web-tree-sitter";
+import { Parser, type Tree } from "web-tree-sitter";
 import { ensureParser, loadGrammar } from "./grammar.js";
 
 export async function withParser<T>(
   source: string,
   format: string,
-  fn: (tree: Parser.Tree) => T | Promise<T>,
+  fn: (tree: Tree) => T | Promise<T>,
 ): Promise<T | null> {
   await ensureParser();
 
@@ -16,7 +16,7 @@ export async function withParser<T>(
   const parser = new Parser();
   parser.setLanguage(grammar);
 
-  let tree: Parser.Tree | null;
+  let tree: Tree | null;
 
   try {
     tree = parser.parse(source);

--- a/test/unit/extraction/code.test.mjs
+++ b/test/unit/extraction/code.test.mjs
@@ -348,3 +348,133 @@ test("code chunk boundaries never split Unicode surrogate pairs", async () => {
     assert.doesNotMatch(fragment.content.text, /^[\uDC00-\uDFFF]/u);
   }
 });
+
+test("code extractor preserves php symbols, scopes, properties, and constants", async () => {
+  const php = await new CodeExtractor().extract(
+    codeSource(
+      "php",
+      [
+        "<?php",
+        "namespace App {",
+        "/** Charges a guest. */",
+        "interface ChargerInterface { public function charge(int $cents): bool; }",
+        "trait Loggable { public function log(string $msg): void {} }",
+        "enum ChargeStatus: string { case Paid = 'paid'; const int MIN = 1; }",
+        "abstract class BaseCharger implements ChargerInterface {",
+        "  /** The wallet. */",
+        "  private readonly Wallet $wallet;",
+        "  public const int MAX = 100;",
+        "  public string $full {",
+        "    get => $this->a;",
+        "    set(string $v) { $this->a = $v; }",
+        "  }",
+        "  private(set) int $counter = 0;",
+        "  public static function make(int $limit): static { return new static($limit); }",
+        "  public function __construct(",
+        "    private Logger $logger,",
+        "    string $tag,",
+        "  ) {}",
+        "}",
+        "function helper(int $x): int { return $x * 2; }",
+        "}",
+      ].join("\n"),
+      "fixture.php",
+    ),
+  );
+
+  assert.deepEqual(fragmentNamed(php, "ChargerInterface").metadata, {
+    kind: "code",
+    symbolType: "interface",
+    symbolName: "ChargerInterface",
+    scope: "App",
+    nodeType: "interface_declaration",
+    signature: "interface ChargerInterface",
+    doc: "Charges a guest.",
+    modifiers: [],
+  });
+  assert.deepEqual(fragmentNamed(php, "make").metadata, {
+    kind: "code",
+    symbolType: "function",
+    symbolName: "make",
+    scope: "App::BaseCharger",
+    nodeType: "method_declaration",
+    signature: "public static function make(int $limit): static",
+    doc: null,
+    modifiers: ["public", "static"],
+  });
+  assert.deepEqual(fragmentNamed(php, "wallet").metadata, {
+    kind: "code",
+    symbolType: "value",
+    symbolName: "wallet",
+    scope: "App::BaseCharger",
+    nodeType: "property_element",
+    signature: "private readonly Wallet $wallet",
+    doc: "The wallet.",
+    modifiers: ["private"],
+  });
+  assert.deepEqual(fragmentNamed(php, "MAX").metadata, {
+    kind: "code",
+    symbolType: "value",
+    symbolName: "MAX",
+    scope: "App::BaseCharger",
+    nodeType: "const_element",
+    signature: "public const int MAX = 100",
+    doc: null,
+    modifiers: ["public"],
+  });
+  assert.deepEqual(fragmentNamed(php, "full").metadata, {
+    kind: "code",
+    symbolType: "value",
+    symbolName: "full",
+    scope: "App::BaseCharger",
+    nodeType: "property_element",
+    signature: "public string $full",
+    doc: null,
+    modifiers: ["public"],
+  });
+  assert.deepEqual(fragmentNamed(php, "charge").metadata, {
+    kind: "code",
+    symbolType: "function",
+    symbolName: "charge",
+    scope: "App::ChargerInterface",
+    nodeType: "method_declaration",
+    signature: "public function charge(int $cents): bool",
+    doc: null,
+    modifiers: ["public"],
+  });
+  assert.equal(fragmentNamed(php, "App").metadata.symbolType, "module");
+  assert.equal(fragmentNamed(php, "ChargeStatus").metadata.symbolType, "class");
+  assert.deepEqual(fragmentNamed(php, "Paid").metadata.modifiers, []);
+  assert.equal(fragmentNamed(php, "Paid").metadata.symbolType, "value");
+  assert.equal(fragmentNamed(php, "MIN").metadata.scope, "App::ChargeStatus");
+  assert.equal(
+    fragmentNamed(php, "Loggable").metadata.nodeType,
+    "trait_declaration",
+  );
+  assert.equal(fragmentNamed(php, "log").metadata.scope, "App::Loggable");
+  assert.equal(fragmentNamed(php, "helper").metadata.scope, "App");
+  assert.deepEqual(fragmentNamed(php, "counter").metadata.modifiers, [
+    "private",
+  ]);
+  assert.deepEqual(fragmentNamed(php, "logger").metadata, {
+    kind: "code",
+    symbolType: "value",
+    symbolName: "logger",
+    scope: "App::BaseCharger",
+    nodeType: "property_promotion_parameter",
+    signature: "private Logger $logger",
+    doc: null,
+    modifiers: ["private"],
+  });
+  assert.equal(
+    php.find((fragment) => fragment.metadata?.symbolName === "tag"),
+    undefined,
+  );
+  assert.deepEqual(fragmentNamed(php, "__construct").metadata.modifiers, [
+    "public",
+  ]);
+  assert.equal(
+    fragmentNamed(php, "__construct").metadata.signature,
+    "public function __construct( private Logger $logger, string $tag, )",
+  );
+});


### PR DESCRIPTION
PHP files fell back to plain-text chunks. Every PHP declaration carries a name 
field and the shared classifier already maps trait, enum and namespace nodes 
correctly, so the adapter only adds what PHP does differently.

Properties and constants declare several names per statement, and promoted 
constructor parameters declare properties from inside a signature. Both are 
handled by resolveEntities, which keeps promoted properties on the class 
breadcrumb rather than the constructor's, since the walk never descends into an
entity node.

Modifiers read PHP's modifier nodes rather than the shared signature regex, 
which otherwise reports a promoted parameter's visibility as the constructor's
own. 

Covers namespaces, classes, interfaces, traits, enums, methods, functions, 
properties, constants, enum cases and promoted constructor properties.

Third, and final, step to support php in code extraction. See issue #88.

This branch requires and contains code from #90. It should be updated when it is 
merged into main.