### PR TITLE
fix(watcher): recover activation after registration failures

### DIFF
--- a/src/daemon/backend.ts
+++ b/src/daemon/backend.ts
@@ -1005,13 +1005,13 @@ export class DaemonBackend implements ZvecGrepDaemonBackend {
       },
       onPendingChange: (pending) => runtime.setWatcherPending(pending),
       onActivity: () => runtime.recordWatcherActivity(),
+      onActiveChange: (active) => runtime.setWatcherActive(active),
       getRootPaths: () =>
         this.statusCache.get(runtime.canonicalRoot)?.workspaceIndex?.rootPaths,
     });
     watcher.start();
     this.indexCoordinators.set(runtime.canonicalRoot, coordinator);
     this.watchers.set(runtime.canonicalRoot, watcher);
-    runtime.setWatcherActive(true);
   }
 
   private async settleKnownChanges(runtime: RootRuntime): Promise<void> {

--- a/src/daemon/watch-manager.ts
+++ b/src/daemon/watch-manager.ts
@@ -18,6 +18,7 @@ export type WatchManagerOptions = {
   watchFactory?: typeof watch;
   onPendingChange?: (pending: boolean) => void;
   onActivity?: () => void;
+  onActiveChange?: (active: boolean) => void;
   resumeCheckIntervalMs?: number;
   resumeThresholdMs?: number;
   platform?: NodeJS.Platform;
@@ -49,11 +50,16 @@ export class WatchManager {
   private reconcileTimer?: ReturnType<typeof setInterval>;
   private resumeTimer?: ReturnType<typeof setInterval>;
   private closed = false;
+  private active = false;
+  private useDirectoryWatchers: boolean;
   private reconcileRequested = false;
   private lastResumeCheckAt = Date.now();
 
   constructor(private readonly options: WatchManagerOptions) {
     this.changes = this.newChangeSet();
+    this.useDirectoryWatchers = requiresDirectoryWatchers(
+      options.platform ?? process.platform,
+    );
   }
 
   start(): void {
@@ -90,6 +96,7 @@ export class WatchManager {
     this.watchers.clear();
     this.watchedDirectories.clear();
     this.directoryWatchers.clear();
+    this.setActive(false);
     if (this.debounceTimer) clearTimeout(this.debounceTimer);
     if (this.maxWaitTimer) clearTimeout(this.maxWaitTimer);
     if (this.reconcileTimer) clearInterval(this.reconcileTimer);
@@ -111,7 +118,22 @@ export class WatchManager {
   }
 
   async refreshPaths(): Promise<void> {
-    if (this.closed || this.directoryWatchers.size === 0) {
+    if (this.closed) {
+      return;
+    }
+    if (this.directoryWatchers.size === 0) {
+      if (this.useDirectoryWatchers) {
+        await this.watchDirectoryTree(
+          this.options.root,
+          this.options.watchFactory ?? watch,
+        );
+        if (this.directoryWatchers.size > 0) {
+          // Changes can land after the index's final status scan but before
+          // the initial directory tree is fully watched. Reconcile once after
+          // closing that activation gap; later path refreshes stay incremental.
+          this.queueFullReconcile();
+        }
+      }
       return;
     }
     await this.refreshDirectoryTree(
@@ -148,7 +170,9 @@ export class WatchManager {
     if (!info && eventType === "rename") {
       this.removeDirectoryWatchers(path);
     }
-    if (!(await this.shouldTrackPath(path, info?.isDirectory() === true))) {
+    if (
+      !(await this.shouldTrackPath(path, info?.isDirectory() === true, "track"))
+    ) {
       return;
     }
     if (this.closed) {
@@ -253,6 +277,9 @@ export class WatchManager {
     const recoveryKey = directory ?? PRIMARY_WATCHER;
     this.watchers.add(watcher);
     if (directory) this.directoryWatchers.set(directory, watcher);
+    if (!directory || directory === this.options.root) {
+      this.setActive(true);
+    }
     watcher.on("error", () => {
       watcher.close();
       this.watchers.delete(watcher);
@@ -260,30 +287,10 @@ export class WatchManager {
         this.directoryWatchers.delete(directory);
         this.watchedDirectories.delete(directory);
       }
-      const recovery = this.recoveryState(recoveryKey);
-      if (recovery.stableTimer) clearTimeout(recovery.stableTimer);
-      recovery.stableTimer = undefined;
-      recovery.consecutiveErrors += 1;
-      if (!recovery.reconciliationPending) {
-        recovery.reconciliationPending = true;
-        this.queueFullReconcile();
+      if (!directory || directory === this.options.root) {
+        this.setActive(false);
       }
-      if (!this.closed) {
-        if (recovery.retryTimer) clearTimeout(recovery.retryTimer);
-        const retryDelayMs = Math.min(
-          100 * 2 ** (recovery.consecutiveErrors - 1),
-          5_000,
-        );
-        recovery.retryTimer = setTimeout(() => {
-          recovery.retryTimer = undefined;
-          if (directory) {
-            void this.watchDirectoryTree(directory, factory);
-          } else {
-            this.startPrimaryWatcher(factory);
-          }
-        }, retryDelayMs);
-        recovery.retryTimer.unref?.();
-      }
+      this.recoverWatcher(recoveryKey, directory, factory);
     });
     const recovery = this.recoveryState(recoveryKey);
     if (recovery.stableTimer) clearTimeout(recovery.stableTimer);
@@ -309,12 +316,65 @@ export class WatchManager {
     return created;
   }
 
-  private startPrimaryWatcher(factory: typeof watch): void {
+  private recoverWatcher(
+    recoveryKey: string | typeof PRIMARY_WATCHER,
+    directory: string | undefined,
+    factory: typeof watch,
+  ): void {
+    const recovery = this.recoveryState(recoveryKey);
+    if (recovery.stableTimer) clearTimeout(recovery.stableTimer);
+    recovery.stableTimer = undefined;
+    recovery.consecutiveErrors += 1;
+    if (!recovery.reconciliationPending) {
+      recovery.reconciliationPending = true;
+      this.queueFullReconcile();
+    }
     if (this.closed) {
       return;
     }
-    if (requiresDirectoryWatchers(this.options.platform ?? process.platform)) {
-      void this.watchDirectoryTree(this.options.root, factory);
+    if (recovery.retryTimer) clearTimeout(recovery.retryTimer);
+    const retryDelayMs = Math.min(
+      100 * 2 ** (recovery.consecutiveErrors - 1),
+      5_000,
+    );
+    recovery.retryTimer = setTimeout(() => {
+      recovery.retryTimer = undefined;
+      if (directory) {
+        void this.restoreDirectoryWatcher(directory, factory);
+      } else {
+        this.startPrimaryWatcher(factory, true);
+      }
+    }, retryDelayMs);
+    recovery.retryTimer.unref?.();
+  }
+
+  private async restoreDirectoryWatcher(
+    directory: string,
+    factory: typeof watch,
+  ): Promise<void> {
+    await this.watchDirectoryTree(directory, factory);
+    if (!this.closed && this.directoryWatchers.has(directory)) {
+      this.queueFullReconcile();
+    }
+  }
+
+  private setActive(active: boolean): void {
+    if (this.active === active) {
+      return;
+    }
+    this.active = active;
+    this.options.onActiveChange?.(active);
+  }
+
+  private startPrimaryWatcher(
+    factory: typeof watch,
+    reconcileAfterRegistration = false,
+  ): void {
+    if (this.closed) {
+      return;
+    }
+    if (this.useDirectoryWatchers) {
+      void this.startDirectoryWatchers(factory, reconcileAfterRegistration);
       return;
     }
     try {
@@ -338,8 +398,26 @@ export class WatchManager {
         ),
         factory,
       );
+      if (reconcileAfterRegistration) {
+        this.queueFullReconcile();
+      }
     } catch {
-      void this.watchDirectoryTree(this.options.root, factory);
+      this.useDirectoryWatchers = true;
+      void this.startDirectoryWatchers(factory, true);
+    }
+  }
+
+  private async startDirectoryWatchers(
+    factory: typeof watch,
+    reconcileAfterRegistration: boolean,
+  ): Promise<void> {
+    await this.watchDirectoryTree(this.options.root, factory);
+    if (
+      !this.closed &&
+      reconcileAfterRegistration &&
+      this.directoryWatchers.has(this.options.root)
+    ) {
+      this.queueFullReconcile();
     }
   }
 
@@ -354,7 +432,10 @@ export class WatchManager {
     ) {
       return;
     }
-    if (!(await this.shouldTrackPath(directory, true))) {
+    if (
+      !(await this.shouldTrackPath(directory, true, "defer")) ||
+      this.closed
+    ) {
       return;
     }
     if (!this.watchedDirectories.has(directory)) {
@@ -377,9 +458,13 @@ export class WatchManager {
           factory,
           directory,
         );
-      } catch {
+      } catch (error) {
         this.watchedDirectories.delete(directory);
-        this.queueFullReconcile();
+        if (isMissingWatchTarget(error)) {
+          this.queueFullReconcile();
+          return;
+        }
+        this.recoverWatcher(directory, directory, factory);
         return;
       }
     }
@@ -398,15 +483,19 @@ export class WatchManager {
   private async shouldTrackPath(
     path: string,
     isDirectory: boolean,
+    whenRootPathsUnavailable: "track" | "defer",
   ): Promise<boolean> {
     if (basename(path) === ".gitignore") {
       return true;
     }
     try {
-      const rootPaths = this.options.getRootPaths?.();
+      if (!this.options.getRootPaths) {
+        return true;
+      }
+      const rootPaths = this.options.getRootPaths();
       return rootPaths
         ? await pathCanAffectIndex(rootPaths, path, isDirectory)
-        : true;
+        : whenRootPathsUnavailable === "track";
     } catch {
       // Filtering must fail open so an unreadable rule file cannot hide a
       // change that the indexer still needs to reconcile.
@@ -439,6 +528,9 @@ export class WatchManager {
         this.watchers.delete(watcher);
         this.directoryWatchers.delete(directory);
         this.watchedDirectories.delete(directory);
+        if (directory === this.options.root) {
+          this.setActive(false);
+        }
       }
     }
   }
@@ -450,4 +542,11 @@ export class WatchManager {
 // per-user fs.inotify.max_user_watches quota for the whole machine.
 function requiresDirectoryWatchers(platform: NodeJS.Platform): boolean {
   return platform === "linux";
+}
+
+function isMissingWatchTarget(error: unknown): boolean {
+  if (typeof error !== "object" || error === null || !("code" in error)) {
+    return false;
+  }
+  return error.code === "ENOENT" || error.code === "ENOTDIR";
 }

--- a/test/daemon-backend.test.mjs
+++ b/test/daemon-backend.test.mjs
@@ -17,6 +17,61 @@ const noopWatchManagerFactory = () => ({
   close: async () => {},
 });
 
+test("daemon reports watcher active only after watch registration", async () => {
+  const temporaryDirectory = await mkdtemp(
+    join(tmpdir(), "zvec-grep-watcher-active-"),
+  );
+  const root = join(temporaryDirectory, "repo");
+  await mkdir(root);
+  await writeFile(join(root, "answer.ts"), "export const answer = 42;\n");
+  const service = await createZvecGrep({
+    root,
+    embeddingModel: new TestEmbeddingModel(),
+  });
+  await service.index();
+  await service.close();
+  let watcherOptions;
+  const backend = new DaemonBackend({
+    version: "1.0.0",
+    modelPoolOptions: { createModel: () => new TestEmbeddingModel() },
+    createService: (options) =>
+      createZvecGrep({
+        ...options,
+        embeddingModel: new TestEmbeddingModel(),
+      }),
+    watchManagerFactory: (options) => {
+      watcherOptions = options;
+      return {
+        start() {},
+        flushPending: async () => {},
+        close: async () => {},
+      };
+    },
+  });
+  try {
+    await backend.search(searchInput(root, "answer", "eventual"));
+    assert.equal(
+      (await backend.indexStatus({ root })).runtime.watcherActive,
+      false,
+    );
+
+    watcherOptions.onActiveChange(true);
+    assert.equal(
+      (await backend.indexStatus({ root })).runtime.watcherActive,
+      true,
+    );
+
+    watcherOptions.onActiveChange(false);
+    assert.equal(
+      (await backend.indexStatus({ root })).runtime.watcherActive,
+      false,
+    );
+  } finally {
+    await backend.close();
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  }
+});
+
 test("index releases its model lease when service creation fails", async () => {
   const temporaryDirectory = await mkdtemp(
     join(tmpdir(), "zvec-grep-backend-"),
@@ -1853,7 +1908,9 @@ test("watch changes use the path-level index pipeline and advance revisions", as
     watchManagerFactory: (options) => {
       watcherOptions = options;
       return {
-        start() {},
+        start() {
+          options.onActiveChange(true);
+        },
         flushPending: async () => {},
         close: async () => {
           watcherCloses += 1;

--- a/test/watch-manager.test.mjs
+++ b/test/watch-manager.test.mjs
@@ -130,6 +130,153 @@ test("watch manager uses per-directory watchers on Linux", async () => {
   }
 });
 
+test("Linux watcher waits for root paths before registering directories", async () => {
+  const temporaryDirectory = await mkdtemp(
+    join(tmpdir(), "zvec-grep-watch-path-policy-"),
+  );
+  const root = join(temporaryDirectory, "repo");
+  const source = join(root, "src");
+  const dependencies = join(root, "node_modules");
+  await mkdir(source, { recursive: true });
+  await mkdir(join(dependencies, "pkg"), { recursive: true });
+  await writeFile(join(root, ".gitignore"), "node_modules/\n");
+  let rootPaths;
+  let rootPathReads = 0;
+  const watched = new Set();
+  const activeStates = [];
+  const reasons = [];
+  const manager = new WatchManager({
+    root,
+    platform: "linux",
+    debounceMs: 5,
+    maxWaitMs: 20,
+    reconcileIntervalMs: 0,
+    resumeCheckIntervalMs: 0,
+    getRootPaths: () => {
+      rootPathReads += 1;
+      return rootPaths;
+    },
+    onActiveChange: (active) => activeStates.push(active),
+    watchFactory: (directory, options) => {
+      assert.equal(options.recursive, false);
+      const watcher = new EventEmitter();
+      watcher.close = () => watched.delete(directory);
+      watched.add(directory);
+      return watcher;
+    },
+    onChanges: (_changes, reason) => reasons.push(reason),
+  });
+  try {
+    manager.start();
+    await waitFor(() => rootPathReads > 0);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    assert.deepEqual([...watched], []);
+    assert.deepEqual(activeStates, []);
+
+    rootPaths = [{ absolutePath: root, recursive: true }];
+    await manager.refreshPaths();
+    await waitFor(() => watched.has(source));
+    assert.equal(watched.has(root), true);
+    assert.equal(watched.has(dependencies), false);
+    assert.deepEqual(activeStates, [true]);
+    await waitFor(() => reasons.length === 1);
+    assert.deepEqual(reasons, ["reconcile"]);
+
+    await manager.refreshPaths();
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    assert.deepEqual(reasons, ["reconcile"]);
+  } finally {
+    await manager.close();
+    assert.deepEqual(activeStates, [true, false]);
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  }
+});
+
+test("recursive watcher keeps events while root paths are unavailable", async () => {
+  const temporaryDirectory = await mkdtemp(
+    join(tmpdir(), "zvec-grep-watch-policy-pending-event-"),
+  );
+  const root = join(temporaryDirectory, "repo");
+  const source = join(root, "src", "a.ts");
+  await mkdir(join(root, "src"), { recursive: true });
+  await writeFile(source, "export const a = 1;\n");
+  let listener;
+  const watcher = new EventEmitter();
+  watcher.close = () => {};
+  const batches = [];
+  const manager = new WatchManager({
+    root,
+    platform: "darwin",
+    debounceMs: 5,
+    maxWaitMs: 20,
+    reconcileIntervalMs: 0,
+    resumeCheckIntervalMs: 0,
+    getRootPaths: () => undefined,
+    watchFactory: (_directory, options, callback) => {
+      assert.equal(options.recursive, true);
+      listener = callback;
+      return watcher;
+    },
+    onChanges: (changes) => batches.push(changes),
+  });
+  try {
+    manager.start();
+    listener("change", "src/a.ts");
+    await waitFor(() => batches.length === 1);
+    assert.deepEqual(batches[0].touchedFiles, [source]);
+  } finally {
+    await manager.close();
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  }
+});
+
+test("recursive watcher fallback starts after root paths become available", async () => {
+  const temporaryDirectory = await mkdtemp(
+    join(tmpdir(), "zvec-grep-watch-recursive-fallback-"),
+  );
+  const root = join(temporaryDirectory, "repo");
+  await mkdir(root);
+  let rootPaths;
+  let recursiveAttempts = 0;
+  const watched = new Set();
+  const activeStates = [];
+  const manager = new WatchManager({
+    root,
+    platform: "darwin",
+    reconcileIntervalMs: 0,
+    resumeCheckIntervalMs: 0,
+    getRootPaths: () => rootPaths,
+    onActiveChange: (active) => activeStates.push(active),
+    watchFactory: (directory, options) => {
+      if (options.recursive) {
+        recursiveAttempts += 1;
+        throw new Error("recursive watch unavailable");
+      }
+      const watcher = new EventEmitter();
+      watcher.close = () => watched.delete(directory);
+      watched.add(directory);
+      return watcher;
+    },
+    onChanges: () => {},
+  });
+  try {
+    manager.start();
+    await waitFor(() => recursiveAttempts === 1);
+    assert.deepEqual([...watched], []);
+    assert.deepEqual(activeStates, []);
+
+    rootPaths = [{ absolutePath: root, recursive: true }];
+    await manager.refreshPaths();
+    await waitFor(() => watched.has(root));
+    assert.equal(recursiveAttempts, 1);
+    assert.deepEqual(activeStates, [true]);
+  } finally {
+    await manager.close();
+    assert.deepEqual(activeStates, [true, false]);
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  }
+});
+
 test("watch manager drops ignored file events before creating a change batch", async () => {
   const temporaryDirectory = await mkdtemp(
     join(tmpdir(), "zvec-grep-watch-ignore-"),
@@ -453,6 +600,7 @@ test("watcher errors trigger reconciliation and replace the failed watcher", asy
   const root = join(temporaryDirectory, "repo");
   await mkdir(root);
   const watchers = [];
+  const activeStates = [];
   const reasons = [];
   const manager = new WatchManager({
     root,
@@ -461,6 +609,7 @@ test("watcher errors trigger reconciliation and replace the failed watcher", asy
     maxWaitMs: 20,
     reconcileIntervalMs: 0,
     resumeCheckIntervalMs: 0,
+    onActiveChange: (active) => activeStates.push(active),
     watchFactory: () => {
       const created = new EventEmitter();
       created.close = () => {};
@@ -474,10 +623,93 @@ test("watcher errors trigger reconciliation and replace the failed watcher", asy
     watchers[0].emit("error", new Error("watch failed"));
     await waitFor(() => reasons.length === 1);
     await waitFor(() => watchers.length === 2);
+    await waitFor(() => reasons.length === 2);
     watchers[1].emit("error", new Error("watch still failed"));
     await waitFor(() => watchers.length === 3);
-    assert.equal(reasons[0], "reconcile");
-    assert.equal(reasons.length, 1);
+    await waitFor(() => reasons.length === 3);
+    assert.deepEqual(reasons, ["reconcile", "reconcile", "reconcile"]);
+    assert.deepEqual(activeStates, [true, false, true, false, true]);
+  } finally {
+    await manager.close();
+    assert.deepEqual(activeStates, [true, false, true, false, true, false]);
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  }
+});
+
+test("Linux root watcher retries synchronous failures before becoming active", async () => {
+  const temporaryDirectory = await mkdtemp(
+    join(tmpdir(), "zvec-grep-watch-sync-error-"),
+  );
+  const root = join(temporaryDirectory, "repo");
+  await mkdir(root);
+  let attempts = 0;
+  const activeStates = [];
+  const reasons = [];
+  const manager = new WatchManager({
+    root,
+    platform: "linux",
+    debounceMs: 5,
+    maxWaitMs: 20,
+    reconcileIntervalMs: 0,
+    resumeCheckIntervalMs: 0,
+    getRootPaths: () => [{ absolutePath: root, recursive: true }],
+    onActiveChange: (active) => activeStates.push(active),
+    watchFactory: () => {
+      attempts += 1;
+      if (attempts === 1) {
+        throw new Error("ENOSPC");
+      }
+      const watcher = new EventEmitter();
+      watcher.close = () => {};
+      return watcher;
+    },
+    onChanges: (_changes, reason) => reasons.push(reason),
+  });
+  try {
+    manager.start();
+    assert.deepEqual(activeStates, []);
+    await waitFor(() => reasons.length === 1);
+    await waitFor(() => attempts === 2);
+    await waitFor(() => activeStates.includes(true));
+    await waitFor(() => reasons.length === 2);
+    assert.deepEqual(reasons, ["reconcile", "reconcile"]);
+  } finally {
+    await manager.close();
+    assert.deepEqual(activeStates, [true, false]);
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  }
+});
+
+test("Linux directory watcher does not retry a deleted directory", async () => {
+  const temporaryDirectory = await mkdtemp(
+    join(tmpdir(), "zvec-grep-watch-deleted-directory-"),
+  );
+  const root = join(temporaryDirectory, "repo");
+  await mkdir(root);
+  let attempts = 0;
+  const reasons = [];
+  const manager = new WatchManager({
+    root,
+    platform: "linux",
+    debounceMs: 5,
+    maxWaitMs: 20,
+    reconcileIntervalMs: 0,
+    resumeCheckIntervalMs: 0,
+    getRootPaths: () => [{ absolutePath: root, recursive: true }],
+    watchFactory: () => {
+      attempts += 1;
+      const error = new Error("directory was removed");
+      error.code = "ENOENT";
+      throw error;
+    },
+    onChanges: (_changes, reason) => reasons.push(reason),
+  });
+  try {
+    manager.start();
+    await waitFor(() => attempts === 1);
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    assert.equal(attempts, 1);
+    assert.deepEqual(reasons, ["reconcile"]);
   } finally {
     await manager.close();
     await rm(temporaryDirectory, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

- defer Linux per-directory watcher registration until index root-path policy is available, preventing an initial traversal of ignored trees
- recover synchronous fs.watch registration failures with the existing exponential backoff path and report watcher activity from actual root registration state
- preserve recursive-watcher events while root paths are temporarily unavailable
- request one reconciliation after initial Linux watcher activation to cover changes between the final index scan and completed watcher registration
- stop retrying ENOENT and ENOTDIR targets while still requesting reconciliation

## Context

This follows up on #86 and closes the remaining startup and failure-mode gaps around #85. In particular, ENOSPC may be thrown synchronously while installing an inotify watcher; previously that path did not recreate the missing watcher and the daemon still reported it as active.

The rebase preserves the latest watcher idle-timeout behavior: real file-system events refresh runtime activity, while scheduled reconciliation does not. Active registration state is reported independently.

The change does not alter query refresh semantics: background refresh remains non-blocking and wait_for_fresh continues to wait for reconciliation.

## Testing

- npm run lint
- npm run typecheck
- Prettier check for all changed files
- npm test