### PR TITLE
fix: parse OpenCode install configs as JSONC

### DIFF
--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -342,7 +342,7 @@ async function installOpenCodeIntegration(
 async function uninstallOpenCodeIntegration(): Promise<InstallAgentResult> {
   const configPath = resolveOpenCodeConfigPath();
   const guidancePath = resolve(dirname(configPath), "AGENTS.md");
-  await uninstallJsonMcpServer(configPath, "mcp");
+  await uninstallJsonMcpServer(configPath, "mcp", "OpenCode");
   await removeMarkedFile({
     path: guidancePath,
     startMarker: ZVEC_GREP_AGENTS_START,
@@ -379,7 +379,7 @@ async function installCursorIntegration(
 
 async function uninstallCursorIntegration(): Promise<InstallAgentResult> {
   const configPath = resolveCursorConfigPath();
-  await uninstallJsonMcpServer(configPath, "mcpServers");
+  await uninstallJsonMcpServer(configPath, "mcpServers", "Cursor");
   return { files: [configPath] };
 }
 
@@ -987,7 +987,9 @@ async function installJsonMcpServer(options: {
   force: boolean;
   label: string;
 }): Promise<void> {
-  const config = await readJsonObject(options.path);
+  const existing = await readTextFileIfExists(options.path);
+  let source = existing.trim() ? existing : "{}\n";
+  const config = parseJsoncSettings(options.path, source, options.label);
   const existingContainer = config[options.containerKey];
   if (existingContainer !== undefined && !isJsonObject(existingContainer)) {
     throw new Error(
@@ -1007,34 +1009,40 @@ async function installJsonMcpServer(options: {
     );
   }
 
-  container.zvec_grep = options.server;
-  config[options.containerKey] = container;
-  await writeTextFileAtomic(
-    options.path,
-    `${JSON.stringify(config, null, 2)}\n`,
+  source = editJsonWithComments(
+    source,
+    [options.containerKey, "zvec_grep"],
+    options.server,
   );
+  await writeTextFileAtomic(options.path, ensureTrailingNewline(source));
 }
 
 async function uninstallJsonMcpServer(
   path: string,
   containerKey: "mcp" | "mcpServers",
+  label: string,
 ): Promise<void> {
   const existing = await readTextFileIfExists(path);
-  if (!existing) return;
+  if (!existing.trim()) return;
 
-  const config = parseJsonObject(path, existing);
+  let source = existing;
+  const config = parseJsoncSettings(path, source, label);
   const container = config[containerKey];
   if (!isJsonObject(container)) return;
   if (!isManagedJsonMcpServer(container.zvec_grep)) return;
 
-  const nextContainer = { ...container };
-  delete nextContainer.zvec_grep;
-  if (Object.keys(nextContainer).length === 0) {
-    delete config[containerKey];
-  } else {
-    config[containerKey] = nextContainer;
+  source = hasJsoncComments(source)
+    ? removeJsoncPropertyPreservingComments(source, [containerKey, "zvec_grep"])
+    : editJsonWithComments(
+        source,
+        Object.keys(container).length === 1
+          ? [containerKey]
+          : [containerKey, "zvec_grep"],
+        undefined,
+      );
+  if (source !== existing) {
+    await writeTextFileAtomic(path, ensureTrailingNewline(source));
   }
-  await writeTextFileAtomic(path, `${JSON.stringify(config, null, 2)}\n`);
 }
 
 type JsonObject = Record<string, unknown>;

--- a/test/install.test.mjs
+++ b/test/install.test.mjs
@@ -2036,6 +2036,57 @@ test("OpenCode installer preserves config and manages a remote MCP server", asyn
   assert.doesNotMatch(uninstalledGuidance, /ZVEC_GREP|## zvec-grep/);
 });
 
+test("OpenCode installer preserves JSONC comments", async (t) => {
+  const temporaryDirectory = await mkdtemp(
+    join(tmpdir(), "zvec-grep-install-opencode-jsonc-"),
+  );
+  const configPath = join(temporaryDirectory, "opencode.json");
+  t.after(async () => {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  });
+
+  await writeFile(
+    configPath,
+    [
+      "{",
+      "  // Keep the user's model comment.",
+      '  "model": "custom/model",',
+      "  /* Keep the other MCP server comment. */",
+      '  "mcp": {',
+      '    "other": { "type": "remote", "url": "https://example.com/mcp" }',
+      "  }",
+      "}",
+      "",
+    ].join("\n"),
+  );
+
+  await installTarget("opencode", { OPENCODE_CONFIG: configPath }, [
+    "--mcp-transport=http",
+  ]);
+  const installed = await readFile(configPath, "utf8");
+  assert.match(installed, /\/\/ Keep the user's model comment\./);
+  assert.match(installed, /\/\* Keep the other MCP server comment\. \*\//);
+  const config = parseJsonWithComments(installed);
+  assert.equal(config.model, "custom/model");
+  assert.equal(config.mcp.other.url, "https://example.com/mcp");
+  assert.deepEqual(config.mcp.zvec_grep, {
+    type: "remote",
+    url: "http://127.0.0.1:7999/mcp",
+    enabled: true,
+    timeout: 600000,
+    oauth: false,
+  });
+
+  await uninstallTarget("opencode", { OPENCODE_CONFIG: configPath });
+  const uninstalled = await readFile(configPath, "utf8");
+  assert.match(uninstalled, /\/\/ Keep the user's model comment\./);
+  assert.match(uninstalled, /\/\* Keep the other MCP server comment\. \*\//);
+  const uninstalledConfig = parseJsonWithComments(uninstalled);
+  assert.equal(uninstalledConfig.mcp.zvec_grep, undefined);
+  assert.equal(uninstalledConfig.mcp.other.url, "https://example.com/mcp");
+  assert.equal(uninstalledConfig.model, "custom/model");
+});
+
 test("JSON installers require force before replacing an unmanaged server", async (t) => {
   const temporaryDirectory = await mkdtemp(
     join(tmpdir(), "zvec-grep-install-json-conflict-"),


### PR DESCRIPTION
OpenCode configs often use JSONC comments. Install and uninstall now parse them with jsonc-parser and preserve comments. Fixes #97