### PR TITLE
fix: estimate llama embedding context VRAM from vocab size

### DIFF
--- a/src/engine/models/backends/llama-cpp.ts
+++ b/src/engine/models/backends/llama-cpp.ts
@@ -88,6 +88,38 @@ type LlamaCppDependencies = {
 const DEFAULT_MODEL_CACHE_DIR = join(defaultHome(), "models");
 const GGUF_MAGIC = Buffer.from("GGUF");
 const DEFAULT_PARALLELISM_CAP = 8;
+const BYTES_PER_MIB = 1024 * 1024;
+const DEFAULT_CONTEXT_VRAM_OVERHEAD_MB = 150;
+const GPU_CONTEXT_VRAM_BUDGET_RATIO = 0.25;
+const LOGITS_BYTES_PER_ELEMENT = 4;
+const GGUF_VALUE_TYPE = {
+  UINT8: 0,
+  INT8: 1,
+  UINT16: 2,
+  INT16: 3,
+  UINT32: 4,
+  INT32: 5,
+  FLOAT32: 6,
+  BOOL: 7,
+  STRING: 8,
+  ARRAY: 9,
+  UINT64: 10,
+  INT64: 11,
+  FLOAT64: 12,
+} as const;
+const GGUF_VALUE_TYPE_SIZE: Readonly<Record<number, number>> = {
+  [GGUF_VALUE_TYPE.UINT8]: 1,
+  [GGUF_VALUE_TYPE.INT8]: 1,
+  [GGUF_VALUE_TYPE.UINT16]: 2,
+  [GGUF_VALUE_TYPE.INT16]: 2,
+  [GGUF_VALUE_TYPE.UINT32]: 4,
+  [GGUF_VALUE_TYPE.INT32]: 4,
+  [GGUF_VALUE_TYPE.FLOAT32]: 4,
+  [GGUF_VALUE_TYPE.BOOL]: 1,
+  [GGUF_VALUE_TYPE.UINT64]: 8,
+  [GGUF_VALUE_TYPE.INT64]: 8,
+  [GGUF_VALUE_TYPE.FLOAT64]: 8,
+};
 const DEFAULT_DARWIN_CMAKE_OPTIONS = {
   GGML_OPENMP: "OFF",
 } as const;
@@ -157,6 +189,7 @@ export class LlamaCppEmbeddingModel extends BaseEmbeddingModel {
   private contextsCreatePromise: Promise<LlamaEmbeddingContext[]> | null = null;
   private usingCpuFallback = false;
   private disposed = false;
+  private vocabSize?: number;
 
   constructor(
     private readonly entry: LlamaCppEmbeddingCatalogEntry,
@@ -409,6 +442,7 @@ export class LlamaCppEmbeddingModel extends BaseEmbeddingModel {
     downloadProgress: ModelDownloadProgressReporter,
   ): Promise<LlamaModel> {
     const modelPath = await this.resolveModelPath(downloadProgress);
+    this.vocabSize = readGgufVocabSize(modelPath);
     const llama = await this.ensureLlama(downloadProgress);
     const model = await llama.loadModel(this.modelLoadOptions(modelPath));
     this.model = model;
@@ -429,6 +463,7 @@ export class LlamaCppEmbeddingModel extends BaseEmbeddingModel {
     textCount: number,
     onProgress?: (progress: EmbeddingModelProgress) => void,
   ): Promise<LlamaEmbeddingContext[]> {
+    await this.ensureModel(onProgress);
     const targetParallelism = await this.resolveEffectiveParallelism(textCount);
     if (this.contexts.length >= targetParallelism) {
       return this.contexts.slice(0, targetParallelism);
@@ -567,11 +602,11 @@ export class LlamaCppEmbeddingModel extends BaseEmbeddingModel {
     ) {
       try {
         const vram = await llama.getVramState();
-        const freeMb = vram.free / (1024 * 1024);
-        return Math.max(
-          1,
-          Math.min(DEFAULT_PARALLELISM_CAP, Math.floor((freeMb * 0.25) / 150)),
-        );
+        return resolveLlamaGpuContextParallelism({
+          freeVramBytes: vram.free,
+          contextSize: this.entry.contextSize,
+          vocabSize: this.vocabSize,
+        });
       } catch {
         return 2;
       }
@@ -725,6 +760,246 @@ function resolveParallelismOverride(
   }
 
   return Math.min(DEFAULT_PARALLELISM_CAP, parsed);
+}
+
+export function estimateLlamaEmbeddingContextVramMb(options: {
+  contextSize: number;
+  vocabSize?: number;
+}): number {
+  const contextSize = Math.max(0, options.contextSize);
+  const vocabSize = normalizePositiveInt(options.vocabSize) ?? 0;
+  const logitsMb =
+    contextSize > 0 && vocabSize > 0
+      ? (contextSize * vocabSize * LOGITS_BYTES_PER_ELEMENT) / BYTES_PER_MIB
+      : 0;
+  return DEFAULT_CONTEXT_VRAM_OVERHEAD_MB + logitsMb;
+}
+
+export function resolveLlamaGpuContextParallelism(options: {
+  freeVramBytes: number;
+  contextSize: number;
+  vocabSize?: number;
+  cap?: number;
+}): number {
+  const freeMb = Math.max(0, options.freeVramBytes) / BYTES_PER_MIB;
+  const perContextMb = estimateLlamaEmbeddingContextVramMb(options);
+  const cap = options.cap ?? DEFAULT_PARALLELISM_CAP;
+
+  return Math.max(
+    1,
+    Math.min(
+      cap,
+      Math.floor((freeMb * GPU_CONTEXT_VRAM_BUDGET_RATIO) / perContextMb),
+    ),
+  );
+}
+
+export function readGgufVocabSize(filePath: string): number | undefined {
+  if (!existsSync(filePath)) {
+    return undefined;
+  }
+
+  const fd = openSync(filePath, "r");
+  try {
+    return parseGgufVocabSize(fd);
+  } catch {
+    return undefined;
+  } finally {
+    closeSync(fd);
+  }
+}
+
+function parseGgufVocabSize(fd: number): number | undefined {
+  const cursor = { fd, pos: 0 };
+  const magic = readCursorBytes(cursor, 4);
+  if (!magic.equals(GGUF_MAGIC)) {
+    return undefined;
+  }
+
+  const version = readCursorU32(cursor);
+  if (version < 2 || version > 3) {
+    return undefined;
+  }
+
+  readCursorU64(cursor);
+  const keyCount = readCursorU64(cursor);
+  if (keyCount > 10_000) {
+    return undefined;
+  }
+
+  for (let index = 0; index < keyCount; index++) {
+    const key = readCursorString(cursor, 4096);
+    const type = readCursorU32(cursor);
+    if (key.endsWith(".vocab_size")) {
+      const vocabSize = normalizePositiveInt(readGgufNumeric(cursor, type));
+      if (vocabSize !== undefined) {
+        return vocabSize;
+      }
+      continue;
+    }
+
+    if (key === "tokenizer.ggml.tokens" && type === GGUF_VALUE_TYPE.ARRAY) {
+      const elementType = readCursorU32(cursor);
+      const count = normalizePositiveInt(readCursorU64(cursor));
+      if (count !== undefined) {
+        return count;
+      }
+      skipGgufArrayElements(cursor, elementType, 0);
+      continue;
+    }
+
+    skipGgufValue(cursor, type);
+  }
+
+  return undefined;
+}
+
+type GgufCursor = {
+  fd: number;
+  pos: number;
+};
+
+function readCursorBytes(cursor: GgufCursor, size: number): Buffer {
+  if (size < 0 || size > 16 * 1024 * 1024) {
+    throw new Error("invalid GGUF read size");
+  }
+
+  const buffer = Buffer.alloc(size);
+  let offset = 0;
+  while (offset < size) {
+    const bytesRead = readSync(
+      cursor.fd,
+      buffer,
+      offset,
+      size - offset,
+      cursor.pos,
+    );
+    if (bytesRead === 0) {
+      throw new Error("unexpected GGUF EOF");
+    }
+    cursor.pos += bytesRead;
+    offset += bytesRead;
+  }
+  return buffer;
+}
+
+function readCursorU32(cursor: GgufCursor): number {
+  return readCursorBytes(cursor, 4).readUInt32LE(0);
+}
+
+function readCursorU64(cursor: GgufCursor): number {
+  const value = readCursorBytes(cursor, 8).readBigUInt64LE(0);
+  if (value > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new Error("GGUF integer exceeds Number.MAX_SAFE_INTEGER");
+  }
+  return Number(value);
+}
+
+function readCursorI32(cursor: GgufCursor): number {
+  return readCursorBytes(cursor, 4).readInt32LE(0);
+}
+
+function readCursorI64(cursor: GgufCursor): number {
+  const value = readCursorBytes(cursor, 8).readBigInt64LE(0);
+  if (
+    value > BigInt(Number.MAX_SAFE_INTEGER) ||
+    value < BigInt(Number.MIN_SAFE_INTEGER)
+  ) {
+    throw new Error("GGUF integer exceeds Number safe range");
+  }
+  return Number(value);
+}
+
+function readCursorString(cursor: GgufCursor, maxBytes: number): string {
+  const length = readCursorU64(cursor);
+  if (length > maxBytes) {
+    throw new Error("GGUF string exceeds limit");
+  }
+  return readCursorBytes(cursor, length).toString("utf8");
+}
+
+function readGgufNumeric(cursor: GgufCursor, type: number): number | undefined {
+  switch (type) {
+    case GGUF_VALUE_TYPE.UINT8:
+      return readCursorBytes(cursor, 1).readUInt8(0);
+    case GGUF_VALUE_TYPE.INT8:
+      return readCursorBytes(cursor, 1).readInt8(0);
+    case GGUF_VALUE_TYPE.UINT16:
+      return readCursorBytes(cursor, 2).readUInt16LE(0);
+    case GGUF_VALUE_TYPE.INT16:
+      return readCursorBytes(cursor, 2).readInt16LE(0);
+    case GGUF_VALUE_TYPE.UINT32:
+      return readCursorU32(cursor);
+    case GGUF_VALUE_TYPE.INT32:
+      return readCursorI32(cursor);
+    case GGUF_VALUE_TYPE.UINT64:
+      return readCursorU64(cursor);
+    case GGUF_VALUE_TYPE.INT64:
+      return readCursorI64(cursor);
+    default:
+      skipGgufValue(cursor, type);
+      return undefined;
+  }
+}
+
+function skipGgufValue(cursor: GgufCursor, type: number): void {
+  if (type === GGUF_VALUE_TYPE.STRING) {
+    const length = readCursorU64(cursor);
+    cursor.pos += length;
+    return;
+  }
+
+  if (type === GGUF_VALUE_TYPE.ARRAY) {
+    const elementType = readCursorU32(cursor);
+    const count = readCursorU64(cursor);
+    skipGgufArrayElements(cursor, elementType, count);
+    return;
+  }
+
+  const size = GGUF_VALUE_TYPE_SIZE[type];
+  if (size === undefined) {
+    throw new Error("unsupported GGUF value type");
+  }
+  cursor.pos += size;
+}
+
+function skipGgufArrayElements(
+  cursor: GgufCursor,
+  elementType: number,
+  count: number,
+): void {
+  if (count < 0 || count > 2_000_000) {
+    throw new Error("GGUF array is too large");
+  }
+
+  if (elementType === GGUF_VALUE_TYPE.STRING) {
+    for (let index = 0; index < count; index++) {
+      const length = readCursorU64(cursor);
+      cursor.pos += length;
+    }
+    return;
+  }
+
+  if (elementType === GGUF_VALUE_TYPE.ARRAY) {
+    for (let index = 0; index < count; index++) {
+      skipGgufValue(cursor, GGUF_VALUE_TYPE.ARRAY);
+    }
+    return;
+  }
+
+  const size = GGUF_VALUE_TYPE_SIZE[elementType];
+  if (size === undefined) {
+    throw new Error("unsupported GGUF array type");
+  }
+  cursor.pos += size * count;
+}
+
+function normalizePositiveInt(value: number | undefined): number | undefined {
+  if (value === undefined || !Number.isFinite(value) || value <= 0) {
+    return undefined;
+  }
+
+  return Math.floor(value);
 }
 
 function validateGgufFile(filePath: string, modelUri: string): void {

--- a/test/unit/models/llama-cpp.test.mjs
+++ b/test/unit/models/llama-cpp.test.mjs
@@ -2,7 +2,12 @@ import assert from "node:assert/strict";
 import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import test from "node:test";
-import { LlamaCppEmbeddingModel } from "../../../dist/engine/models/backends/llama-cpp.js";
+import {
+  LlamaCppEmbeddingModel,
+  estimateLlamaEmbeddingContextVramMb,
+  readGgufVocabSize,
+  resolveLlamaGpuContextParallelism,
+} from "../../../dist/engine/models/backends/llama-cpp.js";
 import { createTemporaryDirectory } from "../../helpers/fixtures.mjs";
 
 function entry(overrides = {}) {
@@ -75,7 +80,7 @@ function createDependencies(modelPath, options = {}) {
       ? async () => {
           throw new Error("vram unavailable");
         }
-      : async () => ({ total: 8e9, used: 2e9, free: 6e9 }),
+      : async () => options.vram ?? { total: 8e9, used: 2e9, free: 6e9 },
     loadModel: async (loadOptions) => {
       calls.model.push(loadOptions);
       loadModelAttempts++;
@@ -135,6 +140,134 @@ async function captureStderr(callback) {
   } finally {
     process.stderr.write = original;
   }
+}
+
+const GGUF_TYPE = {
+  UINT8: 0,
+  INT8: 1,
+  UINT16: 2,
+  INT16: 3,
+  UINT32: 4,
+  INT32: 5,
+  FLOAT32: 6,
+  BOOL: 7,
+  STRING: 8,
+  ARRAY: 9,
+  UINT64: 10,
+  INT64: 11,
+  FLOAT64: 12,
+};
+
+function u32(value) {
+  const buffer = Buffer.alloc(4);
+  buffer.writeUInt32LE(value);
+  return buffer;
+}
+
+function i32(value) {
+  const buffer = Buffer.alloc(4);
+  buffer.writeInt32LE(value);
+  return buffer;
+}
+
+function u64(value) {
+  const buffer = Buffer.alloc(8);
+  buffer.writeBigUInt64LE(BigInt(value));
+  return buffer;
+}
+
+function i64(value) {
+  const buffer = Buffer.alloc(8);
+  buffer.writeBigInt64LE(BigInt(value));
+  return buffer;
+}
+
+function ggufString(value) {
+  const bytes = Buffer.from(value, "utf8");
+  return Buffer.concat([u64(bytes.length), bytes]);
+}
+
+function encodeGgufValue(type, value) {
+  switch (type) {
+    case GGUF_TYPE.UINT8:
+      return Buffer.from([value]);
+    case GGUF_TYPE.INT8:
+      return Buffer.from([value]);
+    case GGUF_TYPE.UINT16: {
+      const buffer = Buffer.alloc(2);
+      buffer.writeUInt16LE(value);
+      return buffer;
+    }
+    case GGUF_TYPE.INT16: {
+      const buffer = Buffer.alloc(2);
+      buffer.writeInt16LE(value);
+      return buffer;
+    }
+    case GGUF_TYPE.UINT32:
+      return u32(value);
+    case GGUF_TYPE.INT32:
+      return i32(value);
+    case GGUF_TYPE.FLOAT32: {
+      const buffer = Buffer.alloc(4);
+      buffer.writeFloatLE(value);
+      return buffer;
+    }
+    case GGUF_TYPE.BOOL:
+      return Buffer.from([value ? 1 : 0]);
+    case GGUF_TYPE.STRING:
+      return ggufString(value);
+    case GGUF_TYPE.UINT64:
+      return u64(value);
+    case GGUF_TYPE.INT64:
+      return i64(value);
+    case GGUF_TYPE.FLOAT64: {
+      const buffer = Buffer.alloc(8);
+      buffer.writeDoubleLE(value);
+      return buffer;
+    }
+    case GGUF_TYPE.ARRAY: {
+      const parts = [u32(value.elementType), u64(value.items.length)];
+      for (const item of value.items) {
+        parts.push(encodeGgufValue(value.elementType, item));
+      }
+      return Buffer.concat(parts);
+    }
+    default:
+      throw new Error(`unsupported test GGUF type ${type}`);
+  }
+}
+
+function encodeGguf(entries, options = {}) {
+  const parts = [
+    Buffer.from("GGUF"),
+    u32(options.version ?? 3),
+    u64(options.tensorCount ?? 0),
+    u64(options.keyCount ?? entries.length),
+  ];
+  for (const [key, type, value] of entries) {
+    parts.push(ggufString(key), u32(type));
+    parts.push(Buffer.isBuffer(value) ? value : encodeGgufValue(type, value));
+  }
+  if (options.trailer) {
+    parts.push(options.trailer);
+  }
+  return Buffer.concat(parts);
+}
+
+function withParallelismEnv(t, value) {
+  const previous = process.env.ZVEC_GREP_LLAMA_CONTEXT_PARALLELISM;
+  if (value === undefined) {
+    delete process.env.ZVEC_GREP_LLAMA_CONTEXT_PARALLELISM;
+  } else {
+    process.env.ZVEC_GREP_LLAMA_CONTEXT_PARALLELISM = value;
+  }
+  t.after(() => {
+    if (previous === undefined) {
+      delete process.env.ZVEC_GREP_LLAMA_CONTEXT_PARALLELISM;
+    } else {
+      process.env.ZVEC_GREP_LLAMA_CONTEXT_PARALLELISM = previous;
+    }
+  });
 }
 
 test("local embedding loads GGUF, formats and truncates text, parallelizes, caches, and disposes", async (t) => {
@@ -216,6 +349,7 @@ test("local embedding loads GGUF, formats and truncates text, parallelizes, cach
 });
 
 test("local embedding supports qwen query format, automatic GPU parallelism, and context partial capacity", async (t) => {
+  withParallelismEnv(t, undefined);
   const modelFile = await ggufFile(t);
   const setup = createDependencies(modelFile.path, {
     failContextAfter: 2,
@@ -348,4 +482,282 @@ test("local embedding reports context and embedding runtime failures", async (t)
     model.embed([{ kind: "text", text: "value" }]),
     /embedding failed/,
   );
+});
+
+const QWEN3_VOCAB_SIZE = 151_936;
+const QWEN3_CONTEXT_SIZE = 8_192;
+const RTX_4090_FREE_VRAM_BYTES = 21 * 1024 * 1024 * 1024;
+
+test("llama embedding VRAM estimate includes large-vocab logits buffers", () => {
+  assert.equal(estimateLlamaEmbeddingContextVramMb({ contextSize: 2048 }), 150);
+  assert.equal(
+    estimateLlamaEmbeddingContextVramMb({
+      contextSize: 8192,
+      vocabSize: 0,
+    }),
+    150,
+  );
+
+  const qwenEstimate = estimateLlamaEmbeddingContextVramMb({
+    contextSize: QWEN3_CONTEXT_SIZE,
+    vocabSize: QWEN3_VOCAB_SIZE,
+  });
+  const logitsMb = (QWEN3_CONTEXT_SIZE * QWEN3_VOCAB_SIZE * 4) / (1024 * 1024);
+  assert.equal(qwenEstimate, 150 + logitsMb);
+  assert.ok(qwenEstimate > 4700);
+
+  assert.equal(
+    resolveLlamaGpuContextParallelism({
+      freeVramBytes: RTX_4090_FREE_VRAM_BYTES,
+      contextSize: 2048,
+    }),
+    8,
+  );
+  assert.equal(
+    resolveLlamaGpuContextParallelism({
+      freeVramBytes: RTX_4090_FREE_VRAM_BYTES,
+      contextSize: QWEN3_CONTEXT_SIZE,
+      vocabSize: QWEN3_VOCAB_SIZE,
+    }),
+    1,
+  );
+  assert.equal(
+    resolveLlamaGpuContextParallelism({
+      freeVramBytes: RTX_4090_FREE_VRAM_BYTES,
+      contextSize: QWEN3_CONTEXT_SIZE,
+      vocabSize: QWEN3_VOCAB_SIZE,
+      cap: 4,
+    }),
+    1,
+  );
+});
+
+test("readGgufVocabSize parses vocab_size and tokenizer token counts", async (t) => {
+  const missing = await ggufFile(t, "missing.gguf");
+  assert.equal(readGgufVocabSize(`${missing.path}-absent`), undefined);
+  assert.equal(readGgufVocabSize(missing.path), undefined);
+
+  const withMetadata = await ggufFile(
+    t,
+    "qwen3.gguf",
+    encodeGguf([
+      ["general.architecture", GGUF_TYPE.STRING, "qwen3"],
+      ["general.name", GGUF_TYPE.STRING, "fixture"],
+      ["qwen3.block_count", GGUF_TYPE.UINT32, 28],
+      ["qwen3.attention.causal", GGUF_TYPE.BOOL, 1],
+      ["qwen3.rope.freq_base", GGUF_TYPE.FLOAT32, 1_000_000],
+      ["qwen3.logit_scale", GGUF_TYPE.FLOAT64, 1],
+      [
+        "tokenizer.ggml.scores",
+        GGUF_TYPE.ARRAY,
+        { elementType: GGUF_TYPE.FLOAT32, items: [0.1, 0.2] },
+      ],
+      [
+        "tokenizer.ggml.merges",
+        GGUF_TYPE.ARRAY,
+        { elementType: GGUF_TYPE.STRING, items: ["a b", "c d"] },
+      ],
+      [
+        "nested.values",
+        GGUF_TYPE.ARRAY,
+        {
+          elementType: GGUF_TYPE.ARRAY,
+          items: [{ elementType: GGUF_TYPE.UINT32, items: [1, 2] }],
+        },
+      ],
+      ["qwen3.vocab_size", GGUF_TYPE.UINT32, QWEN3_VOCAB_SIZE],
+    ]),
+  );
+  assert.equal(readGgufVocabSize(withMetadata.path), QWEN3_VOCAB_SIZE);
+
+  const uint64Vocab = await ggufFile(
+    t,
+    "uint64-vocab.gguf",
+    encodeGguf([["llama.vocab_size", GGUF_TYPE.UINT64, 32_000]]),
+  );
+  assert.equal(readGgufVocabSize(uint64Vocab.path), 32_000);
+
+  const int32Vocab = await ggufFile(
+    t,
+    "int32-vocab.gguf",
+    encodeGguf([["gemma.vocab_size", GGUF_TYPE.INT32, 256_000]]),
+  );
+  assert.equal(readGgufVocabSize(int32Vocab.path), 256_000);
+
+  const int64Vocab = await ggufFile(
+    t,
+    "int64-vocab.gguf",
+    encodeGguf([["bert.vocab_size", GGUF_TYPE.INT64, 30_522]]),
+  );
+  assert.equal(readGgufVocabSize(int64Vocab.path), 30_522);
+
+  const uint8Vocab = await ggufFile(
+    t,
+    "uint8-vocab.gguf",
+    encodeGguf([["tiny.vocab_size", GGUF_TYPE.UINT8, 16]]),
+  );
+  assert.equal(readGgufVocabSize(uint8Vocab.path), 16);
+
+  const int8Vocab = await ggufFile(
+    t,
+    "int8-vocab.gguf",
+    encodeGguf([["tiny.vocab_size", GGUF_TYPE.INT8, 12]]),
+  );
+  assert.equal(readGgufVocabSize(int8Vocab.path), 12);
+
+  const uint16Vocab = await ggufFile(
+    t,
+    "uint16-vocab.gguf",
+    encodeGguf([["tiny.vocab_size", GGUF_TYPE.UINT16, 512]]),
+  );
+  assert.equal(readGgufVocabSize(uint16Vocab.path), 512);
+
+  const int16Vocab = await ggufFile(
+    t,
+    "int16-vocab.gguf",
+    encodeGguf([["tiny.vocab_size", GGUF_TYPE.INT16, 256]]),
+  );
+  assert.equal(readGgufVocabSize(int16Vocab.path), 256);
+
+  const tokenFallback = await ggufFile(
+    t,
+    "tokens.gguf",
+    encodeGguf([
+      [
+        "tokenizer.ggml.tokens",
+        GGUF_TYPE.ARRAY,
+        { elementType: GGUF_TYPE.STRING, items: ["<pad>", "hello", "world"] },
+      ],
+    ]),
+  );
+  assert.equal(readGgufVocabSize(tokenFallback.path), 3);
+
+  const skippedNonNumeric = await ggufFile(
+    t,
+    "skip-float.gguf",
+    encodeGguf([
+      ["qwen3.vocab_size", GGUF_TYPE.FLOAT32, 12.5],
+      ["qwen3.vocab_size", GGUF_TYPE.UINT32, 151_936],
+    ]),
+  );
+  assert.equal(readGgufVocabSize(skippedNonNumeric.path), 151_936);
+
+  const truncated = await ggufFile(t, "truncated.gguf", Buffer.from("GGUF"));
+  assert.equal(readGgufVocabSize(truncated.path), undefined);
+
+  const unsupportedVersion = await ggufFile(
+    t,
+    "v1.gguf",
+    encodeGguf([["qwen3.vocab_size", GGUF_TYPE.UINT32, 100]], { version: 1 }),
+  );
+  assert.equal(readGgufVocabSize(unsupportedVersion.path), undefined);
+
+  const tooManyKeys = await ggufFile(
+    t,
+    "too-many-keys.gguf",
+    encodeGguf([], { keyCount: 10_001 }),
+  );
+  assert.equal(readGgufVocabSize(tooManyKeys.path), undefined);
+
+  const unknownType = await ggufFile(
+    t,
+    "unknown-type.gguf",
+    encodeGguf([["qwen3.hidden", 99, u32(1)]]),
+  );
+  assert.equal(readGgufVocabSize(unknownType.path), undefined);
+
+  const emptyTokens = await ggufFile(
+    t,
+    "empty-tokens.gguf",
+    encodeGguf([
+      [
+        "tokenizer.ggml.tokens",
+        GGUF_TYPE.ARRAY,
+        { elementType: GGUF_TYPE.STRING, items: [] },
+      ],
+      ["qwen3.vocab_size", GGUF_TYPE.UINT32, 128],
+    ]),
+  );
+  assert.equal(readGgufVocabSize(emptyTokens.path), 128);
+});
+
+test("local embedding caps GPU parallelism for large-vocab GGUF models", async (t) => {
+  withParallelismEnv(t, undefined);
+  const modelFile = await ggufFile(
+    t,
+    "qwen3-embedding.gguf",
+    encodeGguf([
+      ["general.architecture", GGUF_TYPE.STRING, "qwen3"],
+      ["qwen3.vocab_size", GGUF_TYPE.UINT32, QWEN3_VOCAB_SIZE],
+    ]),
+  );
+  const setup = createDependencies(modelFile.path, {
+    vram: {
+      total: 24 * 1024 * 1024 * 1024,
+      used: 3 * 1024 * 1024 * 1024,
+      free: RTX_4090_FREE_VRAM_BYTES,
+    },
+  });
+  const model = new LlamaCppEmbeddingModel(
+    entry({ format: "qwen3", contextSize: QWEN3_CONTEXT_SIZE }),
+    { modelCacheDir: modelFile.root, device: "cuda" },
+    setup.dependencies,
+  );
+  const { vectors } = await model.embed(
+    Array.from({ length: 8 }, (_, index) => ({
+      kind: "text",
+      text: `chunk-${index}`,
+    })),
+  );
+  assert.equal(vectors.length, 8);
+  assert.equal(setup.calls.contexts.length, 1);
+  await model.dispose();
+});
+
+test("local embedding keeps ZVEC_GREP_LLAMA_CONTEXT_PARALLELISM override for large-vocab models", async (t) => {
+  withParallelismEnv(t, "3");
+  const modelFile = await ggufFile(
+    t,
+    "qwen3-override.gguf",
+    encodeGguf([["qwen3.vocab_size", GGUF_TYPE.UINT32, QWEN3_VOCAB_SIZE]]),
+  );
+  const setup = createDependencies(modelFile.path, {
+    vram: {
+      total: 24 * 1024 * 1024 * 1024,
+      used: 3 * 1024 * 1024 * 1024,
+      free: RTX_4090_FREE_VRAM_BYTES,
+    },
+  });
+  const model = new LlamaCppEmbeddingModel(
+    entry({ format: "qwen3", contextSize: QWEN3_CONTEXT_SIZE }),
+    { modelCacheDir: modelFile.root, device: "cuda" },
+    setup.dependencies,
+  );
+  await model.embed(
+    Array.from({ length: 6 }, (_, index) => ({
+      kind: "text",
+      text: `chunk-${index}`,
+    })),
+  );
+  assert.equal(setup.calls.contexts.length, 3);
+  await model.dispose();
+});
+
+test("local embedding falls back to conservative GPU parallelism when VRAM query fails", async (t) => {
+  withParallelismEnv(t, undefined);
+  const modelFile = await ggufFile(t);
+  const setup = createDependencies(modelFile.path, { vramError: true });
+  const model = new LlamaCppEmbeddingModel(
+    entry(),
+    { modelCacheDir: modelFile.root, device: "cuda" },
+    setup.dependencies,
+  );
+  await model.embed(
+    Array.from({ length: 4 }, (_, index) => ({
+      kind: "text",
+      text: `chunk-${index}`,
+    })),
+  );
+  assert.equal(setup.calls.contexts.length, 2);
+  await model.dispose();
 });


### PR DESCRIPTION
resolveParallelism underestimated per-context VRAM for large-vocab embedding models. Factor GGUF vocab into the estimate so indexing no longer oversubscribes GPU memory. Env override ZVEC_GREP_LLAMA_CONTEXT_PARALLELISM is kept. Fixes #94