### PR TITLE
Add pip-installable Python library and API tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,25 @@ zg index --embedding local/potion-retrieval-32m
 > [!NOTE]
 > The index is stored in `.zvec-grep/` under the indexed project root.
 
+### Python library (pip wheel)
+
+Install the Python wrapper package:
+
+```bash
+pip install zvec-grep
+```
+
+Then use it in Python to run the same `zg` workflows:
+
+```python
+from zvec_grep import ZvecGrep
+
+zg = ZvecGrep()
+zg.index(root=".", embedding="local/potion-retrieval-32m")
+result = zg.query("An unseen creature left a few marks.", root=".", human=True, limit=3)
+print(result.stdout)
+```
+
 ### 2. Choose how to search
 
 #### For agents: ask with OpenCode

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,35 @@
+[build-system]
+requires = ["hatchling>=1.27,<2"]
+build-backend = "hatchling.build"
+
+[project]
+name = "zvec-grep"
+version = "0.1.0"
+description = "Python library wrapper for zvec-grep CLI workflows."
+readme = "README.md"
+requires-python = ">=3.10"
+license = "Apache-2.0"
+authors = [{ name = "zvec-ai" }]
+keywords = ["search", "rag", "retrieval", "vector-search", "developer-tools"]
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: Apache Software License",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Topic :: Software Development :: Libraries :: Python Modules",
+]
+
+[project.urls]
+Homepage = "https://github.com/zvec-ai/zvec-grep"
+Repository = "https://github.com/zvec-ai/zvec-grep"
+Issues = "https://github.com/zvec-ai/zvec-grep/issues"
+
+[project.scripts]
+zgpy = "zvec_grep.__main__:main"
+
+[tool.hatch.build.targets.wheel]
+packages = ["zvec_grep"]

--- a/test/package/python-package.test.mjs
+++ b/test/package/python-package.test.mjs
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdir, readdir } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import { promisify } from "node:util";
+import test from "node:test";
+import { createTemporaryDirectory } from "../helpers/fixtures.mjs";
+
+const execFileAsync = promisify(execFile);
+
+function pythonExecutable() {
+  return process.env.PYTHON ?? "python";
+}
+
+async function runPython(args, options = {}) {
+  return execFileAsync(pythonExecutable(), args, {
+    cwd: options.cwd,
+    env: { ...process.env, ...options.env },
+    timeout: options.timeout ?? 120_000,
+    windowsHide: true,
+  });
+}
+
+test("python wheel builds and can be installed for import", async (t) => {
+  const root = resolve(".");
+  const temporaryDirectory = await createTemporaryDirectory(
+    t,
+    "zvec-grep-python-package-",
+  );
+  const wheelDirectory = join(temporaryDirectory, "wheel");
+  const installDirectory = join(temporaryDirectory, "install");
+  await mkdir(wheelDirectory, { recursive: true });
+  await mkdir(installDirectory, { recursive: true });
+
+  await runPython(["-m", "pip", "wheel", ".", "--no-deps", "-w", wheelDirectory], {
+    cwd: root,
+    timeout: 180_000,
+  });
+
+  const wheelFile = (await readdir(wheelDirectory)).find((entry) =>
+    entry.endsWith(".whl"),
+  );
+  assert.ok(wheelFile, "expected a built wheel artifact");
+  const wheelPath = join(wheelDirectory, wheelFile);
+
+  await runPython(
+    [
+      "-m",
+      "pip",
+      "install",
+      "--no-deps",
+      "--target",
+      installDirectory,
+      wheelPath,
+    ],
+    { cwd: root, timeout: 180_000 },
+  );
+
+  const imported = await runPython([
+    "-c",
+    [
+      "import sys",
+      `sys.path.insert(0, r'''${installDirectory}''')`,
+      "from zvec_grep import ZvecGrep, ZGResult, zvec_grep",
+      "assert isinstance(zvec_grep, ZvecGrep)",
+      "assert ZGResult.__name__ == 'ZGResult'",
+    ].join("\n"),
+  ]);
+  assert.equal(imported.stderr, "");
+});
+
+test("python wrapper API builds command arguments and handles failures", async () => {
+  const root = resolve(".");
+  const script = [
+    "from pathlib import Path",
+    "import subprocess",
+    "from unittest.mock import patch",
+    "from zvec_grep import ZvecGrep",
+    "",
+    "client = ZvecGrep(cwd=Path('.'))",
+    "",
+    "with patch('shutil.which', return_value='/usr/bin/zg'):",
+    "    assert client.is_available()",
+    "with patch('shutil.which', return_value=None):",
+    "    assert client.is_available() is False",
+    "",
+    "def fake_run(command, **kwargs):",
+    "    assert kwargs['capture_output'] is True",
+    "    assert kwargs['text'] is True",
+    "    assert kwargs['check'] is False",
+    "    return subprocess.CompletedProcess(command, 0, 'ok', '')",
+    "",
+    "with patch('subprocess.run', side_effect=fake_run):",
+    "    result = client.index(root='workspace', embedding='local/potion', extra_args=['--mode', 'direct'])",
+    "    assert result.args == ('zg', 'index', '--root', 'workspace', '--embedding', 'local/potion', '--mode', 'direct')",
+    "",
+    "def fail_run(command, **kwargs):",
+    "    return subprocess.CompletedProcess(command, 2, '', 'bad')",
+    "",
+    "with patch('subprocess.run', side_effect=fail_run):",
+    "    raised = False",
+    "    try:",
+    "        client.query('needle', root='workspace')",
+    "    except RuntimeError as exc:",
+    "        raised = True",
+    "        assert 'exit code 2' in str(exc)",
+    "    assert raised",
+    "",
+    "def pass_run(command, **kwargs):",
+    "    return subprocess.CompletedProcess(command, 0, 'ready', '')",
+    "",
+    "with patch('subprocess.run', side_effect=pass_run):",
+    "    status = client.status(root='workspace', check_ready=True)",
+    "    assert status.args == ('zg', 'status', '--root', 'workspace', '--check-ready')",
+  ].join("\n");
+
+  const result = await runPython(["-c", script], { cwd: root });
+  assert.equal(result.stderr, "");
+});

--- a/zvec_grep/__init__.py
+++ b/zvec_grep/__init__.py
@@ -1,0 +1,5 @@
+"""Python wrapper for zvec-grep CLI commands."""
+
+from .client import ZGResult, ZvecGrep, zvec_grep
+
+__all__ = ["ZGResult", "ZvecGrep", "zvec_grep"]

--- a/zvec_grep/__main__.py
+++ b/zvec_grep/__main__.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import sys
+
+from .client import zvec_grep
+
+
+def main() -> int:
+    result = zvec_grep.run(*sys.argv[1:], check=False)
+    if result.stdout:
+        print(result.stdout, end="")
+    if result.stderr:
+        print(result.stderr, end="", file=sys.stderr)
+    return result.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/zvec_grep/client.py
+++ b/zvec_grep/client.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import shutil
+import subprocess
+from typing import Iterable
+
+
+@dataclass(frozen=True)
+class ZGResult:
+    """Subprocess result for a `zg` command."""
+
+    args: tuple[str, ...]
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+class ZvecGrep:
+    """Small Python wrapper around the `zg` CLI."""
+
+    def __init__(self, executable: str = "zg", cwd: str | Path | None = None) -> None:
+        self.executable = executable
+        self.cwd = Path(cwd).resolve() if cwd is not None else None
+
+    def is_available(self) -> bool:
+        return shutil.which(self.executable) is not None
+
+    def run(
+        self,
+        *args: str,
+        check: bool = True,
+        cwd: str | Path | None = None,
+    ) -> ZGResult:
+        command = [self.executable, *args]
+        effective_cwd = Path(cwd).resolve() if cwd is not None else self.cwd
+        completed = subprocess.run(
+            command,
+            cwd=str(effective_cwd) if effective_cwd is not None else None,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        result = ZGResult(
+            args=tuple(command),
+            returncode=completed.returncode,
+            stdout=completed.stdout,
+            stderr=completed.stderr,
+        )
+        if check and result.returncode != 0:
+            raise RuntimeError(
+                f"`{' '.join(result.args)}` failed with exit code {result.returncode}\n"
+                f"stdout:\n{result.stdout}\n"
+                f"stderr:\n{result.stderr}"
+            )
+        return result
+
+    def index(
+        self,
+        root: str | Path | None = None,
+        *,
+        embedding: str | None = None,
+        extra_args: Iterable[str] = (),
+        check: bool = True,
+    ) -> ZGResult:
+        args: list[str] = ["index"]
+        if root is not None:
+            args.extend(["--root", str(root)])
+        if embedding is not None:
+            args.extend(["--embedding", embedding])
+        args.extend(extra_args)
+        return self.run(*args, check=check)
+
+    def query(
+        self,
+        query: str,
+        *,
+        root: str | Path | None = None,
+        limit: int | None = None,
+        human: bool = False,
+        extra_args: Iterable[str] = (),
+        check: bool = True,
+    ) -> ZGResult:
+        args: list[str] = ["query"]
+        if root is not None:
+            args.extend(["--root", str(root)])
+        if human:
+            args.append("--human")
+        if limit is not None:
+            args.extend(["--limit", str(limit)])
+        args.extend(extra_args)
+        args.append(query)
+        return self.run(*args, check=check)
+
+    def status(
+        self,
+        *,
+        root: str | Path | None = None,
+        check_ready: bool = False,
+        check: bool = True,
+    ) -> ZGResult:
+        args: list[str] = ["status"]
+        if root is not None:
+            args.extend(["--root", str(root)])
+        if check_ready:
+            args.append("--check-ready")
+        return self.run(*args, check=check)
+
+
+zvec_grep = ZvecGrep()


### PR DESCRIPTION
This pull request introduces a new Python wrapper package for the `zvec-grep` CLI, enabling users to interact with `zg` workflows directly from Python. It includes the implementation of the Python API, packaging configuration, command-line entry point, and comprehensive tests to ensure correct behavior and installation.

**Python library and CLI integration:**

* Added a new `zvec_grep` Python package that wraps the `zg` CLI, exposing a `ZvecGrep` class with methods for `index`, `query`, and `status` operations, as well as subprocess result handling via the `ZGResult` dataclass. Also provides a default singleton instance `zvec_grep`. (`zvec_grep/client.py`, `zvec_grep/__init__.py`) [[1]](diffhunk://#diff-3bfdfbaeec678cef719e071c7a55a53712a9682f2f334bfb7b5a92d0bc9d652eR1-R111) [[2]](diffhunk://#diff-e7f1c071a9975cf0c4d3a091f6c38d9f31cdd7f6aeadacecd9bc2027b884da7dR1-R5)

* Implemented a Python CLI entry point (`zgpy`) that forwards arguments to the `zg` CLI using the Python wrapper, with proper output and exit code handling. (`zvec_grep/__main__.py`, `pyproject.toml`) [[1]](diffhunk://#diff-5ac8adca53373f9705be1d336cdb3653d7c542d31b7e9bcc82b08d2c4713e454R1-R18) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R1-R35)

**Packaging and distribution:**

* Added `pyproject.toml` configuration for building and distributing the Python package via a wheel, including metadata, dependencies, and entry points. (`pyproject.toml`)

**Testing and documentation:**

* Added automated tests to verify that the Python wheel builds, installs, and that the wrapper API correctly builds command arguments, handles subprocess failures, and supports mocking for CLI availability. (`test/package/python-package.test.mjs`)

* Updated `README.md` with installation and usage instructions for the new Python library, including example code for running `zg` workflows from Python. (`README.md`)