### PR TITLE
fix(server): extend watcher idle timeout

### DIFF
--- a/docs/02-cli.md
+++ b/docs/02-cli.md
@@ -222,6 +222,7 @@ refresh, authentication, and logs. See [MCP](./03-mcp.md) for the tool contract.
 | `ZVEC_GREP_SERVER_TOKEN` | Server/client Bearer token |
 | `ZVEC_GREP_SERVER_TOKEN_FILE` | File containing the server/client token |
 | `ZVEC_GREP_MCP_TOOLSET` | Default `agent` or `full` MCP surface |
+| `ZVEC_GREP_WATCHER_IDLE_TIMEOUT_SECONDS` | Seconds of workspace inactivity before the server releases its watcher; default `14400`, `0` disables idle eviction |
 | `ZVEC_GREP_EMBEDDING` | Default model for new indexes |
 | `ZVEC_GREP_API_KEY` | Embedding provider API key |
 | `ZVEC_GREP_ENDPOINT` | Remote Embedding endpoint |

--- a/docs/06-server.md
+++ b/docs/06-server.md
@@ -99,6 +99,19 @@ zg server off
 zg server on --mcp-toolset full
 ```
 
+The Server releases a Workspace watcher and its lightweight runtime after four
+hours without a client request or a relevant file-system change. Periodic
+reconciliation does not extend this idle deadline. To select another timeout,
+set the number of seconds before starting or restarting the Server:
+
+```bash
+export ZVEC_GREP_WATCHER_IDLE_TIMEOUT_SECONDS=7200
+zg server off
+zg server on
+```
+
+Set the value to `0` to keep activated watchers until the Server stops.
+
 ## Configure the mode
 
 Choose a mode for one command:

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -33,6 +33,8 @@ const ENVIRONMENT_VARIABLES = {
   ZVEC_GREP_SERVER_TOKEN: "Server/client Bearer token",
   ZVEC_GREP_SERVER_TOKEN_FILE: "File containing the Server/client Bearer token",
   ZVEC_GREP_MCP_TOOLSET: "Server MCP surface: agent or full",
+  ZVEC_GREP_WATCHER_IDLE_TIMEOUT_SECONDS:
+    "Seconds of workspace inactivity before the Server releases its watcher; default 14400, 0 disables eviction",
   ZVEC_GREP_EMBEDDING: "Default model for new indexes and auth grant",
   ZVEC_GREP_API_KEY: "Embedding provider credential fallback",
   ZVEC_GREP_ENDPOINT: "Remote Embedding endpoint fallback",
@@ -296,6 +298,7 @@ ${formatEnvironmentVariables([
   "ZVEC_GREP_SERVER_TOKEN",
   "ZVEC_GREP_SERVER_TOKEN_FILE",
   "ZVEC_GREP_MCP_TOOLSET",
+  "ZVEC_GREP_WATCHER_IDLE_TIMEOUT_SECONDS",
 ])}
 
 See zg help environment for daemon startup scope.`;
@@ -527,6 +530,7 @@ ${formatEnvironmentVariables([
   "ZVEC_GREP_SERVER_TOKEN",
   "ZVEC_GREP_SERVER_TOKEN_FILE",
   "ZVEC_GREP_MCP_TOOLSET",
+  "ZVEC_GREP_WATCHER_IDLE_TIMEOUT_SECONDS",
 ])}
 
 Embedding:

--- a/src/daemon/backend.ts
+++ b/src/daemon/backend.ts
@@ -1001,6 +1001,7 @@ export class DaemonBackend implements ZvecGrepDaemonBackend {
         coordinator.enqueue(changes, reason);
       },
       onPendingChange: (pending) => runtime.setWatcherPending(pending),
+      onActivity: () => runtime.recordWatcherActivity(),
       getRootPaths: () =>
         this.statusCache.get(runtime.canonicalRoot)?.workspaceIndex?.rootPaths,
     });

--- a/src/daemon/config.ts
+++ b/src/daemon/config.ts
@@ -6,6 +6,11 @@ import { DaemonError } from "./errors.js";
 
 export const DEFAULT_SERVER_HOST = "127.0.0.1";
 export const DEFAULT_SERVER_PORT = 7_999;
+export const DEFAULT_WATCHER_IDLE_TIMEOUT_MS = 4 * 60 * 60_000;
+export const WATCHER_IDLE_TIMEOUT_SECONDS_ENV =
+  "ZVEC_GREP_WATCHER_IDLE_TIMEOUT_SECONDS";
+
+const MAX_TIMER_DELAY_SECONDS = Math.floor(2_147_483_647 / 1_000);
 
 export type ServerListenAddress = {
   host: string;
@@ -34,6 +39,21 @@ export function configuredServerUrl(): string {
   const listen = configuredListenAddress();
   const host = listen.host.includes(":") ? `[${listen.host}]` : listen.host;
   return `http://${host}:${listen.port}/mcp`;
+}
+
+export function configuredWatcherIdleTimeoutMs(
+  environment: NodeJS.ProcessEnv = process.env,
+): number {
+  const configured = environment[WATCHER_IDLE_TIMEOUT_SECONDS_ENV]?.trim();
+  if (!configured) return DEFAULT_WATCHER_IDLE_TIMEOUT_MS;
+  if (!/^\d+$/.test(configured)) {
+    throw invalidWatcherIdleTimeout();
+  }
+  const seconds = Number(configured);
+  if (!Number.isSafeInteger(seconds) || seconds > MAX_TIMER_DELAY_SECONDS) {
+    throw invalidWatcherIdleTimeout();
+  }
+  return seconds * 1_000;
 }
 
 export function parseListenAddress(value?: string): ServerListenAddress {
@@ -124,4 +144,11 @@ function validateToken(token: string): void {
       "Server token must contain at least 32 characters.",
     );
   }
+}
+
+function invalidWatcherIdleTimeout(): DaemonError {
+  return new DaemonError(
+    "INVALID_WATCHER_IDLE_TIMEOUT",
+    `${WATCHER_IDLE_TIMEOUT_SECONDS_ENV} must be an integer between 0 and ${MAX_TIMER_DELAY_SECONDS}; 0 disables idle watcher eviction.`,
+  );
 }

--- a/src/daemon/root-runtime.ts
+++ b/src/daemon/root-runtime.ts
@@ -278,12 +278,15 @@ export class RootRuntime {
     this.watcherActive = active;
   }
 
+  recordWatcherActivity(): void {
+    if (!this.closed) this.options.onActivity?.();
+  }
+
   setWatcherPending(pending: boolean): void {
     if (pending) {
       this.watcherEpoch += 1;
     }
     this.watcherPending = pending;
-    this.options.onActivity?.();
   }
 
   async withWrite<T>(operation: () => Promise<T>): Promise<T> {

--- a/src/daemon/runtime-manager.ts
+++ b/src/daemon/runtime-manager.ts
@@ -7,12 +7,15 @@ import {
 } from "../engine/service/index.js";
 import type { CreateZvecGrepOptions } from "../engine/service/types.js";
 import { DaemonError } from "./errors.js";
+import { DEFAULT_WATCHER_IDLE_TIMEOUT_MS } from "./config.js";
 import type {
   EmbeddingModelLoadRequest,
   EmbeddingModelPool,
 } from "./model-pool.js";
 import { RootRuntime } from "./root-runtime.js";
 import { RootLeaseManager } from "./root-lease.js";
+
+const BUSY_RUNTIME_IDLE_RETRY_MS = 1_000;
 
 export type RuntimeManagerOptions = {
   modelPool: EmbeddingModelPool;
@@ -260,15 +263,20 @@ export class RuntimeManager {
   }
 
   private touchRuntime(canonicalRoot: string): void {
-    const idleTtlMs = this.options.runtimeIdleTtlMs ?? 30 * 60_000;
+    const idleTtlMs =
+      this.options.runtimeIdleTtlMs ?? DEFAULT_WATCHER_IDLE_TIMEOUT_MS;
+    this.scheduleIdleCheck(canonicalRoot, idleTtlMs);
+  }
+
+  private scheduleIdleCheck(canonicalRoot: string, delayMs: number): void {
     const existing = this.idleTimers.get(canonicalRoot);
     if (existing) clearTimeout(existing);
-    if (idleTtlMs <= 0 || this.closed) {
+    if (delayMs <= 0 || this.closed) {
       return;
     }
     const timer = setTimeout(
       () => void this.evictIfIdle(canonicalRoot),
-      idleTtlMs,
+      delayMs,
     );
     timer.unref?.();
     this.idleTimers.set(canonicalRoot, timer);
@@ -287,7 +295,12 @@ export class RuntimeManager {
       snapshot.writerPending ||
       snapshot.watcherPending
     ) {
-      this.touchRuntime(canonicalRoot);
+      const idleTtlMs =
+        this.options.runtimeIdleTtlMs ?? DEFAULT_WATCHER_IDLE_TIMEOUT_MS;
+      this.scheduleIdleCheck(
+        canonicalRoot,
+        Math.min(idleTtlMs, BUSY_RUNTIME_IDLE_RETRY_MS),
+      );
       return;
     }
     await this.evict(canonicalRoot);

--- a/src/daemon/runtime.ts
+++ b/src/daemon/runtime.ts
@@ -1,6 +1,10 @@
 import type { CreateZvecGrepOptions } from "../engine/service/types.js";
 import { DaemonBackend } from "./backend.js";
-import { configuredListenAddress, resolveServerToken } from "./config.js";
+import {
+  configuredListenAddress,
+  configuredWatcherIdleTimeoutMs,
+  resolveServerToken,
+} from "./config.js";
 import { DaemonHttpServer } from "./http-server.js";
 import { DaemonInstanceLock } from "./server-controller.js";
 import { createDaemonLogger } from "./logger.js";
@@ -31,6 +35,7 @@ export async function runDaemonForeground(
     options.mcpToolset,
     process.env[MCP_TOOLSET_ENV],
   );
+  const runtimeIdleTtlMs = configuredWatcherIdleTimeoutMs();
   const listen = configuredListenAddress(options.listen);
   const displayAddress = `http://${displayHost(listen.host)}:${listen.port}/mcp`;
   const instanceLock = await DaemonInstanceLock.acquire(
@@ -60,6 +65,7 @@ export async function runDaemonForeground(
   const backend = new DaemonBackend({
     version: options.version,
     serviceOptions: options.serviceOptions,
+    runtimeIdleTtlMs,
     logger,
   });
   let requestStop: (() => void) | undefined;

--- a/src/daemon/watch-manager.ts
+++ b/src/daemon/watch-manager.ts
@@ -17,6 +17,7 @@ export type WatchManagerOptions = {
   maxChangedPaths?: number;
   watchFactory?: typeof watch;
   onPendingChange?: (pending: boolean) => void;
+  onActivity?: () => void;
   resumeCheckIntervalMs?: number;
   resumeThresholdMs?: number;
   platform?: NodeJS.Platform;
@@ -156,6 +157,7 @@ export class WatchManager {
     if (info?.isDirectory() && eventType === "rename") {
       void this.watchDirectoryTree(path, factory);
     }
+    this.options.onActivity?.();
     this.changes.add(
       path,
       info ? (eventType === "rename" ? "created" : "changed") : "deleted",
@@ -321,7 +323,9 @@ export class WatchManager {
           this.options.root,
           { recursive: true },
           (eventType, filename) => {
-            if (!filename || this.closed) {
+            if (this.closed) return;
+            if (!filename) {
+              this.options.onActivity?.();
               this.queueFullReconcile();
               return;
             }
@@ -358,7 +362,9 @@ export class WatchManager {
       try {
         this.addWatcher(
           factory(directory, { recursive: false }, (eventType, filename) => {
-            if (!filename || this.closed) {
+            if (this.closed) return;
+            if (!filename) {
+              this.options.onActivity?.();
               this.queueFullReconcile();
               return;
             }

--- a/test/daemon-backend.test.mjs
+++ b/test/daemon-backend.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
 import { writeFileSync } from "node:fs";
 import { mkdir, mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -6,6 +7,7 @@ import { join } from "node:path";
 import test from "node:test";
 import { DaemonBackend } from "../dist/daemon/backend.js";
 import { inspectRoot } from "../dist/daemon/runtime-manager.js";
+import { WatchManager } from "../dist/daemon/watch-manager.js";
 import { BaseEmbeddingModel } from "../dist/engine/models/embeddings.js";
 import { createZvecGrep } from "../dist/index.js";
 
@@ -1814,6 +1816,54 @@ test("watch changes use the path-level index pipeline and advance revisions", as
     assert.equal(status.runtime.watcherActive, true);
     assert.equal(status.runtime.dirtyRevision, 2);
     assert.equal(status.runtime.indexedRevision, 2);
+    await waitFor(() => watcherCloses === 1);
+    assert.equal((await backend.serverStatus()).activeRuntimes, 0);
+  } finally {
+    await backend.close();
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  }
+});
+
+test("scheduled watcher reconciliation does not prevent idle eviction", async () => {
+  const temporaryDirectory = await mkdtemp(
+    join(tmpdir(), "zvec-grep-watch-idle-reconcile-"),
+  );
+  const root = join(temporaryDirectory, "repo");
+  await mkdir(root);
+  await writeFile(join(root, "answer.ts"), "export const answer = 42;\n");
+  const service = await createZvecGrep({
+    root,
+    embeddingModel: new TestEmbeddingModel(),
+  });
+  await service.index();
+  await service.close();
+  let watcherCloses = 0;
+  const backend = new DaemonBackend({
+    version: "1.0.0",
+    modelPoolOptions: { createModel: () => new TestEmbeddingModel() },
+    runtimeIdleTtlMs: 100,
+    watchManagerFactory: (options) =>
+      new WatchManager({
+        ...options,
+        debounceMs: 1,
+        maxWaitMs: 5,
+        reconcileIntervalMs: 20,
+        resumeCheckIntervalMs: 0,
+        watchFactory: () => {
+          const watcher = new EventEmitter();
+          watcher.close = () => {
+            watcherCloses += 1;
+          };
+          return watcher;
+        },
+      }),
+  });
+  try {
+    await backend.search({
+      ...searchInput(root, "answer", "eventual"),
+      autoUpdate: false,
+    });
+    assert.equal((await backend.serverStatus()).activeRuntimes, 1);
     await waitFor(() => watcherCloses === 1);
     assert.equal((await backend.serverStatus()).activeRuntimes, 0);
   } finally {

--- a/test/daemon-cache.test.mjs
+++ b/test/daemon-cache.test.mjs
@@ -193,6 +193,31 @@ test("root runtime releases model leases when the read session closes", async ()
   await pool.close();
 });
 
+test("watcher pending state does not count as runtime activity", async () => {
+  const pool = new EmbeddingModelPool({
+    createModel: () => ({ dispose: async () => {} }),
+  });
+  let activities = 0;
+  const runtime = new RootRuntime({
+    canonicalRoot: "/tmp/repo",
+    modelPool: pool,
+    onActivity: () => {
+      activities += 1;
+    },
+  });
+
+  runtime.setWatcherPending(true);
+  assert.equal(runtime.snapshot().watcherPending, true);
+  runtime.setWatcherPending(false);
+  assert.equal(runtime.snapshot().watcherPending, false);
+  assert.equal(activities, 0);
+
+  runtime.recordWatcherActivity();
+  assert.equal(activities, 1);
+  await runtime.close();
+  await pool.close();
+});
+
 test("root runtime replaces a cached session when the embedding model changes", async () => {
   let modelLoads = 0;
   let sessionCloses = 0;

--- a/test/server-cli.test.mjs
+++ b/test/server-cli.test.mjs
@@ -14,7 +14,11 @@ import {
   resolveServerSearchPolicy,
 } from "../dist/client/search-policy.js";
 import { DaemonClient } from "../dist/client/daemon-client.js";
-import { parseListenAddress } from "../dist/daemon/config.js";
+import {
+  DEFAULT_WATCHER_IDLE_TIMEOUT_MS,
+  configuredWatcherIdleTimeoutMs,
+  parseListenAddress,
+} from "../dist/daemon/config.js";
 import { DaemonHttpServer } from "../dist/daemon/http-server.js";
 import { readInstanceRecord } from "../dist/daemon/server-controller.js";
 
@@ -33,6 +37,32 @@ test("server run parses a loopback listen address", () => {
     host: "127.0.0.1",
     port: 8123,
   });
+});
+
+test("watcher idle timeout uses a four-hour default and accepts seconds from the environment", () => {
+  assert.equal(configuredWatcherIdleTimeoutMs({}), 4 * 60 * 60_000);
+  assert.equal(
+    configuredWatcherIdleTimeoutMs({
+      ZVEC_GREP_WATCHER_IDLE_TIMEOUT_SECONDS: "90",
+    }),
+    90_000,
+  );
+  assert.equal(
+    configuredWatcherIdleTimeoutMs({
+      ZVEC_GREP_WATCHER_IDLE_TIMEOUT_SECONDS: "0",
+    }),
+    0,
+  );
+  assert.equal(DEFAULT_WATCHER_IDLE_TIMEOUT_MS, 4 * 60 * 60_000);
+  for (const value of ["-1", "1.5", "forever", "2147484"]) {
+    assert.throws(
+      () =>
+        configuredWatcherIdleTimeoutMs({
+          ZVEC_GREP_WATCHER_IDLE_TIMEOUT_SECONDS: value,
+        }),
+      /must be an integer between 0 and 2147483/,
+    );
+  }
 });
 
 test("server lifecycle and client mode arguments are parsed", () => {

--- a/test/watch-manager.test.mjs
+++ b/test/watch-manager.test.mjs
@@ -44,6 +44,48 @@ test("watch manager debounces file changes and reports overflow reconciliation",
   }
 });
 
+test("scheduled reconciliation does not count as watcher activity", async () => {
+  const temporaryDirectory = await mkdtemp(
+    join(tmpdir(), "zvec-grep-watch-activity-"),
+  );
+  const root = join(temporaryDirectory, "repo");
+  await mkdir(root);
+  await writeFile(join(root, "a.ts"), "export const a = 1;\n");
+  let listener;
+  let activities = 0;
+  const reasons = [];
+  const watcher = new EventEmitter();
+  watcher.close = () => {};
+  const manager = new WatchManager({
+    root,
+    platform: "darwin",
+    debounceMs: 1,
+    maxWaitMs: 5,
+    reconcileIntervalMs: 10,
+    resumeCheckIntervalMs: 0,
+    watchFactory: (_root, _options, callback) => {
+      listener = callback;
+      return watcher;
+    },
+    onActivity: () => {
+      activities += 1;
+    },
+    onChanges: (_changes, reason) => reasons.push(reason),
+  });
+  try {
+    manager.start();
+    await waitFor(() => reasons.includes("reconcile"));
+    assert.equal(activities, 0);
+
+    listener("change", "a.ts");
+    await waitFor(() => activities === 1);
+    assert.equal(activities, 1);
+  } finally {
+    await manager.close();
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  }
+});
+
 test("watch manager uses per-directory watchers on Linux", async () => {
   const temporaryDirectory = await mkdtemp(
     join(tmpdir(), "zvec-grep-watch-fallback-"),


### PR DESCRIPTION
## Summary

- extend the default server watcher/runtime idle timeout from 30 minutes to 4 hours
- ensure periodic reconciliation marks work as pending without refreshing the real-activity deadline
- refresh the deadline only for client requests and relevant file-system events
- support ZVEC_GREP_WATCHER_IDLE_TIMEOUT_SECONDS at daemon startup; 0 disables idle eviction
- document the behavior and environment variable

## Testing

- npm run lint
- npm run build
- Prettier check for all changed files
- node --test --test-concurrency=1 test/server-cli.test.mjs test/watch-manager.test.mjs test/daemon-cache.test.mjs test/daemon-backend.test.mjs (68 passed)


close #92 