### PR TITLE
feat(cli): make search the default zg interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ terminal, or let your agent use it for you.
 
 ## 💫 Why zg?
 
-- **Ready for humans and agents** — install once, index once, then use the same
-  workspace from the CLI or your agent on macOS, Linux, and Windows.
+- **Ready for humans and agents** — install once, then just search. The first
+  CLI search creates a local index that the CLI and your agent can share.
 - **Search beyond keywords** — discover by meaning, rank by relevance, then
   verify with exact text or regex when needed.
 - **Multi-format search** — search source code, documents, and structured data
@@ -62,7 +62,7 @@ terminal, or let your agent use it for you.
 
 ## 🚀 Try it yourself
 
-### 1. Set up a sample bookshelf
+### 1. Set up and search a sample bookshelf
 
 ```bash
 # Requires Node.js 22 or newer.
@@ -73,30 +73,32 @@ curl --retry 3 --retry-all-errors --progress-bar -fL \
   -o alice-in-wonderland.txt https://raw.githubusercontent.com/GITenberg/Alice-s-Adventures-in-Wonderland_11/master/11.txt \
   -o sherlock-holmes.txt https://raw.githubusercontent.com/GITenberg/The-Memoirs-of-Sherlock-Holmes_834/master/834.txt
 
-zg index --embedding local/potion-retrieval-32m
+zg "An unseen creature left a few marks. What did the detective infer?" --limit 3
 ```
 
 > [!NOTE]
-> The index is stored in `.zvec-grep/` under the indexed project root.
+> The first indexed search creates a local index automatically. It is stored in
+> `.zvec-grep/` under the project root and is reused by later searches.
 
 > [!TIP]
-> If `zg index` or `zg query` fails, rerun the same command with `--debug`
+> If `zg --index` or `zg` fails, rerun the same command with `--debug`
 > for diagnostics (supported in both direct and server modes).
-> `zg status --mode direct --debug` reports per-file failures stored in an
+> `zg --status --mode direct --debug` reports per-file failures stored in an
 > existing index; rerun a failed direct command to diagnose command-level
 > fatal errors. Use
-> `zg status --mode server --debug` to inspect recorded server indexing errors.
-> For server connection failures, check `zg server status` and the
+> `zg --status --mode server --debug` to inspect recorded server indexing errors.
+> For server connection failures, check `zg --server status` and the
 > [server logs](./docs/06-server.md#logs-and-state).
 
-### 2. Choose how to search
+zg returns the relevant passages from `sherlock-holmes.txt`, ranked ahead of
+`alice-in-wonderland.txt`.
 
-#### For agents: ask with OpenCode
+### 2. Connect an agent (optional)
 
 With [OpenCode](https://opencode.ai/) configured:
 
 ```bash
-zg install --target opencode --yes
+zg --install --target opencode --yes
 opencode models
 opencode run --model opencode/nemotron-3-ultra-free \
   "An unseen creature left a few marks. What did the detective infer? Cite local evidence."
@@ -133,17 +135,6 @@ left with the key (sherlock-holmes.txt:5464-5470, 5527-5528).
 ```
 
 </details>
-
-#### For humans: search directly
-
-Search the same bookshelf directly, without an agent:
-
-```bash
-zg query --human "An unseen creature left a few marks. What did the detective infer?" --limit 3
-```
-
-zg returns the relevant passages from `sherlock-holmes.txt`, ranked ahead of
-`alice-in-wonderland.txt`.
 
 <a id="benchmarks"></a>
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -46,8 +46,8 @@
 
 ## 💫 为什么选择 zg？
 
-- **人与 Agent 开箱即用**：安装一次、索引一次，即可在 macOS、Linux 和
-  Windows 上通过 CLI 或 Agent 复用同一个工作区。
+- **人与 Agent 开箱即用**：安装后直接搜索；首次 CLI 搜索会自动创建本地索引，
+  CLI 与 Agent 可在 macOS、Linux 和 Windows 上复用同一个工作区。
 - **不止关键词搜索**：先按语义发现内容、按相关性排序，再在需要时使用精确文本
   或正则完成验证。
 - **多格式检索**：搜索源代码、文档和结构化数据，同时保留有用的内容结构与
@@ -61,7 +61,7 @@
 
 ## 🚀 动手体验
 
-### 1. 准备示例书架
+### 1. 准备并搜索示例书架
 
 ```bash
 # 需要 Node.js 22 或更新版本。
@@ -72,26 +72,28 @@ curl --retry 3 --retry-all-errors --progress-bar -fL \
   -o alice-in-wonderland.txt https://raw.githubusercontent.com/GITenberg/Alice-s-Adventures-in-Wonderland_11/master/11.txt \
   -o sherlock-holmes.txt https://raw.githubusercontent.com/GITenberg/The-Memoirs-of-Sherlock-Holmes_834/master/834.txt
 
-zg index --embedding local/potion-retrieval-32m
+zg "An unseen creature left a few marks. What did the detective infer?" --limit 3
 ```
 
 > [!NOTE]
-> 索引保存在被索引项目根目录的 `.zvec-grep/` 中。
+> 首次索引搜索会自动创建本地索引。索引保存在项目根目录的 `.zvec-grep/`
+> 中，并由后续搜索复用。
 
 > [!TIP]
-> `zg index` 或 `zg query` 失败时，在原命令后加 `--debug` 重跑，查看诊断信息（direct 和 server 模式均支持）。
-> 在同一项目下，可用 `zg status --mode direct --debug` 或
-> `zg status --mode server --debug` 查看已记录的索引错误。
-> Server 连接失败时，检查 `zg server status` 和[服务日志](./docs/06-server.md#logs-and-state)。
+> `zg --index` 或 `zg` 失败时，在原命令后加 `--debug` 重跑，查看诊断信息（direct 和 server 模式均支持）。
+> 在同一项目下，可用 `zg --status --mode direct --debug` 或
+> `zg --status --mode server --debug` 查看已记录的索引错误。
+> Server 连接失败时，检查 `zg --server status` 和[服务日志](./docs/06-server.md#logs-and-state)。
 
-### 2. 选择检索方式
+zg 会将 `sherlock-holmes.txt` 中的相关段落排在
+`alice-in-wonderland.txt` 前面。
 
-#### Agent：通过 OpenCode 提问
+### 2. 连接 Agent（可选）
 
 配置好 [OpenCode](https://opencode.ai/) 后：
 
 ```bash
-zg install --target opencode --yes
+zg --install --target opencode --yes
 opencode models
 opencode run --model opencode/nemotron-3-ultra-free \
   "An unseen creature left a few marks. What did the detective infer? Cite local evidence."
@@ -128,17 +130,6 @@ left with the key (sherlock-holmes.txt:5464-5470, 5527-5528).
 ```
 
 </details>
-
-#### 用户：直接检索
-
-不通过 Agent，直接搜索同一个书架：
-
-```bash
-zg query --human "An unseen creature left a few marks. What did the detective infer?" --limit 3
-```
-
-zg 会将 `sherlock-holmes.txt` 中的相关段落排在
-`alice-in-wonderland.txt` 前面。
 
 <a id="benchmarks"></a>
 

--- a/benchmarks/browse-comp-plus/LATEST_REPORT.md
+++ b/benchmarks/browse-comp-plus/LATEST_REPORT.md
@@ -112,7 +112,7 @@ Index preparation is measured separately and excluded from Agent execution metri
 | End-to-end preparation | 22.92 |
 | Server startup | 0.87 |
 | Profile preparation | 0.29 |
-| `zg install` | 0.22 |
+| `zg --install` | 0.22 |
 | Runtime verification and index warmup | 21.57 |
 
 ## Environment

--- a/benchmarks/browse-comp-plus/README.md
+++ b/benchmarks/browse-comp-plus/README.md
@@ -21,7 +21,7 @@ prompt, corpus, Codex settings, and limits:
 
 - **Baseline:** Codex with its standard set of tools.
 - **zvec-grep:** the same Codex setup, with only the zvec-grep MCP tools and
-  usage instructions added by `zg install`.
+  usage instructions added by `zg --install`.
 
 The benchmark records answer quality, token usage, wall-clock time, tool calls,
 and complete Codex trajectories.

--- a/benchmarks/browse-comp-plus/README_CN.md
+++ b/benchmarks/browse-comp-plus/README_CN.md
@@ -13,7 +13,7 @@
 每个问题均通过相互独立的配对 trial 进行评测；每次评测都使用相同的模型、prompt、语料库、Codex 配置和限制：
 
 - **Baseline：** Codex 使用其标准工具集。
-- **zvec-grep：** 保持相同的 Codex 配置，仅通过 `zg install` 增加 zvec-grep MCP 工具和使用指引。
+- **zvec-grep：** 保持相同的 Codex 配置，仅通过 `zg --install` 增加 zvec-grep MCP 工具和使用指引。
 
 Benchmark 记录回答质量、Token 用量、Agent 执行耗时、工具调用次数和完整的 Codex 轨迹。
 

--- a/benchmarks/browse-comp-plus/zg_bench/doctor.py
+++ b/benchmarks/browse-comp-plus/zg_bench/doctor.py
@@ -58,7 +58,7 @@ def _zvec_version() -> Check:
     executable = resolve_executable("zg")
     if executable is None:
         return Check("zvec-grep", False, "'zg' was not found")
-    result = run_command([executable, "version"], timeout=30)
+    result = run_command([executable, "--version"], timeout=30)
     value = result.stdout.strip()
     return Check(
         "zvec-grep",

--- a/benchmarks/browse-comp-plus/zg_bench/index.py
+++ b/benchmarks/browse-comp-plus/zg_bench/index.py
@@ -52,7 +52,7 @@ def index_is_ready(
         (artifacts / "runtime" / "zvec-home").resolve()
     )
     status = run_command(
-        [executable, "status", root, "--mode", "direct", "--check-ready"],
+        [executable, "--status", root, "--mode", "direct", "--check-ready"],
         cwd=root,
         env=environment,
         timeout=120,
@@ -69,7 +69,7 @@ def build_index(
     executable = resolve_executable("zg")
     if executable is None:
         raise RuntimeError("zvec-grep executable not found: zg")
-    version = run_command([executable, "version"], timeout=30)
+    version = run_command([executable, "--version"], timeout=30)
     actual_version = version.stdout.strip().splitlines()[0] if version.stdout else ""
     if not version.ok or not actual_version:
         raise RuntimeError("could not determine the installed zvec-grep version")
@@ -94,7 +94,7 @@ def build_index(
             and state.get("root") == str(root)
         ):
             check = run_command(
-                [executable, "status", root, "--mode", "direct", "--check-ready"],
+                [executable, "--status", root, "--mode", "direct", "--check-ready"],
                 cwd=root,
                 env=environment,
                 timeout=120,
@@ -108,7 +108,7 @@ def build_index(
 
     command: list[str | Path] = [
         executable,
-        "index",
+        "--index",
         root,
         "--mode",
         "direct",
@@ -142,7 +142,7 @@ def build_index(
             _index_failure(config, result.stderr, result.stdout, stderr_log)
         )
     status = run_command(
-        [executable, "status", root, "--mode", "direct", "--check-ready"],
+        [executable, "--status", root, "--mode", "direct", "--check-ready"],
         cwd=root,
         env=environment,
         timeout=120,
@@ -183,7 +183,7 @@ def _prepare_remote_authorization(
     grant = run_command(
         [
             executable,
-            "auth",
+            "--auth",
             "grant",
             root,
             "--capability",

--- a/benchmarks/browse-comp-plus/zg_bench/profiles.py
+++ b/benchmarks/browse-comp-plus/zg_bench/profiles.py
@@ -161,7 +161,7 @@ def prepare_profiles(
     install = run_command(
         [
             zg,
-            "install",
+            "--install",
             "--target",
             "codex",
             "--mcp-transport",
@@ -233,7 +233,7 @@ def prepare_profiles(
             "zvec_mcp": True,
             "zvec_guidance": True,
             "install_command": (
-                "zg install --target codex --mcp-transport http --yes"
+                "zg --install --target codex --mcp-transport http --yes"
             ),
         },
         "install_stdout": install.stdout,
@@ -321,7 +321,7 @@ def ensure_server(
         raise RuntimeError("zvec-grep executable not found: zg")
     environment = server_environment(config, artifacts)
     check = run_command(
-        [executable, "server", "status", "--check-ready"],
+        [executable, "--server", "status", "--check-ready"],
         env=environment,
         timeout=30,
     )
@@ -329,7 +329,7 @@ def ensure_server(
         return
     if check.ok:
         stop = run_command(
-            [executable, "server", "off"],
+            [executable, "--server", "off"],
             env=environment,
             timeout=60,
         )
@@ -338,7 +338,7 @@ def ensure_server(
     start = run_command(
         [
             executable,
-            "server",
+            "--server",
             "on",
             "--listen",
             f"127.0.0.1:{config.zvec_grep.server_port}",
@@ -351,7 +351,7 @@ def ensure_server(
     if not start.ok:
         raise RuntimeError(start.stderr.strip() or start.stdout.strip())
     check = run_command(
-        [executable, "server", "status", "--check-ready"],
+        [executable, "--server", "status", "--check-ready"],
         env=environment,
         timeout=30,
     )
@@ -364,7 +364,7 @@ def stop_server(config: BenchmarkConfig, artifacts: Path) -> None:
     if executable is None:
         raise RuntimeError("zvec-grep executable not found: zg")
     result = run_command(
-        [executable, "server", "off"],
+        [executable, "--server", "off"],
         env=server_environment(config, artifacts),
         timeout=60,
     )
@@ -393,7 +393,6 @@ def prepare_search_runtime(
     warmup = run_command(
         [
             executable,
-            "query",
             "benchmark runtime readiness",
             "--mode",
             "server",

--- a/benchmarks/browse-comp-plus/zg_bench/report.py
+++ b/benchmarks/browse-comp-plus/zg_bench/report.py
@@ -1047,7 +1047,7 @@ Index preparation is measured separately and excluded from Agent execution metri
 | End-to-end preparation | {runtime_preparation['total_wall_seconds']:.2f} |
 | Server startup | {runtime_preparation['server_start_wall_seconds']:.2f} |
 | Profile preparation | {runtime_preparation['profile_preparation_wall_seconds']:.2f} |
-| `zg install` | {runtime_preparation['profile_install_wall_seconds']:.2f} |
+| `zg --install` | {runtime_preparation['profile_install_wall_seconds']:.2f} |
 | Runtime verification and index warmup | {runtime_preparation['warmup_wall_seconds']:.2f} |
 
 ## Environment

--- a/benchmarks/browse-comp-plus/zg_bench/runner.py
+++ b/benchmarks/browse-comp-plus/zg_bench/runner.py
@@ -789,7 +789,7 @@ def run_benchmark(
     codex_version = run_command([codex, "--version"], timeout=30)
     if not codex_version.ok or not codex_version.stdout.strip():
         raise RuntimeError("could not determine the installed Codex version")
-    zg_version = run_command([zg, "version"], timeout=30)
+    zg_version = run_command([zg, "--version"], timeout=30)
     actual_zg_version = (
         zg_version.stdout.strip().splitlines()[0] if zg_version.stdout else ""
     )

--- a/benchmarks/swe-qa-bench/tests/test_runner.py
+++ b/benchmarks/swe-qa-bench/tests/test_runner.py
@@ -470,7 +470,7 @@ class ClaudeMcpInstallTests(unittest.IsolatedAsyncioTestCase):
         install_command, install_kwargs = calls[0]
         self.assertEqual(
             install_command,
-            "zg install --target claude-code --yes",
+            "zg --install --target claude-code --yes",
         )
         self.assertEqual(install_kwargs["cwd"], "/workspace")
         self.assertEqual(

--- a/benchmarks/swe-qa-bench/tests/test_zvec_grep.py
+++ b/benchmarks/swe-qa-bench/tests/test_zvec_grep.py
@@ -36,7 +36,7 @@ class _InstallHarness(ZvecGrepMixin):
         self, environment: Any, command: str, **kwargs: Any
     ) -> _Result:
         self.agent_commands.append(command)
-        if command == "zg version -v":
+        if command == "zg --version":
             return _Result(stdout="0.1.5\n")
         return _Result(
             stdout=(
@@ -148,16 +148,16 @@ class _SetupHarness(ZvecGrepMixin, _SetupBase):
             shutil.rmtree(index_dir, ignore_errors=True)
             index_dir.mkdir(parents=True)
             return _Result()
-        if command.startswith("if zg status --check-ready;"):
+        if command.startswith("if zg --status --check-ready;"):
             ready_path = index_dir / "ready"
             ready = ready_path.is_file() and ready_path.read_text() == "ready\n"
             return _Result(stdout=f"ZG_INDEX_SEED_READY={int(ready)}\n")
-        if command.startswith("zg index "):
+        if command.startswith("zg --index "):
             index_dir.mkdir(parents=True, exist_ok=True)
             (index_dir / "ready").write_text("ready\n", encoding="utf-8")
             (index_dir / "index.bin").write_bytes(b"trusted-index-data")
             return _Result(stdout="index built")
-        if command == "zg status --check-ready":
+        if command == "zg --status --check-ready":
             return _Result(stdout="\N{CHECK MARK} Workspace index is ready")
         if command == "rm -rf -- .zvec-grep":
             shutil.rmtree(index_dir, ignore_errors=True)
@@ -201,13 +201,13 @@ class InstallZvecGrepTests(unittest.IsolatedAsyncioTestCase):
     def test_remote_index_uses_workspace_authorization(self) -> None:
         self.assertEqual(
             ZvecGrepMixin._authorization_command("qwen/text-embedding-v4"),
-            "zg auth grant --capability embedding --scope workspace "
+            "zg --auth grant --capability embedding --scope workspace "
             "--embedding qwen/text-embedding-v4",
         )
         index_command = ZvecGrepMixin._index_command("qwen/text-embedding-v4")
         self.assertEqual(
             index_command,
-            "zg index --embedding qwen/text-embedding-v4",
+            "zg --index --embedding qwen/text-embedding-v4",
         )
         self.assertNotIn("--allow-remote", index_command)
         self.assertIsNone(
@@ -371,7 +371,7 @@ class InstallZvecGrepTests(unittest.IsolatedAsyncioTestCase):
             )
             self.assertTrue(
                 any(
-                    command.startswith("zg index ")
+                    command.startswith("zg --index ")
                     for command in cold_harness.agent_commands
                 )
             )
@@ -397,7 +397,7 @@ class InstallZvecGrepTests(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(hit_environment.downloads, [])
             self.assertFalse(
                 any(
-                    command.startswith("zg index ")
+                    command.startswith("zg --index ")
                     for command in hit_harness.agent_commands
                 )
             )
@@ -440,7 +440,7 @@ class InstallZvecGrepTests(unittest.IsolatedAsyncioTestCase):
 
             cleanup = retry_harness.agent_commands.index("rm -rf -- .zvec-grep")
             cold_index = retry_harness.agent_commands.index(
-                "zg index --embedding local/potion-code-16m-v2"
+                "zg --index --embedding local/potion-code-16m-v2"
             )
             self.assertLess(cleanup, cold_index)
             self.assertEqual(len(retry_environment.uploads), 1)

--- a/benchmarks/swe-qa-bench/zg_bench/agents/zvec_grep.py
+++ b/benchmarks/swe-qa-bench/zg_bench/agents/zvec_grep.py
@@ -230,9 +230,9 @@ class ZvecGrepMixin:
                 status_result = await self.exec_as_agent(
                     environment,
                     command=(
-                        "zg status --check-ready"
+                        "zg --status --check-ready"
                         if supports_ready_check
-                        else "zg status"
+                        else "zg --status"
                     ),
                     cwd=workdir,
                 )
@@ -240,7 +240,7 @@ class ZvecGrepMixin:
                     status_result.stdout or ""
                 ):
                     raise RuntimeError(
-                        "zvec-grep index setup completed but zg status did not "
+                        "zvec-grep index setup completed but zg --status did not "
                         "report state ready"
                     )
                 if seed_identity is not None and seed_key is not None:
@@ -264,7 +264,7 @@ class ZvecGrepMixin:
                 metadata["index_status"]
             ):
                 raise RuntimeError(
-                    "zvec-grep index setup completed but zg status did not "
+                    "zvec-grep index setup completed but zg --status did not "
                     "report state ready"
                 )
 
@@ -392,7 +392,7 @@ class ZvecGrepMixin:
             result = await self.exec_as_agent(
                 environment,
                 command=(
-                    "if zg status --check-ready; then ready=1; else ready=0; fi; "
+                    "if zg --status --check-ready; then ready=1; else ready=0; fi; "
                     "printf 'ZG_INDEX_SEED_READY=%s\\n' \"$ready\""
                 ),
                 cwd=workdir,
@@ -405,7 +405,7 @@ class ZvecGrepMixin:
 
         result = await self.exec_as_agent(
             environment,
-            command="zg status",
+            command="zg --status",
             cwd=workdir,
         )
         return result, self._index_is_ready(result.stdout or "")
@@ -504,7 +504,7 @@ class ZvecGrepMixin:
         mcp_result = await self.exec_as_agent(
             environment,
             command=(
-                "zg install --target " f"{shlex.quote(self._mcp_target)} --yes"
+                "zg --install --target " f"{shlex.quote(self._mcp_target)} --yes"
             ),
             **install_kwargs,
         )
@@ -517,9 +517,9 @@ class ZvecGrepMixin:
         server_status = await self.exec_as_agent(
             environment,
             command=(
-                "zg server status --check-ready"
+                "zg --server status --check-ready"
                 if supports_ready_check
-                else "zg server status"
+                else "zg --server status"
             ),
             cwd=workdir,
         )
@@ -535,7 +535,7 @@ class ZvecGrepMixin:
             )
 
     def _mcp_install_environment(self) -> dict[str, str] | None:
-        """Return target-specific environment for `zg install`."""
+        """Return target-specific environment for `zg --install`."""
         return None
 
     async def _install_zvec_grep(
@@ -574,7 +574,7 @@ class ZvecGrepMixin:
             expected = shlex.quote(expected_version)
             install_command = (
                 "if command -v zg >/dev/null 2>&1 && "
-                f"[ \"$(zg version -v)\" = {expected} ] && "
+                f"[ \"$(zg --version)\" = {expected} ] && "
                 f"npm list -g --depth=0 {binding_package} >/dev/null 2>&1; "
                 "then reused=1; else "
                 f"npm install -g {package} {binding_package} "
@@ -612,11 +612,11 @@ class ZvecGrepMixin:
             )
         await self.exec_as_root(environment, command=" && ".join(link_commands))
         version_result = await self.exec_as_agent(
-            environment, command="zg version -v"
+            environment, command="zg --version"
         )
         version = (version_result.stdout or "").strip()
         if not version:
-            raise RuntimeError("zg version -v returned no version")
+            raise RuntimeError("zg --version returned no version")
         return version, reused == "1"
 
     async def _upload_embedding_config(self, environment: BaseEnvironment) -> None:
@@ -725,14 +725,14 @@ class ZvecGrepMixin:
 
     @staticmethod
     def _index_command(embedding_model: str) -> str:
-        return f"zg index --embedding {shlex.quote(embedding_model)}"
+        return f"zg --index --embedding {shlex.quote(embedding_model)}"
 
     @staticmethod
     def _authorization_command(embedding_model: str) -> str | None:
         if embedding_model.startswith("local/"):
             return None
         return (
-            "zg auth grant --capability embedding --scope workspace "
+            "zg --auth grant --capability embedding --scope workspace "
             f"--embedding {shlex.quote(embedding_model)}"
         )
 

--- a/docs/01-agents.md
+++ b/docs/01-agents.md
@@ -5,7 +5,7 @@
 [Architecture](./05-architecture.md) · [Server](./06-server.md) ·
 [Embedding](./07-embedding.md) · [Roadmap](./08-roadmap.md)
 
-`zg install` connects zvec-grep to supported agents through the local MCP
+`zg --install` connects zvec-grep to supported agents through the local MCP
 server. After that, the agent can use indexed retrieval for workspace-grounded
 semantic discovery while keeping exact lookup on the appropriate native or
 managed-rg route.
@@ -38,17 +38,17 @@ directory; `QODER_IDE_MCP_PATH` independently overrides the full IDE `mcp.json` 
 Run the guided installer to select from detected agents:
 
 ```bash
-zg install
+zg --install
 ```
 
 For scripts or repeatable setup, select targets explicitly:
 
 ```bash
-zg install --target codex --yes
-zg install --target claude --target cursor --yes
-zg install --target qwen --yes
-zg install --target qoder --yes
-zg install --target all --yes
+zg --install --target codex --yes
+zg --install --target claude --target cursor --yes
+zg --install --target qwen --yes
+zg --install --target qoder --yes
+zg --install --target all --yes
 ```
 
 The installer:
@@ -110,7 +110,7 @@ Only after explicit workspace approval may either client run the following
 persistent grant and retry the original MCP search once:
 
 ```bash
-zg auth grant "/absolute/workspace" \
+zg --auth grant "/absolute/workspace" \
   --capability embedding \
   --scope workspace
 ```
@@ -150,7 +150,7 @@ lexical lookup to the agent's native tools:
 | The answer is unrelated open-world knowledge, a current external fact, or web content that does not depend on local evidence | The appropriate external source, not zvec-grep |
 
 `zvec_grep_search` needs an existing index. Managed rg remains available through
-`zg query --rg` and through the optional `full` MCP toolset. See the
+`zg --rg` and through the optional `full` MCP toolset. See the
 [Pipeline guide](./04-pipeline.md) for the distinction and the
 [MCP guide](./03-mcp.md) for tool inputs.
 
@@ -165,7 +165,7 @@ filenames, regexes, and exhaustive occurrence requests stay on the exact route.
 Check the server first:
 
 ```bash
-zg server status --check-ready
+zg --server status --check-ready
 ```
 
 Then start a new agent session and confirm that the client-specific search tool
@@ -179,8 +179,8 @@ MCP connection is unavailable, the same indexed search and optional managed-rg
 route remain available from the shell:
 
 ```bash
-zg query "where theme preferences are restored"
-zg query --rg -F "loadTheme" src
+zg "where theme preferences are restored"
+zg --rg -F "loadTheme" src
 ```
 
 ## Permissions and remote data
@@ -199,10 +199,10 @@ provider. Remote Embedding asks separately on first use; see
 Use the same target names to remove only zvec-grep-managed entries:
 
 ```bash
-zg uninstall --target codex --yes
-zg uninstall --target qwen --yes
-zg uninstall --target qoder --yes
-zg uninstall --target all --yes
+zg --uninstall --target codex --yes
+zg --uninstall --target qwen --yes
+zg --uninstall --target qoder --yes
+zg --uninstall --target all --yes
 ```
 
 Restart the agent or open a new session to apply the change. Uninstalling an

--- a/docs/02-cli.md
+++ b/docs/02-cli.md
@@ -5,38 +5,45 @@
 [Architecture](./05-architecture.md) · [Server](./06-server.md) ·
 [Embedding](./07-embedding.md) · [Roadmap](./08-roadmap.md)
 
-The `zg` command is the human and shell interface to the same local search
-layer used by agents. This page groups the main commands and options; use the
+The `zg` command is a search interface first. Positional arguments are always
+queries; maintenance operations use long action options so ordinary words such
+as `index`, `install`, and `status` never collide with commands. Use the
 installed CLI for version-specific help:
 
+To expose accidental use of the old command shape without making it an alias,
+a leading command-shaped word such as `query`, `index`, or `install` emits a
+warning on stderr and is still parsed as search input. Use `zg -- query` (or
+another literal word after `--`) to make that search intent explicit and
+suppress the warning.
+
 ```bash
-zg help
-zg help query
-zg help models
-zg help file-types
-zg help environment
-zg <command> --help
+zg --help
+zg --help search
+zg --help models
+zg --help file-types
+zg --help environment
+zg --index --help
 ```
 
-## Command overview
+## Interface overview
 
-| Command | Purpose |
+| Form | Purpose |
 | --- | --- |
-| `query` | Search an index or run managed ripgrep |
-| `index` | Build, update, rebuild, or drop a Workspace index |
-| `status` | Inspect Workspace and index state |
-| `install` / `uninstall` | Manage agent integrations |
-| `config` | Configure provider credentials and model defaults |
-| `auth` | Manage Remote Embedding authorization |
-| `server` | Manage the shared MCP server |
-| `help` / `version` | Show help or the installed version |
+| `zg <query>` | Search an index or run managed ripgrep |
+| `--index` | Build, update, rebuild, or drop a Workspace index |
+| `--status` | Inspect Workspace and index state |
+| `--install` / `--uninstall` | Manage agent integrations |
+| `--config` | Configure provider credentials and model defaults |
+| `--auth` | Manage Remote Embedding authorization |
+| `--server` | Manage the shared MCP server |
+| `--help` / `--version` | Show help or the installed version |
 
-## `zg query`
+## `zg`
 
 ```text
-zg query <query> [options]
-zg query --hybrid <query> --fts <query> --vector <query> [--fuse]
-zg query --rg [rg-options] <pattern> [path...]
+zg <query> [options]
+zg --hybrid <query> --fts <query> --vector <query> [--fuse]
+zg --rg [rg-options] <pattern> [path...]
 ```
 
 Search routes:
@@ -55,7 +62,7 @@ Result controls:
 | Option | Meaning |
 | --- | --- |
 | `--limit <n>` | Maximum returned items per group |
-| `--human` | Terminal-oriented output with full previews by default |
+| `--compact` | Force compact output intended for pipes |
 | `--preview none\|short\|full` | Indexed source preview size |
 | `--refresh background\|wait\|off` | Index refresh policy |
 | `--mode direct\|server\|auto` | Execution transport |
@@ -78,25 +85,30 @@ Common scope options for indexed search are `-g/--glob`, `--iglob`, `-t/--type`,
 and `-T/--type-not`. Managed rg additionally supports common ripgrep matching,
 context, discovery, encoding, and regex-engine flags.
 
+If no index exists, `zg` creates one with a local embedding model before the
+first indexed search. A configured local model is respected; a configured
+remote model is not used implicitly. Use `zg --index` when you want to choose a
+remote model, narrow the indexed paths, rebuild, or drop the index.
+
 Examples:
 
 ```bash
-zg query "theme preference persistence on startup"
-zg query --fts "loadTheme" -g "src/**" -t ts
-zg query --vector "where user preferences are restored" --limit 5
-zg query --human "plugin lifecycle" --preview full
-zg query --rg -i -C 2 -g "*.ts" "dark mode" src
+zg "theme preference persistence on startup"
+zg --fts "loadTheme" -g "src/**" -t ts
+zg --vector "where user preferences are restored" --limit 5
+zg "plugin lifecycle" --preview full
+zg --rg -i -C 2 -g "*.ts" "dark mode" src
 ```
 
 See [Retrieval pipeline](./04-pipeline.md#3-query-through-one-search-layer) for
 route selection and freshness behavior.
 
-## `zg index`
+## `zg --index`
 
 ```text
-zg index [root] [options]
-zg index [root] --rebuild [options]
-zg index [root] --drop [--yes]
+zg --index [root] [options]
+zg --index [root] --rebuild [options]
+zg --index [root] --drop [--yes]
 ```
 
 Core options:
@@ -126,16 +138,16 @@ File discovery accepts `-g/--glob`, `--iglob`, `-t/--type`, `-T/--type-not`,
 Examples:
 
 ```bash
-zg index --embedding local/potion-code-16m-v2
-zg index
-zg index --rebuild --embedding local/jina-embeddings-v2-base-code
-zg index --drop --yes
+zg --index --embedding local/potion-code-16m-v2
+zg --index
+zg --index --rebuild --embedding local/jina-embeddings-v2-base-code
+zg --index --drop --yes
 ```
 
-## `zg status`
+## `zg --status`
 
 ```text
-zg status [root] [--mode direct|server|auto] [--check-ready]
+zg --status [root] [--mode direct|server|auto] [--check-ready]
 ```
 
 Status includes the selected root, index policy, stored schema and paths, file
@@ -143,15 +155,15 @@ counts, refresh state, and a suggested next action. `--check-ready` preserves
 normal output and exits non-zero unless the index is ready, which is useful in
 scripts.
 
-## `zg install` and `zg uninstall`
+## `zg --install` and `zg --uninstall`
 
 ```text
-zg install [--target codex|claude|qwen|qoder|opencode|cursor|all|auto] [--mcp-transport stdio|http] [--mcp-toolset agent|full] [--yes] [--force]
-zg uninstall [--target codex|claude|qwen|qoder|opencode|cursor|all|auto] [--yes]
+zg --install [--target codex|claude|qwen|qoder|opencode|cursor|all|auto] [--mcp-transport stdio|http] [--mcp-toolset agent|full] [--yes] [--force]
+zg --uninstall [--target codex|claude|qwen|qoder|opencode|cursor|all|auto] [--yes]
 ```
 
 `--target` is repeatable. `qoder` is the single Qoder target and configures
-Qoder CLI and Qoder IDE together. `zg install` also accepts:
+Qoder CLI and Qoder IDE together. `zg --install` also accepts:
 
 | Option | Meaning |
 | --- | --- |
@@ -163,46 +175,46 @@ Qoder CLI and Qoder IDE together. `zg install` also accepts:
 
 See [Agent integrations](./01-agents.md) before using `--force`.
 
-## `zg config`
+## `zg --config`
 
 ```text
-zg config provider set <provider> --api-key <key>
-zg config model set <model> [--endpoint <url> | --device <device>] [--default]
+zg --config provider set <provider> --api-key <key>
+zg --config model set <model> [--endpoint <url> | --device <device>] [--default]
 ```
 
 Examples:
 
 ```bash
-zg config provider set qwen --api-key "$DASHSCOPE_API_KEY"
-zg config model set qwen/text-embedding-v4 --default
-zg config model set local/potion-code-16m-v2 --device metal
+zg --config provider set qwen --api-key "$DASHSCOPE_API_KEY"
+zg --config model set qwen/text-embedding-v4 --default
+zg --config model set local/potion-code-16m-v2 --device metal
 ```
 
 Global configuration is stored in `~/.zvec-grep/config.json`. Existing indexes
 continue to use their stored model until explicitly rebuilt.
 
-## `zg auth`
+## `zg --auth`
 
 ```text
-zg auth grant [root] --capability embedding --scope workspace [--embedding <model>]
-zg auth status [root]
-zg auth revoke [root]
+zg --auth grant [root] --capability embedding --scope workspace [--embedding <model>]
+zg --auth status [root]
+zg --auth revoke [root]
 ```
 
 Workspace grants are stored under `.zvec-grep/authorization.json` and shared by
 the CLI and MCP server. `--allow-remote` is the non-persistent alternative for
-one `query` or `index` command. `--embedding` selects the Remote Embedding model
+one search or `--index` operation. `--embedding` selects the Remote Embedding model
 to authorize; it does not run embedding. It may be omitted when the model can be
 resolved from the existing Workspace index, `ZVEC_GREP_EMBEDDING`, or the global
 default, in that order.
 
-## `zg server`
+## `zg --server`
 
 ```text
-zg server on [--listen 127.0.0.1:7999] [--token-file <path>] [--mcp-toolset agent|full]
-zg server off [--token-file <path>]
-zg server status [--check-ready]
-zg server run [--listen 127.0.0.1:7999] [--token-file <path>] [--mcp-toolset agent|full]
+zg --server on [--listen 127.0.0.1:7999] [--token-file <path>] [--mcp-toolset agent|full]
+zg --server off [--token-file <path>]
+zg --server status [--check-ready]
+zg --server run [--listen 127.0.0.1:7999] [--token-file <path>] [--mcp-toolset agent|full]
 ```
 
 `on` starts the background daemon; `run` keeps it in the foreground. The server
@@ -229,18 +241,18 @@ refresh, authentication, and logs. See [MCP](./03-mcp.md) for the tool contract.
 | `ZVEC_GREP_DEVICE` | Local model device |
 | `DASHSCOPE_API_KEY` | Qwen API-key fallback after `ZVEC_GREP_API_KEY` |
 | `QWEN_API_KEY` | Qwen API-key fallback after `DASHSCOPE_API_KEY` |
-| `QWEN_HOME` | Qwen Code configuration directory used by `zg install` |
-| `QODER_CONFIG_DIR` | Qoder CLI configuration directory used by `zg install` |
-| `QODER_IDE_MCP_PATH` | Full Qoder IDE `mcp.json` path used by `zg install` |
+| `QWEN_HOME` | Qwen Code configuration directory used by `zg --install` |
+| `QODER_CONFIG_DIR` | Qoder CLI configuration directory used by `zg --install` |
+| `QODER_IDE_MCP_PATH` | Full Qoder IDE `mcp.json` path used by `zg --install` |
 | `QODER_IDE_EXECUTABLE` | Qoder IDE executable used for automatic install-target detection |
 
-Run `zg help environment` for advanced variables, agent integration paths,
+Run `zg --help environment` for advanced variables, agent integration paths,
 scope, and detailed precedence. A new index selects its model in this order:
-explicit `--embedding`, `ZVEC_GREP_EMBEDDING`, then the global default. Existing
-indexes continue to use their stored model unless `--embedding` and `--rebuild`
-explicitly change it.
+explicit `--embedding`, `ZVEC_GREP_EMBEDDING`, the global default, then the
+built-in local default. Existing indexes continue to use their stored model
+unless `--embedding` and `--rebuild` explicitly change it.
 
 Embedding runtime values such as endpoint and device retain this order: explicit
 command option, Workspace snapshot, global configuration, then environment.
-`zg index` forwards its `ZVEC_GREP_EMBEDDING` value in server and auto modes;
+`zg --index` forwards its `ZVEC_GREP_EMBEDDING` value in server and auto modes;
 direct MCP calls use the environment inherited when the daemon started.

--- a/docs/03-mcp.md
+++ b/docs/03-mcp.md
@@ -12,7 +12,7 @@ endpoint is:
 http://127.0.0.1:7999/mcp
 ```
 
-Run `zg install` to configure a supported agent automatically. Use this page
+Run `zg --install` to configure a supported agent automatically. Use this page
 when building another MCP client or when you need the exact boundary between
 the default and compatibility toolsets. See
 [Server and execution modes](./06-server.md) for lifecycle, mode selection,
@@ -120,7 +120,7 @@ authorization. See
 ## `zvec_grep_rg`
 
 This tool is retained in the optional `full` MCP toolset and is not registered
-in the default `agent` toolset. The CLI equivalent, `zg query --rg`, remains
+in the default `agent` toolset. The CLI equivalent, `zg --rg`, remains
 available without changing the MCP toolset.
 
 Pass the ripgrep command you would otherwise run. The command is parsed into
@@ -153,8 +153,8 @@ The CLI owns index lifecycle and diagnostics, so agents normally do not need
 administrative MCP tools. Clients that require them can restart the server with:
 
 ```bash
-zg server off
-zg server on --mcp-toolset full
+zg --server off
+zg --server on --mcp-toolset full
 ```
 
 The `full` toolset exposes six tools:

--- a/docs/04-pipeline.md
+++ b/docs/04-pipeline.md
@@ -17,14 +17,23 @@ same workspace and output conventions but can run without an index.
 
 ## 1. Choose the workspace scope
 
-Run indexing from the repository root, or pass it explicitly:
+For the common case, run a search from the repository root. If no index exists,
+zg creates one there with a local embedding model and then completes the search:
 
 ```bash
 cd your-repository
-zg index --embedding local/potion-code-16m-v2
+zg "where authentication is validated"
+```
+
+Use `--index` when you need to select a model or constrain the workspace before
+the first search:
+
+```bash
+cd your-repository
+zg --index --embedding local/potion-code-16m-v2
 
 # Equivalent with an explicit root
-zg index /absolute/path/to/your-repository \
+zg --index /absolute/path/to/your-repository \
   --embedding local/potion-code-16m-v2
 ```
 
@@ -40,7 +49,7 @@ including an API key when one was explicitly persisted for that workspace.
 Scope large repositories early:
 
 ```bash
-zg index \
+zg --index \
   --embedding local/potion-code-16m-v2 \
   -g "src/**" \
   -g "docs/**" \
@@ -71,7 +80,7 @@ Without an explicit `--max-filesize`, indexing uses type-aware safety limits:
 1 MiB for code, 256 MiB for text and Markdown, 16 MiB for structured data, and
 10 MiB for images. An explicit value replaces the type-aware defaults for every
 selected file. Files excluded by these limits remain silent during normal
-indexing; use `zg index --debug` to print skipped-file counts and samples.
+indexing; use `zg --index --debug` to print skipped-file counts and samples.
 
 ### Supported formats and extraction
 
@@ -113,38 +122,39 @@ not list each skipped path or reason.
 
 ## 2. Build and maintain the index
 
-A new index resolves its model from explicit `--embedding`,
-`ZVEC_GREP_EMBEDDING`, then the configured default. Existing indexes reuse their
-stored model and file-selection settings:
+A manually created index resolves its model from explicit `--embedding`,
+`ZVEC_GREP_EMBEDDING`, the configured default, then the built-in local default.
+An implicit first-search index always uses a local model. Existing indexes reuse
+their stored model and file-selection settings:
 
 ```bash
 # First build
-zg index --embedding local/potion-code-16m-v2
+zg --index --embedding local/potion-code-16m-v2
 
 # Incremental update with the stored schema
-zg index
+zg --index
 ```
 
-Use `zg status` to see the root, selected model, file counts, failures,
+Use `zg --status` to see the root, selected model, file counts, failures,
 truncation, and the suggested next action:
 
 ```bash
-zg status
-zg status --check-ready
+zg --status
+zg --status --check-ready
 ```
 
 Changing the Embedding model or an incompatible endpoint requires an explicit
 rebuild:
 
 ```bash
-zg index --rebuild --embedding local/jina-embeddings-v2-base-code
+zg --index --rebuild --embedding local/jina-embeddings-v2-base-code
 ```
 
 Use `--reset-paths` when the existing file-selection settings should be
 replaced rather than reused. Deleting an index is explicit and destructive:
 
 ```bash
-zg index --drop --yes
+zg --index --drop --yes
 ```
 
 See [Embedding models](./07-embedding.md) before choosing or changing a model.
@@ -156,7 +166,7 @@ See [Embedding models](./07-embedding.md) before choosing or changing a model.
 The shortest query uses hybrid ranked retrieval:
 
 ```bash
-zg query "where theme preferences are restored"
+zg "where theme preferences are restored"
 ```
 
 Choose an explicit route only when you need more control:
@@ -172,20 +182,20 @@ Examples:
 
 ```bash
 # Ranked lexical search
-zg query --fts "AuthService"
+zg --fts "AuthService"
 
 # Explicit semantic search
-zg query --vector "where credentials are validated"
+zg --vector "where credentials are validated"
 
 # Combine and fuse several query groups
-zg query \
+zg \
   --hybrid "authentication flow" \
   --fts "ForbiddenError" \
   --fuse \
   --limit 10
 
 # No index required
-zg query --rg -n -F "AuthService" -g "*.ts" src
+zg --rg -n -F "AuthService" -g "*.ts" src
 ```
 
 Multiple positional queries remain separate groups unless `--fuse` is set.
@@ -206,20 +216,18 @@ between `auto`, `server`, `direct`, and `--refresh`.
 
 ## Output for agents and people
 
-Default indexed CLI output is compact, grouped by query group, and ordered by
-that group's retrieval rank. A result recalled by several groups appears in
-each matching group. Indexed source previews are omitted unless requested,
-reducing context passed to an agent:
+When stdout is a terminal, indexed CLI output is human-readable and includes a
+full source preview by default. When stdout is redirected, output is compact,
+grouped by query group, and omits previews unless requested:
 
 ```bash
-zg query "plugin lifecycle" --preview short --limit 5
+zg "plugin lifecycle" --preview short --limit 5
 ```
 
-For terminal reading, `--human` enables richer presentation and defaults to a
-full preview:
+Use `--compact` to request the pipe-oriented form even in a terminal:
 
 ```bash
-zg query --human "plugin lifecycle" --limit 5
+zg --compact "plugin lifecycle" --limit 5
 ```
 
 Use `--debug` for query diagnostics and `--trace` for per-hit indexed search

--- a/docs/05-architecture.md
+++ b/docs/05-architecture.md
@@ -39,12 +39,12 @@ flowchart LR
 ## Entry and execution
 
 People and scripts enter through the CLI. Agents normally enter through the
-local Streamable HTTP MCP endpoint configured by `zg install`.
+local Streamable HTTP MCP endpoint configured by `zg --install`.
 
 The CLI routes indexed operations through `auto`, `server`, or `direct` mode.
 Both Server and Direct modes call the same engine; the difference is process
 lifetime and coordination, not search behavior. MCP requests always arrive
-through the Server. Managed `zg query --rg` can run directly without a Server
+through the Server. Managed `zg --rg` can run directly without a Server
 or index.
 
 See [Agent integrations](./01-agents.md), [CLI](./02-cli.md),

--- a/docs/06-server.md
+++ b/docs/06-server.md
@@ -40,18 +40,18 @@ Use Direct mode when:
 - a CI job should not leave a daemon running;
 - you want foreground failures and resource lifetime tied to one process.
 
-Managed `zg query --rg` does not need an index or loaded Embedding model. It
+Managed `zg --rg` does not need an index or loaded Embedding model. It
 runs locally regardless of whether a Server is available.
 
 ## Agent setup
 
-`zg install` configures the selected Agent and starts the Server when possible:
+`zg --install` configures the selected Agent and starts the Server when possible:
 
 ```bash
-zg install
+zg --install
 ```
 
-Most Agent users therefore never need to run `zg server on` manually. Restart
+Most Agent users therefore never need to run `zg --server on` manually. Restart
 the Agent or open a new session after installation so it discovers the MCP
 endpoint.
 
@@ -66,14 +66,14 @@ See [Agent integrations](./01-agents.md) for managed configuration and
 Start the background daemon:
 
 ```bash
-zg server on
+zg --server on
 ```
 
 Inspect process readiness, endpoint, PID, and MCP toolset:
 
 ```bash
-zg server status
-zg server status --check-ready
+zg --server status
+zg --server status --check-ready
 ```
 
 `--check-ready` preserves normal output and exits non-zero unless the Server is
@@ -82,21 +82,21 @@ ready, making it suitable for scripts and health checks.
 Stop the daemon gracefully:
 
 ```bash
-zg server off
+zg --server off
 ```
 
 Run it in the foreground for logs or process supervision:
 
 ```bash
-zg server run
+zg --server run
 ```
 
 Only one Server instance can own a given zvec-grep home. If a running Server
 uses the wrong MCP toolset, stop it before restarting with the new profile:
 
 ```bash
-zg server off
-zg server on --mcp-toolset full
+zg --server off
+zg --server on --mcp-toolset full
 ```
 
 ## Configure the mode
@@ -104,8 +104,8 @@ zg server on --mcp-toolset full
 Choose a mode for one command:
 
 ```bash
-zg query --mode direct "root-local index discovery"
-zg status --mode server --check-ready
+zg --mode direct "root-local index discovery"
+zg --status --mode server --check-ready
 ```
 
 Set an environment default:
@@ -164,7 +164,7 @@ The Server only accepts loopback listen addresses. Change the loopback address
 or port with:
 
 ```bash
-zg server on --listen 127.0.0.1:8999
+zg --server on --listen 127.0.0.1:8999
 ```
 
 Set `ZVEC_GREP_SERVER_URL` when a client should use a non-default configured
@@ -183,18 +183,18 @@ file:
 
 ```bash
 export ZVEC_GREP_SERVER_TOKEN="replace-with-a-long-random-token"
-zg server on
+zg --server on
 ```
 
 ```bash
-zg server on --token-file /secure/path/zvec-grep.token
+zg --server on --token-file /secure/path/zvec-grep.token
 ```
 
 Clients can use `ZVEC_GREP_SERVER_TOKEN` or `ZVEC_GREP_SERVER_TOKEN_FILE`.
 Supported Agent integrations can reference an environment-backed token:
 
 ```bash
-zg install \
+zg --install \
   --target codex \
   --mcp-token-env ZVEC_GREP_SERVER_TOKEN \
   --yes
@@ -216,5 +216,5 @@ Credential, authorization, token, API-key, and query fields are filtered from
 daemon log records. Repository identities are logged opaquely rather than as
 raw paths where identity is sufficient.
 
-Use `ZVEC_GREP_HOME` to relocate Server state. Check `zg server status` before
+Use `ZVEC_GREP_HOME` to relocate Server state. Check `zg --server status` before
 reading logs; routine searches do not need a status preflight.

--- a/docs/07-embedding.md
+++ b/docs/07-embedding.md
@@ -7,17 +7,21 @@
 
 The Embedding model determines the vector representation used by indexed
 search. It affects language coverage, memory use, index size, input length, and
-indexing speed. A new index needs an explicit model, an environment default, or
-a configured default:
+indexing speed. A new index selects an explicit model, an environment default,
+or a configured default, and otherwise uses the built-in local default:
 
 ```bash
-zg index --embedding local/potion-code-16m-v2
+zg --index --embedding local/potion-code-16m-v2
 ```
 
 Local models keep workspace content and query text on the machine. Their files
 are downloaded on first use and cached under `~/.zvec-grep/models` by default.
 Remote models avoid local inference but send disclosed query or workspace
 content to the configured provider after authorization.
+
+A first search without an index always creates one with a local model. It
+respects a configured local default but does not implicitly use a remote
+default. Select and authorize a remote model explicitly with `zg --index`.
 
 ## Quick selection
 
@@ -69,8 +73,8 @@ release.
 Set a default for new indexes:
 
 ```bash
-zg config model set local/potion-code-16m-v2 --default
-zg index
+zg --config model set local/potion-code-16m-v2 --default
+zg --index
 ```
 
 `ZVEC_GREP_EMBEDDING` provides a process-level default that takes priority over
@@ -78,11 +82,11 @@ the configured global default for new indexes:
 
 ```bash
 export ZVEC_GREP_EMBEDDING=local/potion-code-16m-v2
-zg index
+zg --index
 ```
 
 An existing index always reuses its stored provider, model, dimensions, and
-metric unless `--embedding` and `--rebuild` explicitly change them. `zg index`
+metric unless `--embedding` and `--rebuild` explicitly change them. `zg --index`
 forwards the current CLI environment default in server and auto modes; direct
 MCP calls use the environment inherited by the daemon.
 
@@ -91,7 +95,7 @@ MCP calls use the environment inherited by the daemon.
 Select a device for local Transformer and GGUF models:
 
 ```bash
-zg index \
+zg --index \
   --embedding local/jina-embeddings-v2-base-code \
   --device auto
 ```
@@ -100,7 +104,7 @@ Supported values are `auto`, `cpu`, `metal`, `vulkan`, and `cuda`. Save a model
 preference globally with:
 
 ```bash
-zg config model set local/jina-embeddings-v2-base-code --device metal
+zg --config model set local/jina-embeddings-v2-base-code --device metal
 ```
 
 The equivalent environment override is `ZVEC_GREP_DEVICE`. Model2Vec models
@@ -110,7 +114,7 @@ their runtime.
 Override the download cache with `--model-cache` or `ZVEC_GREP_MODEL_CACHE`:
 
 ```bash
-zg index \
+zg --index \
   --embedding local/potion-code-16m-v2 \
   --model-cache /path/to/model-cache
 ```
@@ -120,15 +124,15 @@ zg index \
 Configure the Qwen provider credential and, optionally, a model endpoint:
 
 ```bash
-zg config provider set qwen --api-key "$DASHSCOPE_API_KEY"
-zg config model set qwen/text-embedding-v4 --default
+zg --config provider set qwen --api-key "$DASHSCOPE_API_KEY"
+zg --config model set qwen/text-embedding-v4 --default
 ```
 
 One-off values can be passed directly or through `ZVEC_GREP_API_KEY` and
 `ZVEC_GREP_ENDPOINT`:
 
 ```bash
-zg index \
+zg --index \
   --embedding qwen/text-embedding-v4 \
   --api-key "$DASHSCOPE_API_KEY" \
   --allow-remote
@@ -139,13 +143,13 @@ transfer. `--allow-remote` authorizes Remote Embedding only for the current
 command. To create a signed Workspace grant shared by the CLI and MCP server:
 
 ```bash
-zg auth grant \
+zg --auth grant \
   --capability embedding \
   --scope workspace \
   --embedding qwen/text-embedding-v4
 
-zg auth status
-zg auth revoke
+zg --auth status
+zg --auth revoke
 ```
 
 Before granting access, confirm that the workspace content is permitted to be
@@ -154,7 +158,7 @@ this data authorization.
 
 When Qoder CLI reports that it has no handler for `elicitation/create`, or
 declines or cancels without displaying the form, the `AGENTS.md` guidance
-installed by `zg install --target qoder` uses the exact `AskUserQuestion` tool
+installed by `zg --install --target qoder` uses the exact `AskUserQuestion` tool
 as a compatibility path. It offers workspace approval, local FTS only, or
 cancel.
 
@@ -183,7 +187,7 @@ records the count.
 Inspect the index after changing models or file scope:
 
 ```bash
-zg status
+zg --status
 ```
 
 Prefer a model with a larger input limit or narrow the indexed content when
@@ -195,7 +199,7 @@ Vector spaces from different models are incompatible, even when their
 dimensions match. Rebuild explicitly when changing models:
 
 ```bash
-zg index --rebuild --embedding local/jina-embeddings-v2-base-code
+zg --index --rebuild --embedding local/jina-embeddings-v2-base-code
 ```
 
 Changing a remote endpoint also requires a rebuild because the endpoint is part

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,9 +44,9 @@ release.
 The CLI remains the source of truth for flags in the installed version:
 
 ```bash
-zg help
-zg help query
-zg help index
+zg --help
+zg --help search
+zg --help index
 ```
 
 For development setup and pull request conventions, see

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -93,6 +93,44 @@ const MANAGED_RG_OUTPUT_OPTIONS = new Set([
   "-r",
 ]);
 
+const ACTION_FLAGS = new Map<string, CliCommand>([
+  ["--index", "index"],
+  ["--status", "status"],
+  ["--install", "install"],
+  ["--uninstall", "uninstall"],
+  ["--config", "config"],
+  ["--auth", "auth"],
+  ["--server", "server"],
+]);
+
+const COMMAND_SHAPED_QUERY_WORDS = new Set(["query", "search"]);
+const COMMAND_SHAPED_ACTION_WORDS = new Map<string, string>([
+  ["index", "--index"],
+  ["status", "--status"],
+  ["install", "--install"],
+  ["uninstall", "--uninstall"],
+  ["config", "--config"],
+  ["auth", "--auth"],
+  ["server", "--server"],
+  ["help", "--help"],
+  ["version", "--version"],
+]);
+
+export function compatibilityWarningForArgs(
+  args: readonly string[],
+): string | undefined {
+  const first = args[0];
+  if (!first) return undefined;
+
+  if (COMMAND_SHAPED_QUERY_WORDS.has(first)) {
+    return `warning: "zg ${first} ..." is not a subcommand; search is already the default. Remove "${first}", or use 'zg -- "${first}" ...' to search for that literal word.`;
+  }
+
+  const action = COMMAND_SHAPED_ACTION_WORDS.get(first);
+  if (!action) return undefined;
+  return `warning: "zg ${first} ..." no longer runs an action and is parsed as search input. Use "zg ${action} ...", or 'zg -- "${first}" ...' to search for that literal word.`;
+}
+
 export function parseArgs(args: readonly string[]): ParsedArgs {
   const commandInput = parseCommand(args);
   if (commandInput.command === "help" || commandInput.command === "version") {
@@ -104,39 +142,44 @@ export function parseArgs(args: readonly string[]): ParsedArgs {
     };
   }
 
+  const commandArgs = commandInput.args;
   const options: CliOptions = {};
   const positionals: string[] = [];
-  let startIndex = 1;
+  let startIndex = 0;
   if (commandInput.command === "config") {
-    if (args[1] === "model" && args[2] === "set") {
+    if (commandArgs[0] === "model" && commandArgs[1] === "set") {
       options.configAction = "model-set";
-      startIndex = 3;
-    } else if (args[1] === "provider" && args[2] === "set") {
+      startIndex = 2;
+    } else if (commandArgs[0] === "provider" && commandArgs[1] === "set") {
       options.configAction = "provider-set";
-      startIndex = 3;
+      startIndex = 2;
     }
   } else if (commandInput.command === "auth") {
-    if (args[1] === "grant" || args[1] === "status" || args[1] === "revoke") {
-      options.authAction = args[1];
-      startIndex = 2;
+    if (
+      commandArgs[0] === "grant" ||
+      commandArgs[0] === "status" ||
+      commandArgs[0] === "revoke"
+    ) {
+      options.authAction = commandArgs[0];
+      startIndex = 1;
     }
   } else if (commandInput.command === "server") {
     if (
-      args[1] === "on" ||
-      args[1] === "off" ||
-      args[1] === "status" ||
-      args[1] === "run"
+      commandArgs[0] === "on" ||
+      commandArgs[0] === "off" ||
+      commandArgs[0] === "status" ||
+      commandArgs[0] === "run"
     ) {
-      options.serverAction = args[1];
-      startIndex = 2;
+      options.serverAction = commandArgs[0];
+      startIndex = 1;
     }
   }
 
-  for (let index = startIndex; index < args.length; index++) {
-    const arg = args[index]!;
+  for (let index = startIndex; index < commandArgs.length; index++) {
+    const arg = commandArgs[index]!;
 
     if (arg === "--") {
-      positionals.push(...args.slice(index + 1));
+      positionals.push(...commandArgs.slice(index + 1));
       break;
     }
 
@@ -150,14 +193,17 @@ export function parseArgs(args: readonly string[]): ParsedArgs {
         command: "help",
         options: {},
         positionals: [],
-        helpTopic: commandInput.command,
+        helpTopic:
+          commandInput.command === "query" ? "search" : commandInput.command,
       };
     } else if (arg === "--version") {
       throw new Error(`${arg} must be used without a command`);
     } else if (isLongOptionWithValue(arg, "--mode")) {
       options.mode = parseClientMode(valueFromLongOption(arg));
     } else if (arg === "--mode") {
-      options.mode = parseClientMode(readOptionValue(args, ++index, arg));
+      options.mode = parseClientMode(
+        readOptionValue(commandArgs, ++index, arg),
+      );
     } else if (arg === "--force-direct") {
       options.forceDirect = true;
     } else if (arg === "--stdio") {
@@ -165,15 +211,17 @@ export function parseArgs(args: readonly string[]): ParsedArgs {
     } else if (isLongOptionWithValue(arg, "--mcp-toolset")) {
       options.mcpToolset = parseMcpToolset(valueFromLongOption(arg));
     } else if (arg === "--mcp-toolset") {
-      options.mcpToolset = parseMcpToolset(readOptionValue(args, ++index, arg));
+      options.mcpToolset = parseMcpToolset(
+        readOptionValue(commandArgs, ++index, arg),
+      );
     } else if (isLongOptionWithValue(arg, "--listen")) {
       options.listen = valueFromLongOption(arg);
     } else if (arg === "--listen") {
-      options.listen = readOptionValue(args, ++index, arg);
+      options.listen = readOptionValue(commandArgs, ++index, arg);
     } else if (isLongOptionWithValue(arg, "--token-file")) {
       options.serverTokenFile = valueFromLongOption(arg);
     } else if (arg === "--token-file") {
-      options.serverTokenFile = readOptionValue(args, ++index, arg);
+      options.serverTokenFile = readOptionValue(commandArgs, ++index, arg);
     } else if (isLongOptionWithValue(arg, "--target")) {
       options.installTargets = appendInstallTargets(
         options.installTargets,
@@ -182,7 +230,7 @@ export function parseArgs(args: readonly string[]): ParsedArgs {
     } else if (arg === "--target") {
       options.installTargets = appendInstallTargets(
         options.installTargets,
-        readOptionValue(args, ++index, arg),
+        readOptionValue(commandArgs, ++index, arg),
       );
     } else if (isLongOptionWithValue(arg, "--mcp-tool-timeout")) {
       options.installMcpToolTimeoutSeconds = parsePositiveInteger(
@@ -191,7 +239,7 @@ export function parseArgs(args: readonly string[]): ParsedArgs {
       );
     } else if (arg === "--mcp-tool-timeout") {
       options.installMcpToolTimeoutSeconds = parsePositiveInteger(
-        readOptionValue(args, ++index, arg),
+        readOptionValue(commandArgs, ++index, arg),
         arg,
       );
     } else if (isLongOptionWithValue(arg, "--mcp-token-env")) {
@@ -201,7 +249,7 @@ export function parseArgs(args: readonly string[]): ParsedArgs {
       );
     } else if (arg === "--mcp-token-env") {
       options.installMcpTokenEnv = parseEnvironmentVariable(
-        readOptionValue(args, ++index, arg),
+        readOptionValue(commandArgs, ++index, arg),
         arg,
       );
     } else if (isLongOptionWithValue(arg, "--mcp-transport")) {
@@ -210,14 +258,14 @@ export function parseArgs(args: readonly string[]): ParsedArgs {
       );
     } else if (arg === "--mcp-transport") {
       options.installMcpTransport = parseMcpInstallTransport(
-        readOptionValue(args, ++index, arg),
+        readOptionValue(commandArgs, ++index, arg),
       );
     } else if (arg === "--yes") {
       options.yes = true;
     } else if (isLongOptionWithValue(arg, "--allow-remote")) {
       throw allowRemoteValueError();
     } else if (arg === "--allow-remote") {
-      const legacyScope = args[index + 1];
+      const legacyScope = commandArgs[index + 1];
       if (legacyScope === "once" || legacyScope === "workspace") {
         throw allowRemoteValueError();
       }
@@ -228,7 +276,7 @@ export function parseArgs(args: readonly string[]): ParsedArgs {
       );
     } else if (arg === "--capability") {
       options.authorizationCapability = parseAuthorizationCapability(
-        readOptionValue(args, ++index, arg),
+        readOptionValue(commandArgs, ++index, arg),
       );
     } else if (isLongOptionWithValue(arg, "--scope")) {
       options.authorizationScope = parseAuthorizationScope(
@@ -236,7 +284,7 @@ export function parseArgs(args: readonly string[]): ParsedArgs {
       );
     } else if (arg === "--scope") {
       options.authorizationScope = parseAuthorizationScope(
-        readOptionValue(args, ++index, arg),
+        readOptionValue(commandArgs, ++index, arg),
       );
     } else if (arg === "--rg") {
       options.rg = true;
@@ -245,16 +293,22 @@ export function parseArgs(args: readonly string[]): ParsedArgs {
     } else if (arg === "--trace") {
       options.trace = true;
     } else if (arg === "--human") {
-      options.human = true;
+      throw new Error(
+        "--human has been removed; terminal output is human-readable by default",
+      );
+    } else if (arg === "--compact") {
+      options.human = false;
     } else if (arg === "--check-ready") {
       options.checkReady = true;
     } else if (isLongOptionWithValue(arg, "--preview")) {
       options.preview = parsePreviewMode(valueFromLongOption(arg));
     } else if (arg === "--preview") {
-      options.preview = parsePreviewMode(readOptionValue(args, ++index, arg));
+      options.preview = parsePreviewMode(
+        readOptionValue(commandArgs, ++index, arg),
+      );
     } else if (arg === "--json") {
       throw new Error(
-        "--json has been removed; use the default agent markdown output or --human",
+        "--json is not supported; redirect output or use --compact for compact markdown",
       );
     } else if (arg === "--no-color") {
       options.color = "never";
@@ -272,30 +326,30 @@ export function parseArgs(args: readonly string[]): ParsedArgs {
       options.refresh = parseQueryRefreshMode(valueFromLongOption(arg));
     } else if (arg === "--refresh") {
       options.refresh = parseQueryRefreshMode(
-        readOptionValue(args, ++index, arg),
+        readOptionValue(commandArgs, ++index, arg),
       );
     } else if (arg === "--prefer-symbol") {
       options.preferSymbol = true;
     } else if (arg === "--home") {
-      options.home = readOptionValue(args, ++index, arg);
+      options.home = readOptionValue(commandArgs, ++index, arg);
     } else if (arg === "--embedding") {
-      options.embedding = readOptionValue(args, ++index, arg);
+      options.embedding = readOptionValue(commandArgs, ++index, arg);
     } else if (arg === "--model-cache") {
-      options.modelCacheDir = readOptionValue(args, ++index, arg);
+      options.modelCacheDir = readOptionValue(commandArgs, ++index, arg);
     } else if (arg === "--device") {
-      options.device = parseDevice(readOptionValue(args, ++index, arg));
+      options.device = parseDevice(readOptionValue(commandArgs, ++index, arg));
     } else if (arg === "--api-key") {
-      options.apiKey = readOptionValue(args, ++index, arg);
+      options.apiKey = readOptionValue(commandArgs, ++index, arg);
     } else if (arg === "--endpoint") {
-      options.endpoint = readOptionValue(args, ++index, arg);
+      options.endpoint = readOptionValue(commandArgs, ++index, arg);
     } else if (arg === "--limit") {
       options.limit = parsePositiveInteger(
-        readOptionValue(args, ++index, arg),
+        readOptionValue(commandArgs, ++index, arg),
         arg,
       );
     } else if (arg === "--embedding-concurrency") {
       options.embeddingConcurrency = parsePositiveInteger(
-        readOptionValue(args, ++index, arg),
+        readOptionValue(commandArgs, ++index, arg),
         arg,
       );
     } else if (isLongOptionWithValue(arg, "--hybrid")) {
@@ -307,7 +361,7 @@ export function parseArgs(args: readonly string[]): ParsedArgs {
     } else if (arg === "--hybrid") {
       options.hybridQueries = appendQuery(
         options.hybridQueries,
-        readOptionValue(args, ++index, arg),
+        readOptionValue(commandArgs, ++index, arg),
         arg,
       );
     } else if (isLongOptionWithValue(arg, "--fts")) {
@@ -321,7 +375,7 @@ export function parseArgs(args: readonly string[]): ParsedArgs {
       options.routes = appendRoute(
         options.routes,
         "fts",
-        readOptionValue(args, ++index, arg),
+        readOptionValue(commandArgs, ++index, arg),
         arg,
       );
     } else if (isLongOptionWithValue(arg, "--vector")) {
@@ -335,13 +389,15 @@ export function parseArgs(args: readonly string[]): ParsedArgs {
       options.routes = appendRoute(
         options.routes,
         "vector",
-        readOptionValue(args, ++index, arg),
+        readOptionValue(commandArgs, ++index, arg),
         arg,
       );
     } else if (arg === "--fuse") {
       options.fuse = true;
     } else if (arg === "--color") {
-      options.color = parseColorMode(readOptionValue(args, ++index, arg));
+      options.color = parseColorMode(
+        readOptionValue(commandArgs, ++index, arg),
+      );
     } else if (isLongOptionWithValue(arg, "--glob")) {
       options.globs = appendValue(
         options.globs,
@@ -351,7 +407,7 @@ export function parseArgs(args: readonly string[]): ParsedArgs {
     } else if (arg === "--glob" || arg === "-g") {
       options.globs = appendValue(
         options.globs,
-        readOptionValue(args, ++index, arg),
+        readOptionValue(commandArgs, ++index, arg),
         arg,
       );
     } else if (isLongOptionWithValue(arg, "--iglob")) {
@@ -363,7 +419,7 @@ export function parseArgs(args: readonly string[]): ParsedArgs {
     } else if (arg === "--iglob") {
       options.insensitiveGlobs = appendValue(
         options.insensitiveGlobs,
-        readOptionValue(args, ++index, arg),
+        readOptionValue(commandArgs, ++index, arg),
         arg,
       );
     } else if (isLongOptionWithValue(arg, "--type")) {
@@ -375,7 +431,7 @@ export function parseArgs(args: readonly string[]): ParsedArgs {
     } else if (arg === "--type" || arg === "-t") {
       options.fileTypes = appendValue(
         options.fileTypes,
-        readOptionValue(args, ++index, arg),
+        readOptionValue(commandArgs, ++index, arg),
         arg,
       );
     } else if (isLongOptionWithValue(arg, "--type-not")) {
@@ -387,7 +443,7 @@ export function parseArgs(args: readonly string[]): ParsedArgs {
     } else if (arg === "--type-not" || arg === "-T") {
       options.excludedFileTypes = appendValue(
         options.excludedFileTypes,
-        readOptionValue(args, ++index, arg),
+        readOptionValue(commandArgs, ++index, arg),
         arg,
       );
     } else if (arg === "--hidden") {
@@ -403,7 +459,7 @@ export function parseArgs(args: readonly string[]): ParsedArgs {
     } else if (arg === "--ignore-file") {
       options.ignoreFiles = appendValue(
         options.ignoreFiles,
-        readOptionValue(args, ++index, arg),
+        readOptionValue(commandArgs, ++index, arg),
         arg,
       );
     } else if (isLongOptionWithValue(arg, "--max-depth")) {
@@ -413,7 +469,7 @@ export function parseArgs(args: readonly string[]): ParsedArgs {
       );
     } else if (arg === "--max-depth") {
       options.maxDepth = parseNonNegativeInteger(
-        readOptionValue(args, ++index, arg),
+        readOptionValue(commandArgs, ++index, arg),
         arg,
       );
     } else if (isLongOptionWithValue(arg, "--max-filesize")) {
@@ -423,7 +479,7 @@ export function parseArgs(args: readonly string[]): ParsedArgs {
       );
     } else if (arg === "--max-filesize") {
       options.maxFileSizeBytes = parseByteSize(
-        readOptionValue(args, ++index, arg),
+        readOptionValue(commandArgs, ++index, arg),
         arg,
       );
     } else if (arg === "--follow" || arg === "-L") {
@@ -447,7 +503,7 @@ export function parseArgs(args: readonly string[]): ParsedArgs {
     } else if (arg === "--file") {
       options.rgOptions = appendRgPatternFile(
         options.rgOptions,
-        readOptionValue(args, ++index, arg),
+        readOptionValue(commandArgs, ++index, arg),
         arg,
       );
       markRgCompatibilityOption(options, arg);
@@ -461,7 +517,7 @@ export function parseArgs(args: readonly string[]): ParsedArgs {
     } else if (RG_OPTIONS_WITH_VALUE.has(arg)) {
       options.rgOptions = appendRgExtraArgs(options.rgOptions, [
         arg,
-        readOptionValue(args, ++index, arg),
+        readOptionValue(commandArgs, ++index, arg),
       ]);
       markRgCompatibilityOption(options, arg);
     } else if (RG_OPTIONS_WITHOUT_VALUE.has(arg)) {
@@ -482,7 +538,7 @@ export function parseArgs(args: readonly string[]): ParsedArgs {
     } else if (arg === "--regexp") {
       options.rgOptions = appendRgPattern(
         options.rgOptions,
-        readOptionValue(args, ++index, arg),
+        readOptionValue(commandArgs, ++index, arg),
       );
       markRgCompatibilityOption(options, arg);
     } else if (isLongOptionWithValue(arg, "--context")) {
@@ -497,7 +553,7 @@ export function parseArgs(args: readonly string[]): ParsedArgs {
       options.rgOptions = setRgContext(
         options.rgOptions,
         "both",
-        readOptionValue(args, ++index, arg),
+        readOptionValue(commandArgs, ++index, arg),
         arg,
       );
       markRgCompatibilityOption(options, arg);
@@ -513,7 +569,7 @@ export function parseArgs(args: readonly string[]): ParsedArgs {
       options.rgOptions = setRgContext(
         options.rgOptions,
         "before",
-        readOptionValue(args, ++index, arg),
+        readOptionValue(commandArgs, ++index, arg),
         arg,
       );
       markRgCompatibilityOption(options, arg);
@@ -529,7 +585,7 @@ export function parseArgs(args: readonly string[]): ParsedArgs {
       options.rgOptions = setRgContext(
         options.rgOptions,
         "after",
-        readOptionValue(args, ++index, arg),
+        readOptionValue(commandArgs, ++index, arg),
         arg,
       );
       markRgCompatibilityOption(options, arg);
@@ -538,21 +594,21 @@ export function parseArgs(args: readonly string[]): ParsedArgs {
         `${arg} changes rg output and cannot be used with managed --rg`,
       );
     } else if (isShortRgOptionGroup(arg)) {
-      index = parseShortRgOptionGroup(args, index, options);
+      index = parseShortRgOptionGroup(commandArgs, index, options);
     } else if (arg === "--modified-after") {
       options.modifiedAfter = parseModifiedTime(
-        readOptionValue(args, ++index, arg),
+        readOptionValue(commandArgs, ++index, arg),
         arg,
       );
     } else if (arg === "--modified-before") {
       options.modifiedBefore = parseModifiedTime(
-        readOptionValue(args, ++index, arg),
+        readOptionValue(commandArgs, ++index, arg),
         arg,
       );
     } else if (arg === "--symbol-type") {
       options.symbolTypes = [
         ...(options.symbolTypes ?? []),
-        parseSymbolType(readOptionValue(args, ++index, arg)),
+        parseSymbolType(readOptionValue(commandArgs, ++index, arg)),
       ];
     } else {
       throw new Error(`Unknown option: ${arg}`);
@@ -566,57 +622,58 @@ export function parseArgs(args: readonly string[]): ParsedArgs {
 function parseCommand(args: readonly string[]): {
   command: CliCommand;
   helpTopic?: string;
+  args: readonly string[];
 } {
   const [first, ...rest] = args;
-  if (
-    first === undefined ||
-    first === "help" ||
-    first === "-h" ||
-    first === "--help"
-  ) {
-    if (first !== "help" && rest.length > 0) {
-      throw new Error(`${first} does not accept arguments`);
-    }
-    if (first === "help" && rest.length > 1) {
-      throw new Error("zg help accepts at most one command or topic");
+  if (first === undefined) {
+    return { command: "help", args: [] };
+  }
+  if (first === "-h" || first === "--help") {
+    if (rest.length > 1) {
+      throw new Error(`${first} accepts at most one topic`);
     }
     return {
       command: "help",
-      ...(first === "help" && rest[0] ? { helpTopic: rest[0] } : {}),
+      ...(rest[0] ? { helpTopic: rest[0] } : {}),
+      args: [],
+    };
+  }
+  if (first.startsWith("--help=")) {
+    if (rest.length > 0) {
+      throw new Error("--help=<topic> does not accept arguments");
+    }
+    const helpTopic = first.slice("--help=".length);
+    if (!helpTopic) throw new Error("--help requires a topic after =");
+    return { command: "help", helpTopic, args: [] };
+  }
+
+  if (first === "-v" || first === "--version") {
+    if (rest.length > 0) {
+      throw new Error(`${first} does not accept arguments`);
+    }
+    return { command: "version", args: [] };
+  }
+
+  const delimiter = args.indexOf("--");
+  const optionEnd = delimiter === -1 ? args.length : delimiter;
+  const actions = args
+    .slice(0, optionEnd)
+    .map((arg, index) => ({ command: ACTION_FLAGS.get(arg), index }))
+    .filter(
+      (entry): entry is { command: CliCommand; index: number } =>
+        entry.command !== undefined,
+    );
+  if (actions.length > 1) {
+    throw new Error("Only one management action can be used at a time");
+  }
+  if (actions[0]) {
+    return {
+      command: actions[0].command,
+      args: args.filter((_, index) => index !== actions[0]!.index),
     };
   }
 
-  if (first === "version" || first === "-v" || first === "--version") {
-    const acceptsVersionFlag =
-      first === "version" &&
-      rest.length === 1 &&
-      (rest[0] === "-v" || rest[0] === "--version");
-    if (rest.length > 0 && !acceptsVersionFlag) {
-      throw new Error(`${first} does not accept arguments`);
-    }
-    return { command: "version" };
-  }
-
-  if (
-    first === "query" ||
-    first === "index" ||
-    first === "status" ||
-    first === "install" ||
-    first === "uninstall" ||
-    first === "config" ||
-    first === "auth" ||
-    first === "server"
-  ) {
-    return { command: first };
-  }
-
-  if (first === "serve") {
-    throw new Error(
-      "zg serve has been removed; use zg server on and Streamable HTTP MCP",
-    );
-  }
-
-  throw new Error(`Unknown command: ${first}`);
+  return { command: "query", args };
 }
 
 function validateCliShape(
@@ -626,27 +683,27 @@ function validateCliShape(
 ): void {
   if (command === "auth") {
     if (!options.authAction) {
-      throw new Error("zg auth requires grant, status, or revoke");
+      throw new Error("zg --auth requires grant, status, or revoke");
     }
     if (positionals.length > 1) {
-      throw new Error(`zg auth ${options.authAction} accepts at most one root`);
+      throw new Error(
+        `zg --auth ${options.authAction} accepts at most one root`,
+      );
     }
     if (
       options.authAction !== "grant" &&
       (options.authorizationCapability || options.authorizationScope)
     ) {
       throw new Error(
-        `--capability and --scope can only be used with zg auth grant`,
+        `--capability and --scope can only be used with zg --auth grant`,
       );
     }
   } else if (options.authorizationCapability || options.authorizationScope) {
-    throw new Error("--capability and --scope can only be used with zg auth");
+    throw new Error("--capability and --scope can only be used with zg --auth");
   }
 
   if (options.allowRemote && command !== "query" && command !== "index") {
-    throw new Error(
-      "--allow-remote can only be used with query or index commands",
-    );
+    throw new Error("--allow-remote can only be used with search or --index");
   }
   const queryOnly = firstEnabledOption([
     [options.rg, "--rg"],
@@ -654,7 +711,7 @@ function validateCliShape(
     [options.routes?.length, "--fts/--vector"],
     [options.fuse, "--fuse"],
     [options.trace, "--trace"],
-    [options.human, "--human"],
+    [options.human, "--compact"],
     [options.preview, "--preview"],
     [options.limit, "--limit"],
     [options.refresh, "--refresh"],
@@ -665,7 +722,7 @@ function validateCliShape(
     [options.rgCompatibilityOptions?.length, "ripgrep options"],
   ]);
   if (command !== "query" && queryOnly) {
-    throw new Error(`${queryOnly} can only be used with zg query`);
+    throw new Error(`${queryOnly} can only be used for search`);
   }
   if (
     options.debug &&
@@ -674,7 +731,7 @@ function validateCliShape(
     command !== "status"
   ) {
     throw new Error(
-      "--debug can only be used with zg query, zg index, or zg status",
+      "--debug can only be used with zg, zg --index, or zg --status",
     );
   }
 
@@ -686,7 +743,7 @@ function validateCliShape(
   ]);
   if (sharedSelection && command !== "query" && command !== "index") {
     throw new Error(
-      `${sharedSelection} can only be used with query or index commands`,
+      `${sharedSelection} can only be used with search or --index`,
     );
   }
 
@@ -703,14 +760,12 @@ function validateCliShape(
     command !== "index" &&
     !(command === "query" && options.rg)
   ) {
-    throw new Error(
-      `${discoveryOption} can only be used with index commands or zg query --rg`,
-    );
+    throw new Error(`${discoveryOption} can only be used with --index or --rg`);
   }
 
   if (command === "config") {
     if (!options.configAction) {
-      throw new Error("zg config requires provider set or model set");
+      throw new Error("zg --config requires provider set or model set");
     }
     const unsupported = firstEnabledOption([
       [options.installTargets?.length, "--target"],
@@ -744,16 +799,16 @@ function validateCliShape(
     ]);
     if (unsupported) {
       throw new Error(
-        `zg config ${options.configAction === "model-set" ? "model" : "provider"} set does not accept ${unsupported}`,
+        `zg --config ${options.configAction === "model-set" ? "model" : "provider"} set does not accept ${unsupported}`,
       );
     }
   } else if (options.defaultModel) {
-    throw new Error("--default can only be used with zg config model set");
+    throw new Error("--default can only be used with zg --config model set");
   }
 
   if (command === "server") {
     if (!options.serverAction && !options.serverStdio) {
-      throw new Error("zg server requires on, off, status, run, or --stdio");
+      throw new Error("zg --server requires on, off, status, run, or --stdio");
     }
     if (options.serverAction && options.serverStdio) {
       throw new Error("--stdio cannot be combined with a server action");
@@ -764,13 +819,13 @@ function validateCliShape(
       options.serverAction !== "on" &&
       !options.serverStdio
     ) {
-      throw new Error("--listen can only be used with zg server on or run");
+      throw new Error("--listen can only be used with zg --server on or run");
     }
     if (
       options.serverTokenFile !== undefined &&
       options.serverAction === "status"
     ) {
-      throw new Error("--token-file cannot be used with zg server status");
+      throw new Error("--token-file cannot be used with zg --server status");
     }
     if (
       options.mcpToolset !== undefined &&
@@ -779,15 +834,15 @@ function validateCliShape(
       !options.serverStdio
     ) {
       throw new Error(
-        "--mcp-toolset can only be used with zg server on or run",
+        "--mcp-toolset can only be used with zg --server on or run",
       );
     }
   } else if (options.mcpToolset !== undefined && command !== "install") {
     throw new Error(
-      "--mcp-toolset can only be used with zg server on, run, --stdio, or zg install",
+      "--mcp-toolset can only be used with zg --server on, run, --stdio, or zg --install",
     );
   } else if (options.serverStdio !== undefined) {
-    throw new Error("--stdio can only be used with zg server");
+    throw new Error("--stdio can only be used with zg --server");
   }
 
   if (
@@ -833,7 +888,9 @@ function validateCliShape(
     command !== "index" &&
     command !== "status"
   ) {
-    throw new Error("--mode can only be used with query, index, or status");
+    throw new Error(
+      "--mode can only be used with search, --index, or --status",
+    );
   }
   if (
     options.checkReady &&
@@ -841,14 +898,14 @@ function validateCliShape(
     !(command === "server" && options.serverAction === "status")
   ) {
     throw new Error(
-      "--check-ready can only be used with zg status or zg server status",
+      "--check-ready can only be used with zg --status or zg --server status",
     );
   }
   if (options.listen !== undefined && command !== "server") {
-    throw new Error("--listen can only be used with zg server on or run");
+    throw new Error("--listen can only be used with zg --server on or run");
   }
   if (options.serverTokenFile !== undefined && command !== "server") {
-    throw new Error("--token-file can only be used with zg server");
+    throw new Error("--token-file can only be used with zg --server");
   }
 
   if (
@@ -856,21 +913,19 @@ function validateCliShape(
     command !== "install" &&
     command !== "uninstall"
   ) {
-    throw new Error(
-      "--target can only be used with zg install or zg uninstall",
-    );
+    throw new Error("--target can only be used with --install or --uninstall");
   }
   if (
     options.installMcpToolTimeoutSeconds !== undefined &&
     command !== "install"
   ) {
-    throw new Error("--mcp-tool-timeout can only be used with zg install");
+    throw new Error("--mcp-tool-timeout can only be used with zg --install");
   }
   if (options.installMcpTokenEnv !== undefined && command !== "install") {
-    throw new Error("--mcp-token-env can only be used with zg install");
+    throw new Error("--mcp-token-env can only be used with zg --install");
   }
   if (options.installMcpTransport !== undefined && command !== "install") {
-    throw new Error("--mcp-transport can only be used with zg install");
+    throw new Error("--mcp-transport can only be used with zg --install");
   }
   if (
     command === "install" &&
@@ -880,7 +935,7 @@ function validateCliShape(
     throw new Error("--mcp-token-env requires --mcp-transport http");
   }
   if (options.force && command !== "install") {
-    throw new Error("--force can only be used with zg install");
+    throw new Error("--force can only be used with zg --install");
   }
 
   if (command === "install" || command === "uninstall") {
@@ -908,7 +963,7 @@ function validateCliShape(
       [options.embeddingConcurrency, "--embedding-concurrency"],
     ]);
     if (unsupported) {
-      throw new Error(`${unsupported} is not supported with zg ${command}`);
+      throw new Error(`${unsupported} is not supported with zg --${command}`);
     }
   }
   if (
@@ -918,18 +973,18 @@ function validateCliShape(
     !(command === "index" && options.drop)
   ) {
     throw new Error(
-      "--yes is only valid for install, uninstall, or index --drop",
+      "--yes is only valid for --install, --uninstall, or --index --drop",
     );
   }
 
   if (options.drop && command !== "index") {
-    throw new Error("--drop can only be used with zg index");
+    throw new Error("--drop can only be used with zg --index");
   }
   if (options.rebuild && command !== "index") {
-    throw new Error("--rebuild can only be used with zg index");
+    throw new Error("--rebuild can only be used with zg --index");
   }
   if (options.resetPaths && command !== "index") {
-    throw new Error("--reset-paths can only be used with zg index");
+    throw new Error("--reset-paths can only be used with zg --index");
   }
   if (
     options.drop &&
@@ -954,7 +1009,9 @@ function validateCliShape(
       options.follow ||
       options.embeddingConcurrency)
   ) {
-    throw new Error("zg index --drop cannot be combined with indexing options");
+    throw new Error(
+      "zg --index --drop cannot be combined with indexing options",
+    );
   }
 
   if (command === "query") {
@@ -964,7 +1021,7 @@ function validateCliShape(
       [options.embeddingConcurrency, "--embedding-concurrency"],
     ]);
     if (unsupported) {
-      throw new Error(`${unsupported} is not supported with zg query`);
+      throw new Error(`${unsupported} is not supported while searching`);
     }
   }
 
@@ -974,9 +1031,7 @@ function validateCliShape(
       (options.hybridQueries?.length ?? 0) +
       (options.routes?.length ?? 0);
     if (queryCount === 0) {
-      throw new Error(
-        "zg query requires a query or --hybrid/--fts/--vector route",
-      );
+      throw new Error("zg requires a query or --hybrid/--fts/--vector route");
     }
   }
 }
@@ -1008,7 +1063,7 @@ function allowRemoteValueError(): Error {
       "--allow-remote does not accept a value.",
       "It authorizes Remote Embedding for the current command only.",
       "For persistent authorization, use:",
-      "  zg auth grant --capability embedding --scope workspace",
+      "  zg --auth grant --capability embedding --scope workspace",
     ].join("\n"),
   );
 }
@@ -1020,7 +1075,7 @@ function parseAuthorizationCapability(value: string): "embedding" {
 
 function parseAuthorizationScope(value: string): "workspace" {
   if (value === "workspace") return value;
-  throw new Error("zg auth supports only workspace scope");
+  throw new Error("zg --auth supports only workspace scope");
 }
 
 function readOptionValue(

--- a/src/cli/auth.ts
+++ b/src/cli/auth.ts
@@ -55,7 +55,7 @@ export async function runAuth(parsed: ParsedArgs): Promise<void> {
     return;
   }
   if (parsed.options.authAction !== "grant") {
-    throw new Error("zg auth requires grant, status, or revoke");
+    throw new Error("zg --auth requires grant, status, or revoke");
   }
 
   const serviceOptions = createServiceOptions(parsed.options, root);
@@ -147,7 +147,7 @@ export async function authorizeCliPlan(
       [
         "Remote Embedding authorization is required.",
         "Re-run with --allow-remote, or grant Workspace authorization:",
-        "  zg auth grant --capability embedding --scope workspace",
+        "  zg --auth grant --capability embedding --scope workspace",
       ].join("\n"),
     );
   }
@@ -268,7 +268,7 @@ export function requireEmbeddingModelCatalogEntry(reference: string) {
   throw new Error(
     [
       `Unsupported embedding model: ${reference}`,
-      "Run `zg help models` to list supported models.",
+      "Run `zg --help models` to list supported models.",
     ].join("\n"),
   );
 }
@@ -317,7 +317,7 @@ export function assertRequestedEndpointCompatible(
     return;
   }
   throw new Error(
-    "The requested embedding endpoint differs from the workspace snapshot. Run zg index --endpoint <url> --rebuild first.",
+    "The requested embedding endpoint differs from the workspace snapshot. Run zg --index --endpoint <url> --rebuild first.",
   );
 }
 

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -77,6 +77,8 @@ import {
   withRemoteEmbeddingOperationPermit,
 } from "./auth.js";
 
+const DEFAULT_IMPLICIT_EMBEDDING = "local/potion-code-16m-v2";
+
 export async function runParsedCommand(parsed: ParsedArgs): Promise<void> {
   switch (parsed.command) {
     case "query":
@@ -112,7 +114,7 @@ export async function runParsedCommand(parsed: ParsedArgs): Promise<void> {
 async function runConfig(parsed: ParsedArgs): Promise<void> {
   if (parsed.positionals.length !== 1) {
     throw new Error(
-      `zg config ${parsed.options.configAction === "provider-set" ? "provider" : "model"} set requires exactly one reference`,
+      `zg --config ${parsed.options.configAction === "provider-set" ? "provider" : "model"} set requires exactly one reference`,
     );
   }
   const reference = parsed.positionals[0]!;
@@ -130,7 +132,7 @@ async function runConfig(parsed: ParsedArgs): Promise<void> {
       throw unsupportedRemoteEmbeddingProvider(reference);
     }
     if (parsed.options.apiKey === undefined) {
-      throw new Error("zg config provider set requires --api-key");
+      throw new Error("zg --config provider set requires --api-key");
     }
     updateGlobalConfig({
       providers: {
@@ -145,7 +147,7 @@ async function runConfig(parsed: ParsedArgs): Promise<void> {
   }
 
   if (parsed.options.configAction !== "model-set") {
-    throw new Error("zg config requires provider set or model set");
+    throw new Error("zg --config requires provider set or model set");
   }
   const catalogEntry = requireEmbeddingModelCatalogEntry(reference);
   if (
@@ -154,7 +156,7 @@ async function runConfig(parsed: ParsedArgs): Promise<void> {
     !parsed.options.defaultModel
   ) {
     throw new Error(
-      "zg config model set requires --endpoint, --device, or --default",
+      "zg --config model set requires --endpoint, --device, or --default",
     );
   }
   if (
@@ -213,7 +215,7 @@ async function runIndex(parsed: ParsedArgs): Promise<void> {
   const root = resolveIndexRoot(parsed.positionals[0]);
   const rootPath = indexRootPath(root, parsed.options);
   if (parsed.positionals.length > 1) {
-    throw new Error("zg index accepts at most one root path");
+    throw new Error("zg --index accepts at most one root path");
   }
 
   if (parsed.options.drop) {
@@ -356,7 +358,7 @@ function serverIndexFailureSummary(result: Record<string, unknown>): string {
       return `[${code}] Index job failed.`;
     }
   }
-  return `Index job ${String(result.job_id ?? "unknown")} failed. Run zg status --mode server for details.`;
+  return `Index job ${String(result.job_id ?? "unknown")} failed. Run zg --status --mode server for details.`;
 }
 
 function nonEmptyString(value: unknown): string | undefined {
@@ -504,7 +506,7 @@ async function confirmIndexDrop(
   }
   if (!process.stdin.isTTY || !process.stdout.isTTY) {
     throw new Error(
-      "zg index --drop requires --yes in a non-interactive shell",
+      "zg --index --drop requires --yes in a non-interactive shell",
     );
   }
 
@@ -525,7 +527,7 @@ async function confirmIndexDrop(
 async function runServer(parsed: ParsedArgs): Promise<void> {
   if (parsed.positionals.length > 0) {
     throw new Error(
-      `zg server ${parsed.options.serverStdio ? "--stdio" : parsed.options.serverAction} does not accept positional arguments`,
+      `zg --server ${parsed.options.serverStdio ? "--stdio" : parsed.options.serverAction} does not accept positional arguments`,
     );
   }
   const { readPackageVersion } = await import("./version.js");
@@ -587,7 +589,7 @@ async function runServer(parsed: ParsedArgs): Promise<void> {
 async function runStatus(parsed: ParsedArgs): Promise<void> {
   const root = parsed.positionals[0] ?? process.cwd();
   if (parsed.positionals.length > 1) {
-    throw new Error("zg status accepts at most one root path");
+    throw new Error("zg --status accepts at most one root path");
   }
 
   const mode = resolveClientMode(parsed.options.mode);
@@ -644,8 +646,8 @@ async function runQuery(parsed: ParsedArgs): Promise<void> {
   ) {
     throw new Error(
       parsed.options.rg
-        ? "zg query --rg requires a pattern. Use zg help query for examples."
-        : "zg query requires text or --hybrid/--fts/--vector routes. Use zg help query for examples.",
+        ? "zg --rg requires a pattern. Use zg --help search for examples."
+        : "zg requires text or --hybrid/--fts/--vector routes. Use zg --help search for examples.",
     );
   }
   if (commandOptions.rg) {
@@ -657,7 +659,10 @@ async function runQuery(parsed: ParsedArgs): Promise<void> {
     await routeByMode({
       mode,
       serverAvailable: () => daemonIsReady(commandOptions.home),
-      server: () => runServerQuery(commandOptions, queries, routes),
+      server: async () => {
+        await ensureServerIndex(commandOptions);
+        await runServerQuery(commandOptions, queries, routes);
+      },
       direct: () => runDirectQuery(commandOptions, queries),
     });
     return;
@@ -710,7 +715,15 @@ async function runDirectQuery(
         if (progressEvent.phase !== "done") progress.report(progressEvent);
       },
     );
-    const info = await directQueryInfo(zvecGrep);
+    let info = await directQueryInfo(zvecGrep);
+    if (!info.indexed && info.indexPolicy !== "disabled") {
+      await buildImplicitDirectIndex(
+        commandOptions,
+        info.root,
+        progress.report,
+      );
+      info = await directQueryInfo(zvecGrep);
+    }
     const schema = info.workspaceIndex?.embedding;
     const workspaceRuntime = workspaceRuntimeFromInfo(info);
     const modelInfo =
@@ -768,6 +781,64 @@ async function runDirectQuery(
   } finally {
     await zvecGrep.close();
   }
+}
+
+async function buildImplicitDirectIndex(
+  options: CliOptions,
+  root: string,
+  onProgress: (progress: IndexProgress) => void,
+): Promise<void> {
+  const embedding = implicitEmbeddingReference(options);
+  console.error(`No index found; creating one with ${embedding}.`);
+  const service = await createZvecGrep(
+    createServiceOptions({ ...options, embedding }, root),
+  );
+  try {
+    await service.index({ root, onProgress });
+  } finally {
+    await service.close();
+  }
+}
+
+async function ensureServerIndex(options: CliOptions): Promise<void> {
+  const root = resolve(process.cwd());
+  const client = daemonClient(options);
+  const status = await client.callTool("zvec_grep_index_status", { root });
+  if (status.indexed === true || status.index_policy === "disabled") return;
+
+  const embedding = implicitEmbeddingReference(options);
+  console.error(`No index found; creating one with ${embedding}.`);
+  const progress = createIndexProgressReporter({ color: options.color });
+  let result: Record<string, unknown>;
+  try {
+    result = await client.callTool(
+      "zvec_grep_index",
+      {
+        root,
+        embedding,
+        device: options.device,
+        embeddingConcurrency: options.embeddingConcurrency,
+        wait: true,
+      },
+      {
+        onProgress: (event) => {
+          const update = indexProgressFromMessage(event.message);
+          if (update) progress.report(update.progress);
+        },
+        embeddingEnvironment: embedding,
+      },
+    );
+  } finally {
+    progress.finish();
+  }
+  if (result.state === "failed") throw serverIndexFailure(result);
+}
+
+function implicitEmbeddingReference(options: CliOptions): string {
+  const configured = configuredEmbeddingReference(options, undefined);
+  return configured?.startsWith("local/")
+    ? configured
+    : DEFAULT_IMPLICIT_EMBEDDING;
 }
 
 async function runServerQuery(

--- a/src/cli/format/status.ts
+++ b/src/cli/format/status.ts
@@ -170,7 +170,7 @@ export function printRemoteEmbeddingAuthorizationStatus(
     console.log("");
     console.log(theme.accent("Run"));
     console.log(
-      `  ${theme.path("zg auth grant --capability embedding --scope workspace")}`,
+      `  ${theme.path("zg --auth grant --capability embedding --scope workspace")}`,
     );
     return;
   }
@@ -223,7 +223,7 @@ export function printWorkspaceInfo(
   const status = info.status ?? undefined;
   const completion = indexCompletionFromStatus(status);
   const suggestion =
-    status && statusNeedsRefresh(status) ? "zg index" : info.suggestion;
+    status && statusNeedsRefresh(status) ? "zg --index" : info.suggestion;
 
   const state = workspaceState(info);
   printWorkspaceIndexStatus(theme, {
@@ -253,7 +253,7 @@ export function printWorkspaceInfo(
       : undefined,
     suggestion,
     failedReasons: status
-      ? summarizeFailedFileReasons(status.failedFiles, "zg index")
+      ? summarizeFailedFileReasons(status.failedFiles, "zg --index")
       : undefined,
   });
   return state;
@@ -726,7 +726,7 @@ export function printNoIndexableFilesTip(options: CliOptions): void {
     theme,
     "tip",
     theme.warning(
-      "No indexable files were found. Run `zg help file-types` to review supported file types and indexing rules.",
+      "No indexable files were found. Run `zg --help file-types` to review supported file types and indexing rules.",
     ),
   );
 }

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -47,15 +47,15 @@ const ENVIRONMENT_VARIABLES = {
   ZVEC_GREP_LLAMA_CONTEXT_PARALLELISM:
     "Positive llama.cpp context parallelism override (advanced)",
   NO_COLOR: "Disable terminal colors",
-  CODEX_HOME: "Codex configuration directory used by zg install",
-  CLAUDE_CONFIG_DIR: "Claude configuration directory used by zg install",
-  QWEN_HOME: "Qwen Code configuration directory used by zg install",
-  QODER_CONFIG_DIR: "Qoder CLI configuration directory used by zg install",
-  QODER_IDE_MCP_PATH: "Full Qoder IDE mcp.json path used by zg install",
+  CODEX_HOME: "Codex configuration directory used by zg --install",
+  CLAUDE_CONFIG_DIR: "Claude configuration directory used by zg --install",
+  QWEN_HOME: "Qwen Code configuration directory used by zg --install",
+  QODER_CONFIG_DIR: "Qoder CLI configuration directory used by zg --install",
+  QODER_IDE_MCP_PATH: "Full Qoder IDE mcp.json path used by zg --install",
   QODER_IDE_EXECUTABLE:
     "Qoder IDE executable used by automatic install-target detection",
-  OPENCODE_CONFIG: "OpenCode configuration file used by zg install",
-  CURSOR_CONFIG_DIR: "Cursor configuration directory used by zg install",
+  OPENCODE_CONFIG: "OpenCode configuration file used by zg --install",
+  CURSOR_CONFIG_DIR: "Cursor configuration directory used by zg --install",
 } as const;
 
 type EnvironmentVariableName = keyof typeof ENVIRONMENT_VARIABLES;
@@ -72,47 +72,52 @@ function mainHelp(version: string): string {
   return `zvec-grep ${version}
 
 Usage:
-  zg <command> [options]
+  zg [search options] <query>
+  zg --<action> [action options]
 
-Commands:
-  query          Search indexed context or run managed ripgrep
-  index          Build, rebuild, or drop the workspace index
-  status         Show workspace and index status
-  config         Configure provider credentials and embedding model defaults
-  auth           Manage Workspace Remote Embedding authorization
-  server         Start, stop, inspect, or run the shared MCP server
-  install        Install agent integrations
-  uninstall      Remove agent integrations
-  help           Show help for a command or topic
-  version        Print the installed version
+Search is the default operation. Management actions use reserved long options,
+so words such as "index", "install", and "status" remain valid queries.
+Leading command-shaped words emit a migration warning; use zg -- "index" to
+confirm that such a word is intended as literal search input.
+
+Actions:
+  --index        Build, rebuild, or drop the workspace index
+  --status       Show workspace and index status
+  --config       Configure provider credentials and embedding model defaults
+  --auth         Manage Workspace Remote Embedding authorization
+  --server       Start, stop, inspect, or run the shared MCP server
+  --install      Install agent integrations
+  --uninstall    Remove agent integrations
+  --help         Show help for an action or topic
+  --version      Print the installed version
 
 Examples:
-  zg query "where authentication is validated"
-  zg query --fts "AuthService"
-  zg query --rg -F "AuthService" src
-  zg index --embedding local/potion-code-16m-v2
-  zg status
-  zg auth status
-  zg server on
-  zg config model set local/potion-code-16m-v2 --device metal
-  zg install
+  zg "where authentication is validated"
+  zg --fts "AuthService"
+  zg --rg -F "AuthService" src
+  zg --index --embedding local/potion-code-16m-v2
+  zg --status
+  zg --auth status
+  zg --server on
+  zg --config model set local/potion-code-16m-v2 --device metal
+  zg --install
 
 Environment:
 ${formatEnvironmentVariables(MAIN_ENVIRONMENT_VARIABLES)}
 
-Run zg help models or zg help file-types for supported indexing capabilities.
-Run zg help environment for all variables, scopes, aliases, and precedence.
-Run zg help <command> or zg <command> --help for command-specific help.
+Run zg --help models or zg --help file-types for supported indexing capabilities.
+Run zg --help environment for all variables, scopes, aliases, and precedence.
+Run zg --help <action> or zg --<action> --help for action-specific help.
 Use zg -h/--help for this page and zg -v/--version for the version.`;
 }
 
 function commandHelp(topic: string): string | undefined {
   switch (topic) {
-    case "query":
+    case "search":
       return `Usage:
-  zg query <query> [options]
-  zg query --hybrid <query> --fts <query> --vector <query> [--fuse]
-  zg query --rg [rg-options] <pattern> [path...]
+  zg <query> [options]
+  zg --hybrid <query> --fts <query> --vector <query> [--fuse]
+  zg --rg [rg-options] <pattern> [path...]
 
 Search routes:
   positional query                  Hybrid FTS and vector search
@@ -124,8 +129,8 @@ Search routes:
 
 Result options:
   --limit <n>                       Maximum results per group (default: 7)
-  --human                           Human-readable output (default: agent markdown)
-  --preview <none|short|full>       Indexed preview size (default: none; --human: full)
+  --compact                         Force compact output intended for pipes
+  --preview <none|short|full>       Indexed preview size (default: terminal=full, pipe=none)
   --debug                           Print diagnostics to stderr
   --trace                           Include per-hit indexed search trace
   --refresh <background|wait|off>   Refresh policy (defaults: server=background, direct=off)
@@ -164,12 +169,15 @@ ${formatEnvironmentVariables([
   "ZVEC_GREP_DEVICE",
 ])}
 
-See zg help environment for precedence and Server-mode scope.`;
+If no index exists, zg creates one with a local embedding model before searching.
+Terminal output is human-readable by default; redirected output is compact.
+
+See zg --help environment for precedence and Server-mode scope.`;
     case "index":
       return `Usage:
-  zg index [root] [options]
-  zg index [root] --rebuild [options]
-  zg index [root] --drop [--yes]
+  zg --index [root] [options]
+  zg --index [root] --rebuild [options]
+  zg --index [root] --drop [--yes]
 
 Index options:
   --rebuild                         Rebuild the existing index
@@ -200,8 +208,8 @@ File selection:
   -L, --follow                      Follow symbolic links safely
   --reset-paths                     Clear inherited file-selection settings
 
-New indexes require --embedding, ZVEC_GREP_EMBEDDING, or a configured default.
-Existing indexes reuse their stored embedding schema.
+New indexes use --embedding, ZVEC_GREP_EMBEDDING, a configured default, or the
+built-in local default in that order. Existing indexes reuse their schema.
 
 Environment:
 ${formatEnvironmentVariables([
@@ -213,10 +221,10 @@ ${formatEnvironmentVariables([
   "ZVEC_GREP_DEVICE",
 ])}
 
-See zg help environment for precedence and Server-mode scope.`;
+See zg --help environment for precedence and Server-mode scope.`;
     case "status":
       return `Usage:
-  zg status [root] [--mode <direct|server|auto>] [--check-ready] [--debug]
+  zg --status [root] [--mode <direct|server|auto>] [--check-ready] [--debug]
 
 Shows the nearest workspace root, index policy, index state, embedding schema,
 stored paths, refresh status, and suggested next action.
@@ -226,8 +234,8 @@ stored paths, refresh status, and suggested next action.
 Workspace index is ready.`;
     case "config":
       return `Usage:
-  zg config provider set <provider> --api-key <key>
-  zg config model set <model> [--endpoint <url> | --device <device>] [--default]
+  zg --config provider set <provider> --api-key <key>
+  zg --config model set <model> [--endpoint <url> | --device <device>] [--default]
 
 Provider options:
   --api-key <key>                   Default API key for the provider
@@ -244,9 +252,9 @@ Existing indexes continue to use their stored model.
 Global configuration is stored in ~/.zvec-grep/config.json.`;
     case "auth":
       return `Usage:
-  zg auth grant [root] --capability embedding --scope workspace [--embedding <model>]
-  zg auth status [root]
-  zg auth revoke [root]
+  zg --auth grant [root] --capability embedding --scope workspace [--embedding <model>]
+  zg --auth status [root]
+  zg --auth revoke [root]
 
 Manage the signed Remote Embedding grant stored in the Workspace under
 .zvec-grep/authorization.json. Workspace grants are shared by zg CLI and zg MCP.
@@ -259,7 +267,7 @@ Scopes used during operations:
   once                              Current CLI command or Agent tool call only
   workspace                         Persisted in this Workspace
 
-Use --allow-remote on zg query or zg index to authorize Remote Embedding for
+Use --allow-remote on zg or zg --index to authorize Remote Embedding for
 that command only. This authorization is not persisted. API credentials
 configure a provider but do not grant permission.
 
@@ -272,11 +280,11 @@ ${formatEnvironmentVariables([
 ])}`;
     case "server":
       return `Usage:
-  zg server --stdio [--token-file <path>] [--mcp-toolset <agent|full>]
-  zg server on [--listen 127.0.0.1:7999] [--token-file <path>] [--mcp-toolset <agent|full>]
-  zg server off [--token-file <path>]
-  zg server status [--check-ready]
-  zg server run [--listen 127.0.0.1:7999] [--token-file <path>] [--mcp-toolset <agent|full>]
+  zg --server --stdio [--token-file <path>] [--mcp-toolset <agent|full>]
+  zg --server on [--listen 127.0.0.1:7999] [--token-file <path>] [--mcp-toolset <agent|full>]
+  zg --server off [--token-file <path>]
+  zg --server status [--check-ready]
+  zg --server run [--listen 127.0.0.1:7999] [--token-file <path>] [--mcp-toolset <agent|full>]
 
 --stdio is the MCP client bootstrap transport. It safely starts or reuses the
 shared daemon, proxies MCP over stdin/stdout, and leaves the daemon running
@@ -299,10 +307,10 @@ ${formatEnvironmentVariables([
   "ZVEC_GREP_MCP_TOOLSET",
 ])}
 
-See zg help environment for daemon startup scope.`;
+See zg --help environment for daemon startup scope.`;
     case "install":
       return `Usage:
-  zg install [--target codex|claude|qwen|qoder|opencode|cursor|all|auto] [--mcp-transport stdio|http] [--mcp-toolset agent|full] [--yes] [--force]
+  zg --install [--target codex|claude|qwen|qoder|opencode|cursor|all|auto] [--mcp-transport stdio|http] [--mcp-toolset agent|full] [--yes] [--force]
 
 Options:
   --target <agent>                  codex, claude, qwen, qoder, opencode, cursor, auto, or all; repeatable
@@ -328,19 +336,20 @@ use. Restart the agent or open a new session after installation. This does not
 install the npm package.`;
     case "uninstall":
       return `Usage:
-  zg uninstall [--target codex|claude|qwen|qoder|opencode|cursor|all|auto] [--yes]
+  zg --uninstall [--target codex|claude|qwen|qoder|opencode|cursor|all|auto] [--yes]
 
 Removes zvec-grep-managed MCP configuration, agent-specific approval, and
 guidance. The qoder target removes the managed Qoder CLI and IDE integration
 together.`;
     case "help":
       return `Usage:
-  zg help [command|topic]
-  zg <command> --help
+  zg --help [action|topic]
+  zg --<action> --help
   zg -h
   zg --help
 
 Topics:
+  search                             Search options and behavior
   models                             Supported embedding models
   file-types                         Supported file types and structural parsing
   environment, env                   Environment variables and precedence`;
@@ -353,8 +362,6 @@ Topics:
       return environmentHelp();
     case "version":
       return `Usage:
-  zg version
-  zg version -v
   zg -v
   zg --version`;
     default:
@@ -373,7 +380,7 @@ function modelsHelp(): string {
   });
 
   return `Usage:
-  zg help models
+  zg --help models
 
 Supported embedding models:
 ${formatEmbeddingModels(models)}
@@ -382,7 +389,7 @@ Local models are downloaded to the model cache on first use. Remote models
 require provider credentials plus --allow-remote or a Workspace authorization.
 Only qwen/qwen3-vl-embedding accepts image input.
 
-Existing indexes keep their stored model. See zg help environment for
+Existing indexes keep their stored model. See zg --help environment for
 new-index model selection and runtime precedence.`;
 }
 
@@ -424,7 +431,7 @@ function fileTypesHelp(): string {
   ]);
 
   return `Usage:
-  zg help file-types
+  zg --help file-types
 
 Structured code (symbols and scopes):
 ${formatFileTypeTable(structuredCode)}
@@ -518,8 +525,8 @@ function formatTable(
 
 function environmentHelp(): string {
   return `Usage:
-  zg help environment
-  zg help env
+  zg --help environment
+  zg --help env
 
 Client and Server:
 ${formatEnvironmentVariables([
@@ -569,12 +576,12 @@ ${formatEnvironmentVariables([
 
 Precedence:
   Embedding runtime                 CLI > Workspace snapshot > Global config > Environment
-  New-index model                  --embedding > ZVEC_GREP_EMBEDDING > Global config
+  New-index model                  --embedding > ZVEC_GREP_EMBEDDING > Global config > Built-in local
   Client mode                      --mode > ZVEC_GREP_MODE > Global config
   Qwen environment credential      ZVEC_GREP_API_KEY > DASHSCOPE_API_KEY > QWEN_API_KEY
 
 Server scope:
-  zg index forwards its ZVEC_GREP_EMBEDDING default to Server and auto modes.
+  zg --index forwards its ZVEC_GREP_EMBEDDING default to Server and auto modes.
   Direct MCP calls use the embedding environment inherited by the daemon.
   Restart the daemon after changing its embedding runtime environment.
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S node --liftoff-only
 
-import { parseArgs } from "./args.js";
+import { compatibilityWarningForArgs, parseArgs } from "./args.js";
 import { runParsedCommand } from "./commands.js";
 import { colorModeFromArgs, printError } from "./errors.js";
 import { printHelp } from "./help.js";
@@ -16,7 +16,13 @@ async function main(): Promise<void> {
   let debug = false;
 
   try {
+    const compatibilityWarning = compatibilityWarningForArgs(args);
+    if (compatibilityWarning) console.error(compatibilityWarning);
+
     const parsed = parseArgs(args);
+    if (parsed.command === "query" && parsed.options.human === undefined) {
+      parsed.options.human = process.stdout.isTTY === true;
+    }
     debug = parsed.options.debug === true;
 
     if (parsed.command === "version") {

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -128,9 +128,11 @@ const QODER_MCP_PERMISSION_RULES = [
 const QODER_MCP_PERMISSIONS = QODER_MCP_PERMISSION_RULES.map(
   ({ permission }) => permission,
 );
-const QODER_CLI_MCP_DESCRIPTION = "Managed by zg install";
+const QODER_CLI_MCP_DESCRIPTION = "Managed by zg --install";
 const QODER_PERMISSION_OWNERSHIP_PREFIX = `${QODER_CLI_MCP_DESCRIPTION}; managed permissions=`;
-const QODER_IDE_MCP_DESCRIPTION = "Managed by zg install";
+const QODER_IDE_MCP_DESCRIPTION = "Managed by zg --install";
+const LEGACY_QODER_MCP_DESCRIPTION = "Managed by zg install";
+const LEGACY_QODER_PERMISSION_OWNERSHIP_PREFIX = `${LEGACY_QODER_MCP_DESCRIPTION}; managed permissions=`;
 const DEFAULT_MCP_TOOL_TIMEOUT_SECONDS = 600;
 
 export async function runInstall(parsed: ParsedArgs): Promise<void> {
@@ -164,7 +166,7 @@ export async function runInstall(parsed: ParsedArgs): Promise<void> {
     console.log(`    ready at ${server.serverUrl ?? resolveServerUrl()}`);
   } else {
     console.log(`  ${installMutedMark()} Server`);
-    console.log("    not started; run `zg server on`");
+    console.log("    not started; run `zg --server on`");
   }
   if (transport === "stdio") {
     console.log(`  ${installSuccessMark()} Connection`);
@@ -1316,15 +1318,17 @@ function removeQoderPermissionRules(
 }
 
 function qoderOwnedPermissionRules(server: unknown): string[] {
-  if (
-    !isJsonObject(server) ||
-    typeof server.description !== "string" ||
-    !server.description.startsWith(QODER_PERMISSION_OWNERSHIP_PREFIX)
-  ) {
+  if (!isJsonObject(server) || typeof server.description !== "string") {
     return [];
   }
-  const alwaysAllow = server.description
-    .slice(QODER_PERMISSION_OWNERSHIP_PREFIX.length)
+  const description = server.description;
+  const prefix = [
+    QODER_PERMISSION_OWNERSHIP_PREFIX,
+    LEGACY_QODER_PERMISSION_OWNERSHIP_PREFIX,
+  ].find((candidate) => description.startsWith(candidate));
+  if (!prefix) return [];
+  const alwaysAllow = description
+    .slice(prefix.length)
     .split(",")
     .filter(Boolean);
   return QODER_MCP_PERMISSION_RULES.filter(({ tool }) =>
@@ -1848,7 +1852,7 @@ function isManagedJsonMcpServer(value: unknown): boolean {
     Array.isArray(value.command) &&
     (value.command.length === 3 || value.command.length === 5) &&
     value.command[0] === "zg" &&
-    value.command[1] === "server" &&
+    isServerActionArg(value.command[1]) &&
     value.command[2] === "--stdio" &&
     (value.command.length === 3 ||
       (value.command[3] === "--mcp-toolset" &&
@@ -1859,7 +1863,8 @@ function isManagedJsonMcpServer(value: unknown): boolean {
 function isManagedQoderIdeMcpServer(value: unknown): boolean {
   return (
     isJsonObject(value) &&
-    value.description === QODER_IDE_MCP_DESCRIPTION &&
+    (value.description === QODER_IDE_MCP_DESCRIPTION ||
+      value.description === LEGACY_QODER_MCP_DESCRIPTION) &&
     ((typeof value.command === "string" && isStableStdioArgs(value.args)) ||
       (value.type === "sse" && typeof value.url === "string"))
   );
@@ -1869,7 +1874,7 @@ function isStdioArgs(value: unknown): boolean {
   return (
     Array.isArray(value) &&
     (value.length === 2 || value.length === 4) &&
-    value[0] === "server" &&
+    isServerActionArg(value[0]) &&
     value[1] === "--stdio" &&
     (value.length === 2 ||
       (value[2] === "--mcp-toolset" &&
@@ -1882,7 +1887,7 @@ function isStableStdioArgs(value: unknown): boolean {
     Array.isArray(value) &&
     (value.length === 3 || value.length === 5) &&
     typeof value[0] === "string" &&
-    value[1] === "server" &&
+    isServerActionArg(value[1]) &&
     value[2] === "--stdio" &&
     (value.length === 3 ||
       (value[3] === "--mcp-toolset" &&
@@ -1890,9 +1895,13 @@ function isStableStdioArgs(value: unknown): boolean {
   );
 }
 
+function isServerActionArg(value: unknown): boolean {
+  return value === "--server" || value === "server";
+}
+
 function stdioArgs(mcpToolset?: McpToolset): string[] {
   return [
-    "server",
+    "--server",
     "--stdio",
     ...(mcpToolset ? ["--mcp-toolset", mcpToolset] : []),
   ];
@@ -2238,7 +2247,7 @@ function agentGuidanceBlock(toolNames?: {
 ${formatPromptRules("### Qoder Remote Embedding authorization recovery", [
   `When \`${searchTool}\` needs \`remote_embedding_authorization\` and the current Qoder host returns \`code = 51500 message = method not found: No request handler configured\` without showing an authorization form, returns \`${REMOTE_EMBEDDING_ELICITATION_UNSUPPORTED_MESSAGE}\`, or reports that authorization was declined or cancelled without showing the user an authorization form, treat it as a Qoder client interaction limitation: the host lacks the server-to-client \`elicitation/create\` request handler. The outer MCP \`tools/call\` has already reached the registered MCP server and tool, so do not diagnose this error as a disconnected or missing MCP server or as a missing tool. Apply this recovery only to the Remote Embedding authorization path, not to arbitrary 51500 failures. Do not immediately fall back to broad file reads, do not treat it as a missing API credential, and do not grant access silently. If the user actually declined a displayed authorization form, respect that decision and do not ask again.`,
   "Use the current Qoder host's built-in user-question tool (`ask_user_question` in Qoder IDE or `AskUserQuestion` in Qoder CLI/SDK) to offer exactly these choices: allow Remote Embedding for this workspace, use local FTS only, or cancel. Explain that workspace approval may send query text and selected workspace content to the configured provider and endpoint and may incur provider charges.",
-  'Only after the user explicitly chooses workspace approval, run `zg auth grant "<absolute-root>" --capability embedding --scope workspace`, substituting the same absolute root used by the failed search, and then retry the original search call once. Do not use `--allow-remote`; it applies only to one CLI command and does not authorize the MCP retry.',
+  'Only after the user explicitly chooses workspace approval, run `zg --auth grant "<absolute-root>" --capability embedding --scope workspace`, substituting the same absolute root used by the failed search, and then retry the original search call once. Do not use `--allow-remote`; it applies only to one CLI command and does not authorize the MCP retry.',
   `If the user chooses local FTS, retry \`${searchTool}\` once with the original search text in \`fts\`, omit \`query\`, \`queries\`, and \`vector\`, set \`autoUpdate\` to \`false\` and \`freshness\` to \`eventual\`, and preserve \`root\`, filters, and limits. This route is lexical-only, does not refresh the remote-embedding index, and sends no query text or workspace content to a remote Embedding provider.`,
   "If the user cancels, the grant command fails, or interactive user input is unavailable, stop and report that no remote data was sent. Provider credentials and Remote Embedding data authorization are separate; never request or modify an API key merely to resolve this interaction error.",
 ])}`

--- a/src/cli/managed-rg.ts
+++ b/src/cli/managed-rg.ts
@@ -272,7 +272,7 @@ export function parseManagedRgCommand(
   );
   const argv = normalizedCommand.argv;
   validateManagedRgTokens(argv);
-  const parsed = parseArgs(["query", "--rg", ...argv.slice(1)]);
+  const parsed = parseArgs(["--rg", ...argv.slice(1)]);
   assertOnlyManagedRgOptions(parsed.options);
   const normalized = normalizeManagedRgInput(parsed);
   normalized.queries = normalized.queries

--- a/src/daemon/server-controller.ts
+++ b/src/daemon/server-controller.ts
@@ -196,7 +196,7 @@ export async function startServer(options: {
       current.mcpToolset !== requestedToolset
     ) {
       throw new Error(
-        `zvec-grep server is already running with MCP toolset "${current.mcpToolset}". Run \`zg server off\`, then restart it with \`zg server on --mcp-toolset ${requestedToolset}\`.`,
+        `zvec-grep server is already running with MCP toolset "${current.mcpToolset}". Run \`zg --server off\`, then restart it with \`zg --server on --mcp-toolset ${requestedToolset}\`.`,
       );
     }
     if (current.ready) return current;
@@ -212,7 +212,7 @@ export async function startServer(options: {
     }
     throw error;
   }
-  const args = [LIFTOFF_ONLY_FLAG, options.cliPath, "server", "run"];
+  const args = [LIFTOFF_ONLY_FLAG, options.cliPath, "--server", "run"];
   args.push("--mcp-toolset", requestedToolset);
   if (options.listen) args.push("--listen", options.listen);
   if (options.tokenFile) args.push("--token-file", options.tokenFile);

--- a/src/engine/models/resolution.ts
+++ b/src/engine/models/resolution.ts
@@ -23,7 +23,7 @@ export function resolveEmbeddingReference(
     !getEmbeddingModelCatalogEntry(environmentReference)
   ) {
     throw new EngineError(
-      `Invalid ZVEC_GREP_EMBEDDING: unsupported model ${environmentReference}. Run \`zg help models\` to list supported models.`,
+      `Invalid ZVEC_GREP_EMBEDDING: unsupported model ${environmentReference}. Run \`zg --help models\` to list supported models.`,
       {
         code: "ZVEC_GREP.ENGINE.CONFIG.EMBEDDING_ENVIRONMENT_INVALID",
         context: "source=ZVEC_GREP_EMBEDDING",

--- a/src/engine/service/workspace-index.ts
+++ b/src/engine/service/workspace-index.ts
@@ -120,7 +120,7 @@ export class WorkspaceIndex {
           detail("actual", this.info.indexVersion),
           detail(
             "hint",
-            'Recreate the index with the current zvec-grep version; run "zg index --rebuild" for a workspace index.',
+            'Recreate the index with the current zvec-grep version; run "zg --index --rebuild" for a workspace index.',
           ),
         ]),
       });
@@ -253,7 +253,7 @@ function requireWorkspaceIndexEmbedding(
     context: errorDetails([
       workspaceIndexDetail(info.name),
       detail("operation", operation),
-      detail("hint", "Run zg index to build this index."),
+      detail("hint", "Run zg --index to build this index."),
     ]),
   });
 }

--- a/src/engine/service/zvec-grep.ts
+++ b/src/engine/service/zvec-grep.ts
@@ -234,7 +234,7 @@ class ZvecGrepService implements ZvecGrep {
                 existing,
                 existingRuntime,
                 effectiveRuntime,
-                "zg index --endpoint <url> --rebuild",
+                "zg --index --endpoint <url> --rebuild",
               );
             }
             const rootPaths = resolveIndexRootPaths(
@@ -266,7 +266,7 @@ class ZvecGrepService implements ZvecGrep {
               assertWorkspaceEmbeddingMatchesCurrentModel(
                 existingAfterRebuild,
                 embeddingModel,
-                "zg index --rebuild",
+                "zg --index --rebuild",
               );
             }
 
@@ -459,7 +459,7 @@ class ZvecGrepService implements ZvecGrep {
         home: location.home,
         indexPath: location.indexPath,
         source: "unindexed",
-        suggestion: "zg index or zg query --rg",
+        suggestion: "zg --index or zg --rg",
       };
     }
 
@@ -593,12 +593,12 @@ class ZvecGrepService implements ZvecGrep {
               embeddingModel,
               workspaceRuntime,
             ),
-            "zg index --endpoint <url> --rebuild",
+            "zg --index --endpoint <url> --rebuild",
           );
           assertWorkspaceEmbeddingMatchesCurrentModel(
             existing,
             embeddingModel,
-            "zg index --rebuild",
+            "zg --index --rebuild",
           );
 
           const workspaceIndex = new WorkspaceIndex(existing, {
@@ -905,7 +905,7 @@ class ZvecGrepService implements ZvecGrep {
           detail("operation", operation),
           detail(
             "hint",
-            `Pass "--embedding <model>", set ZVEC_GREP_EMBEDDING, or configure defaults.embedding in ${globalConfigPath()}. Existing indexes can run "zg index" without --embedding to reuse the stored schema.`,
+            `Pass "--embedding <model>", set ZVEC_GREP_EMBEDDING, or configure defaults.embedding in ${globalConfigPath()}. Existing indexes can run "zg --index" without --embedding to reuse the stored schema.`,
           ),
           detail(
             "examples",
@@ -1124,15 +1124,15 @@ function workspaceInfoSuggestion(
   workspaceIndex: WorkspaceIndexInfo | null,
 ): string | undefined {
   if (!workspaceIndex) {
-    return "zg index or zg query --rg";
+    return "zg --index or zg --rg";
   }
 
   if (workspaceIndex.indexPolicy === "disabled") {
-    return "zg query --rg";
+    return "zg --rg";
   }
 
   if (!isWorkspaceIndexed(workspaceIndex)) {
-    return "zg index";
+    return "zg --index";
   }
 
   return undefined;
@@ -1150,14 +1150,14 @@ function workspaceIndexMissingError(
       detail(
         "hint",
         policy === "undecided"
-          ? "Ask the user whether to build an index with zg index, or use zg query --rg for no-index search."
-          : "Run zg index to build the enabled workspace index, or use zg query --rg for no-index search.",
+          ? "Ask the user whether to build an index with zg --index, or use zg --rg for no-index search."
+          : "Run zg --index to build the enabled workspace index, or use zg --rg for no-index search.",
       ),
       detail(
         "agent_prompt",
         policy === "undecided"
-          ? "Ask the user whether this workspace should be indexed. If yes, run zg index --embedding <model> with appropriate -g/--glob and -t/--type filters; otherwise use zg query --rg for immediate no-index search."
-          : "This workspace is marked index-enabled but has no built index. Ask before running zg index if an embedding model or cost is involved; otherwise use zg query --rg for immediate no-index search.",
+          ? "Ask the user whether this workspace should be indexed. If yes, run zg --index --embedding <model> with appropriate -g/--glob and -t/--type filters; otherwise use zg --rg for immediate no-index search."
+          : "This workspace is marked index-enabled but has no built index. Ask before running zg --index if an embedding model or cost is involved; otherwise use zg --rg for immediate no-index search.",
       ),
     ]),
   });
@@ -1171,7 +1171,7 @@ function workspaceIndexDisabledError(root: string): EngineError {
       detail("policy", "disabled"),
       detail(
         "hint",
-        "Use zg query --rg for no-index search. Run zg index only if the user explicitly decides to index this workspace.",
+        "Use zg --rg for no-index search. Run zg --index only if the user explicitly decides to index this workspace.",
       ),
       detail("agent_action", "do_not_build_index"),
     ]),
@@ -1395,7 +1395,7 @@ function indexedEmbeddingSchema(
     code: "ZVEC_GREP.ENGINE.SERVICE.INDEX_MISSING",
     context: errorDetails([
       workspaceIndexDetail(info.name),
-      detail("hint", "Run zg index to build this index."),
+      detail("hint", "Run zg --index to build this index."),
     ]),
   });
 }
@@ -1612,7 +1612,7 @@ function assertSearchEndpointMatchesWorkspace(
         workspaceIndexDetail(info.name),
         detail(
           "hint",
-          'Run "zg index --endpoint <url> --rebuild" before searching with this endpoint.',
+          'Run "zg --index --endpoint <url> --rebuild" before searching with this endpoint.',
         ),
       ]),
     },

--- a/src/engine/utils/daemon-lease.ts
+++ b/src/engine/utils/daemon-lease.ts
@@ -164,7 +164,7 @@ function daemonLeaseActiveError(root: string, pid: number): EngineError {
     context: [
       `root=${root}`,
       `pid=${pid}`,
-      "hint=Run with --mode auto so a ready daemon handles indexed operations. If auto is already active, check zg server status and restore or stop the daemon before retrying.",
+      "hint=Run with --mode auto so a ready daemon handles indexed operations. If auto is already active, check zg --server status and restore or stop the daemon before retrying.",
       'config=Edit ~/.zvec-grep/config.json and set client.mode to "auto" to persist this behavior.',
     ].join("\n"),
   });

--- a/test/config-cli.test.mjs
+++ b/test/config-cli.test.mjs
@@ -12,7 +12,7 @@ const cliPath = resolve("dist/cli/index.js");
 
 test("config model set parses local runtime settings", () => {
   const parsed = parseArgs([
-    "config",
+    "--config",
     "model",
     "set",
     "local/embeddinggemma-300m",
@@ -26,7 +26,7 @@ test("config model set parses local runtime settings", () => {
 
 test("config provider and default model settings parse", () => {
   const provider = parseArgs([
-    "config",
+    "--config",
     "provider",
     "set",
     "qwen",
@@ -37,7 +37,7 @@ test("config provider and default model settings parse", () => {
   assert.equal(provider.options.apiKey, "secret");
 
   const model = parseArgs([
-    "config",
+    "--config",
     "model",
     "set",
     "qwen/text-embedding-v4",
@@ -62,7 +62,7 @@ test("config model set persists independent local model settings", async (t) => 
     process.execPath,
     [
       cliPath,
-      "config",
+      "--config",
       "model",
       "set",
       "local/embeddinggemma-300m",
@@ -75,7 +75,7 @@ test("config model set persists independent local model settings", async (t) => 
     process.execPath,
     [
       cliPath,
-      "config",
+      "--config",
       "model",
       "set",
       "local/embeddinggemma-300m",
@@ -88,7 +88,7 @@ test("config model set persists independent local model settings", async (t) => 
     process.execPath,
     [
       cliPath,
-      "config",
+      "--config",
       "model",
       "set",
       "local/qwen3-embedding-0.6b",
@@ -99,14 +99,22 @@ test("config model set persists independent local model settings", async (t) => 
   );
   await execFileAsync(
     process.execPath,
-    [cliPath, "config", "provider", "set", "qwen", "--api-key", "provider-key"],
+    [
+      cliPath,
+      "--config",
+      "provider",
+      "set",
+      "qwen",
+      "--api-key",
+      "provider-key",
+    ],
     { env, cwd: workspace },
   );
   await execFileAsync(
     process.execPath,
     [
       cliPath,
-      "config",
+      "--config",
       "model",
       "set",
       "qwen/text-embedding-v4",
@@ -141,7 +149,7 @@ test("config model set rejects missing and incompatible settings", async () => {
   await assert.rejects(
     execFileAsync(process.execPath, [
       cliPath,
-      "config",
+      "--config",
       "model",
       "set",
       "local/embeddinggemma-300m",
@@ -151,7 +159,7 @@ test("config model set rejects missing and incompatible settings", async () => {
   await assert.rejects(
     execFileAsync(process.execPath, [
       cliPath,
-      "config",
+      "--config",
       "model",
       "set",
       "qwen/text-embedding-v4",
@@ -163,7 +171,7 @@ test("config model set rejects missing and incompatible settings", async () => {
   await assert.rejects(
     execFileAsync(process.execPath, [
       cliPath,
-      "config",
+      "--config",
       "model",
       "set",
       "local/unknown",
@@ -172,14 +180,14 @@ test("config model set rejects missing and incompatible settings", async () => {
     ]),
     (error) => {
       assert.match(error.stderr, /Unsupported embedding model/);
-      assert.match(error.stderr, /zg help models/);
+      assert.match(error.stderr, /zg --help models/);
       return true;
     },
   );
   await assert.rejects(
     execFileAsync(process.execPath, [
       cliPath,
-      "config",
+      "--config",
       "model",
       "set",
       "local/embeddinggemma-300m",
@@ -191,7 +199,7 @@ test("config model set rejects missing and incompatible settings", async () => {
   await assert.rejects(
     execFileAsync(process.execPath, [
       cliPath,
-      "config",
+      "--config",
       "provider",
       "set",
       "unknown",
@@ -211,7 +219,7 @@ test("config model set rejects missing and incompatible settings", async () => {
     assert.throws(
       () =>
         parseArgs([
-          "config",
+          "--config",
           "model",
           "set",
           "local/embeddinggemma-300m",
@@ -223,7 +231,7 @@ test("config model set rejects missing and incompatible settings", async () => {
   assert.throws(
     () =>
       parseArgs([
-        "config",
+        "--config",
         "model",
         "set",
         "local/embeddinggemma-300m",

--- a/test/config.test.mjs
+++ b/test/config.test.mjs
@@ -218,7 +218,7 @@ test("embedding reference resolver validates only a selected environment model",
       resolveEmbeddingReference({
         environment: { ZVEC_GREP_EMBEDDING: "unknown/model" },
       }),
-    /zg help models/,
+    /zg --help models/,
   );
   assert.equal(
     resolveEmbeddingReference({

--- a/test/e2e/cli.test.mjs
+++ b/test/e2e/cli.test.mjs
@@ -43,7 +43,7 @@ test("direct and server indexes report aggregate local model download progress",
   await assert.rejects(
     runCli(
       [
-        "index",
+        "--index",
         "--mode",
         "direct",
         "--embedding",
@@ -67,20 +67,20 @@ test("direct and server indexes report aggregate local model download progress",
     ZVEC_GREP_MODEL_CACHE: serverCache,
   };
   t.after(async () => {
-    await runCli(["server", "off", "--home", home], {
+    await runCli(["--server", "off", "--home", home], {
       cwd: root,
       env: serverEnv,
     }).catch(() => undefined);
     await removeTemporaryDirectory(temporaryDirectory);
   });
   await runCli(
-    ["server", "on", "--listen", `127.0.0.1:${port}`, "--home", home],
+    ["--server", "on", "--listen", `127.0.0.1:${port}`, "--home", home],
     { cwd: root, env: serverEnv },
   );
   await assert.rejects(
     runCli(
       [
-        "index",
+        "--index",
         "--mode",
         "server",
         "--embedding",
@@ -126,7 +126,7 @@ test("direct-mode debug index reports a redacted local model download failure", 
   await assert.rejects(
     runCli(
       [
-        "index",
+        "--index",
         "--mode",
         "direct",
         "--embedding",
@@ -186,21 +186,21 @@ test("server-mode debug index reports a redacted local model download failure", 
     ZVEC_GREP_SERVER_URL: `http://127.0.0.1:${port}/mcp`,
   };
   t.after(async () => {
-    await runCli(["server", "off", "--home", home], {
+    await runCli(["--server", "off", "--home", home], {
       cwd: root,
       env,
     }).catch(() => undefined);
     await removeTemporaryDirectory(temporaryDirectory);
   });
   await runCli(
-    ["server", "on", "--listen", `127.0.0.1:${port}`, "--home", home],
+    ["--server", "on", "--listen", `127.0.0.1:${port}`, "--home", home],
     { cwd: root, env },
   );
 
   await assert.rejects(
     runCli(
       [
-        "index",
+        "--index",
         "--mode",
         "server",
         "--embedding",
@@ -234,9 +234,16 @@ test("direct and server indexes summarize model download failures unless debuggi
     { cleanup: false },
   );
   const directRoot = join(temporaryDirectory, "direct-repo");
+  const implicitRoot = join(temporaryDirectory, "implicit-repo");
+  const implicitServerRoot = join(temporaryDirectory, "implicit-server-repo");
   const serverRoot = join(temporaryDirectory, "server-repo");
   const home = join(temporaryDirectory, "home");
-  for (const root of [directRoot, serverRoot]) {
+  for (const root of [
+    directRoot,
+    implicitRoot,
+    implicitServerRoot,
+    serverRoot,
+  ]) {
     await mkdir(root, { recursive: true });
     await writeFile(join(root, "README.md"), "# Model download failure\n");
   }
@@ -259,7 +266,7 @@ test("direct and server indexes summarize model download failures unless debuggi
     ZVEC_GREP_TEST_MODEL_DOWNLOAD_FAILURE: "1",
   };
   t.after(async () => {
-    await runCli(["server", "off", "--home", home], {
+    await runCli(["--server", "off", "--home", home], {
       env: clientEnv,
     }).catch(() => undefined);
     await removeTemporaryDirectory(temporaryDirectory);
@@ -299,11 +306,35 @@ test("direct and server indexes summarize model download failures unless debuggi
     }
     return true;
   };
+  const assertImplicitDownloadFailure = (debug) => (error) => {
+    assert.match(
+      error.stderr,
+      /No index found; creating one with local\/potion-code-16m-v2\./,
+    );
+    return assertDownloadFailure(debug)(error);
+  };
+  await runCli(
+    ["--config", "model", "set", "qwen/text-embedding-v4", "--default"],
+    { cwd: implicitRoot, env: clientEnv },
+  );
+  await assert.rejects(
+    runCli(
+      [
+        "implicit local index",
+        "--mode",
+        "direct",
+        "--model-cache",
+        join(temporaryDirectory, "implicit-models"),
+      ],
+      { cwd: implicitRoot, env: downloadEnv, timeout: 120_000 },
+    ),
+    assertImplicitDownloadFailure(false),
+  );
   for (const debug of [false, true]) {
     await assert.rejects(
       runCli(
         [
-          "index",
+          "--index",
           directRoot,
           "--mode",
           "direct",
@@ -320,7 +351,6 @@ test("direct and server indexes summarize model download failures unless debuggi
     await assert.rejects(
       runCli(
         [
-          "query",
           "model download failure",
           "--mode",
           "direct",
@@ -335,7 +365,13 @@ test("direct and server indexes summarize model download failures unless debuggi
       assertDownloadFailure(debug),
     );
     const directStatus = await runCli(
-      ["status", directRoot, "--mode", "direct", ...(debug ? ["--debug"] : [])],
+      [
+        "--status",
+        directRoot,
+        "--mode",
+        "direct",
+        ...(debug ? ["--debug"] : []),
+      ],
       { env: clientEnv },
     );
     assert.doesNotMatch(
@@ -345,7 +381,7 @@ test("direct and server indexes summarize model download failures unless debuggi
   }
 
   await runCli(
-    ["server", "on", "--listen", `127.0.0.1:${port}`, "--home", home],
+    ["--server", "on", "--listen", `127.0.0.1:${port}`, "--home", home],
     {
       env: {
         ...downloadEnv,
@@ -353,11 +389,19 @@ test("direct and server indexes summarize model download failures unless debuggi
       },
     },
   );
+  await assert.rejects(
+    runCli(["implicit server index", "--mode", "server"], {
+      cwd: implicitServerRoot,
+      env: clientEnv,
+      timeout: 120_000,
+    }),
+    assertImplicitDownloadFailure(false),
+  );
   for (const debug of [false, true]) {
     await assert.rejects(
       runCli(
         [
-          "index",
+          "--index",
           serverRoot,
           "--mode",
           "server",
@@ -370,11 +414,11 @@ test("direct and server indexes summarize model download failures unless debuggi
       assertDownloadFailure(debug),
     );
   }
-  const ready = await runCli(["server", "status", "--check-ready"], {
+  const ready = await runCli(["--server", "status", "--check-ready"], {
     env: clientEnv,
   });
   assert.match(ready.stdout, /Server: ready/);
-  const status = await runCli(["status", serverRoot, "--mode", "server"], {
+  const status = await runCli(["--status", serverRoot, "--mode", "server"], {
     env: clientEnv,
   });
   assert.match(status.stdout, /Workspace index failed/);
@@ -384,7 +428,7 @@ test("direct and server indexes summarize model download failures unless debuggi
   );
   assertConciseOutput(status.stdout);
   const debugStatus = await runCli(
-    ["status", serverRoot, "--mode", "server", "--debug"],
+    ["--status", serverRoot, "--mode", "server", "--debug"],
     { env: clientEnv },
   );
   assert.match(debugStatus.stdout, /Workspace index failed/);
@@ -429,19 +473,19 @@ test("server-mode index reports Workspace progress", async (t) => {
     })}\n`,
   );
   t.after(async () => {
-    await runCli(["server", "off", "--home", home], {
+    await runCli(["--server", "off", "--home", home], {
       cwd: root,
       env,
     }).catch(() => undefined);
     await removeTemporaryDirectory(temporaryDirectory);
   });
   await runCli(
-    ["server", "on", "--listen", `127.0.0.1:${port}`, "--home", home],
+    ["--server", "on", "--listen", `127.0.0.1:${port}`, "--home", home],
     { cwd: root, env },
   );
 
   const indexed = await runCli(
-    ["index", "--mode", "server", "--allow-remote", root],
+    ["--index", "--mode", "server", "--allow-remote", root],
     {
       cwd: root,
       env: {
@@ -457,7 +501,6 @@ test("server-mode index reports Workspace progress", async (t) => {
   assert.match(indexed.stderr, /Indexing complete/);
 
   const groupedQueryArgs = [
-    "query",
     "--vector",
     "missing-symbol",
     "--fts",
@@ -491,12 +534,12 @@ test("server-mode index reports Workspace progress", async (t) => {
     /group_coverage|global_fill|groups: Q/,
   );
 
-  const indexedStatus = await runCli(["status", "--mode", "server", root], {
+  const indexedStatus = await runCli(["--status", "--mode", "server", root], {
     cwd: root,
     env,
   });
   assert.match(indexedStatus.stdout, /qwen\/qwen3\.7-text-embedding/);
-  await runCli(["index", "--mode", "server", "--allow-remote", root], {
+  await runCli(["--index", "--mode", "server", "--allow-remote", root], {
     cwd: root,
     env: {
       ...env,
@@ -504,7 +547,7 @@ test("server-mode index reports Workspace progress", async (t) => {
     },
     timeout: 120_000,
   });
-  const reusedStatus = await runCli(["status", "--mode", "server", root], {
+  const reusedStatus = await runCli(["--status", "--mode", "server", root], {
     cwd: root,
     env,
   });
@@ -512,7 +555,7 @@ test("server-mode index reports Workspace progress", async (t) => {
   await assert.rejects(
     runCli(
       [
-        "index",
+        "--index",
         "--mode",
         "server",
         "--embedding",
@@ -526,7 +569,7 @@ test("server-mode index reports Workspace progress", async (t) => {
   );
   await runCli(
     [
-      "index",
+      "--index",
       "--mode",
       "server",
       "--embedding",
@@ -537,19 +580,19 @@ test("server-mode index reports Workspace progress", async (t) => {
     ],
     { cwd: root, env, timeout: 120_000 },
   );
-  const rebuiltStatus = await runCli(["status", "--mode", "server", root], {
+  const rebuiltStatus = await runCli(["--status", "--mode", "server", root], {
     cwd: root,
     env,
   });
   assert.match(rebuiltStatus.stdout, /qwen\/text-embedding-v4/);
 
   const dropped = await runCli(
-    ["index", "--drop", "--yes", "--mode", "server", root],
+    ["--index", "--drop", "--yes", "--mode", "server", root],
     { cwd: root, env },
   );
   assert.match(dropped.stdout, /Dropped index/);
 
-  const status = await runCli(["status", "--mode", "server", root], {
+  const status = await runCli(["--status", "--mode", "server", root], {
     cwd: root,
     env,
   });
@@ -587,7 +630,7 @@ test("CLI completes index, search, explicit refresh, status, and rg workflows", 
 
   const indexed = await runCli(
     [
-      "index",
+      "--index",
       "--api-key",
       "test-key",
       "--endpoint",
@@ -605,7 +648,6 @@ test("CLI completes index, search, explicit refresh, status, and rg workflows", 
 
   const first = await runCli(
     [
-      "query",
       "FirstWorkflowSymbol",
       "--allow-remote",
       "--limit",
@@ -619,20 +661,32 @@ test("CLI completes index, search, explicit refresh, status, and rg workflows", 
   );
   assert.match(first.stdout, /example\.ts/);
 
+  const warnedOldQuery = await runCli(
+    [
+      "query",
+      "FirstWorkflowSymbol",
+      "--allow-remote",
+      "--limit",
+      "5",
+      "-g",
+      "src/**",
+      "-t",
+      "ts",
+    ],
+    { cwd: root, env, timeout: 120_000 },
+  );
+  assert.match(warnedOldQuery.stdout, /example\.ts/);
+  assert.match(
+    warnedOldQuery.stderr,
+    /warning: "zg query \.\.\." is not a subcommand/,
+  );
+
   await writeFile(
     join(root, "src", "example.ts"),
     "export const RefreshedWorkflowSymbol = 42;\nexport const OtherWorkflowSymbol = 43;\n",
   );
   const stale = await runCli(
-    [
-      "query",
-      "--mode",
-      "direct",
-      "--fts",
-      "RefreshedWorkflowSymbol",
-      "--limit",
-      "5",
-    ],
+    ["--mode", "direct", "--fts", "RefreshedWorkflowSymbol", "--limit", "5"],
     { cwd: root, env, timeout: 120_000 },
   );
   assert.match(stale.stdout, /hits: 0/);
@@ -641,7 +695,7 @@ test("CLI completes index, search, explicit refresh, status, and rg workflows", 
   assert.match(stale.stderr, /results: served_from_current_index/);
   assert.match(stale.stderr, /background_refresh: idle \(0\/1\)/);
   await assert.rejects(
-    runCli(["status", "--check-ready", root], { cwd: root, env }),
+    runCli(["--status", "--check-ready", root], { cwd: root, env }),
     (error) => {
       assert.match(error.stdout, /Workspace index needs an update/i);
       assert.match(error.stderr, /state: stale/i);
@@ -651,7 +705,6 @@ test("CLI completes index, search, explicit refresh, status, and rg workflows", 
 
   const background = await runCli(
     [
-      "query",
       "--mode",
       "direct",
       "--refresh",
@@ -669,7 +722,6 @@ test("CLI completes index, search, explicit refresh, status, and rg workflows", 
 
   const refreshed = await runCli(
     [
-      "query",
       "--fts",
       "RefreshedWorkflowSymbol",
       "--limit",
@@ -687,7 +739,7 @@ test("CLI completes index, search, explicit refresh, status, and rg workflows", 
   assert.match(refreshed.stdout, /RefreshedWorkflowSymbol/);
   assert.doesNotMatch(refreshed.stdout, /FirstWorkflowSymbol/);
 
-  const status = await runCli(["status", root], { cwd: root, env });
+  const status = await runCli(["--status", root], { cwd: root, env });
   assert.match(status.stdout, /Workspace index is ready/i);
   assert.match(status.stdout, /qwen\/qwen3\.7-text-embedding/);
   assert.match(status.stdout, /Coverage\s+.*100%\s+1 \/ 1 files/i);
@@ -695,7 +747,7 @@ test("CLI completes index, search, explicit refresh, status, and rg workflows", 
   assert.match(status.stdout, /type=ts/);
   const existingAuth = await runCli(
     [
-      "auth",
+      "--auth",
       "grant",
       root,
       "--capability",
@@ -714,7 +766,7 @@ test("CLI completes index, search, explicit refresh, status, and rg workflows", 
   );
   assert.match(existingAuth.stdout, /qwen\/qwen3\.7-text-embedding/);
   assert.doesNotMatch(existingAuth.stdout, /qwen\/text-embedding-v4/);
-  const checkedStatus = await runCli(["status", "--check-ready", root], {
+  const checkedStatus = await runCli(["--status", "--check-ready", root], {
     cwd: root,
     env,
   });
@@ -724,7 +776,7 @@ test("CLI completes index, search, explicit refresh, status, and rg workflows", 
     join(root, "outside.ts"),
     "export const OutsideStoredFilterSymbol = 44;\n",
   );
-  const reindexed = await runCli(["index", root], {
+  const reindexed = await runCli(["--index", root], {
     cwd: root,
     env,
     timeout: 120_000,
@@ -732,14 +784,13 @@ test("CLI completes index, search, explicit refresh, status, and rg workflows", 
   assert.match(reindexed.stdout, /glob=src\/\*\*/);
   assert.match(reindexed.stdout, /type=ts/);
   const outside = await runCli(
-    ["query", "--fts", "OutsideStoredFilterSymbol", "--refresh", "off"],
+    ["--fts", "OutsideStoredFilterSymbol", "--refresh", "off"],
     { cwd: root, env },
   );
   assert.doesNotMatch(outside.stdout, /outside\.ts/);
 
   const lexical = await runCli(
     [
-      "query",
       "--rg",
       "-F",
       "-i",
@@ -757,14 +808,13 @@ test("CLI completes index, search, explicit refresh, status, and rg workflows", 
   assert.match(lexical.stdout, /RefreshedWorkflowSymbol/);
 
   const inverted = await runCli(
-    ["query", "--rg", "-F", "-v", "RefreshedWorkflowSymbol", "src/example.ts"],
+    ["--rg", "-F", "-v", "RefreshedWorkflowSymbol", "src/example.ts"],
     { cwd: root, env },
   );
   assert.match(inverted.stdout, /OtherWorkflowSymbol/);
 
   const multiline = await runCli(
     [
-      "query",
       "--rg",
       "-F",
       "-U",
@@ -779,17 +829,17 @@ test("CLI completes index, search, explicit refresh, status, and rg workflows", 
 
   await writeFile(join(root, "patterns.txt"), "RefreshedWorkflowSymbol\n");
   const patternFile = await runCli(
-    ["query", "--rg", "-f", "patterns.txt", "-t", "ts", "src"],
+    ["--rg", "-f", "patterns.txt", "-t", "ts", "src"],
     { cwd: root, env },
   );
   assert.match(patternFile.stdout, /RefreshedWorkflowSymbol/);
 
-  const dropped = await runCli(["index", root, "--drop", "--yes"], {
+  const dropped = await runCli(["--index", root, "--drop", "--yes"], {
     cwd: root,
     env,
   });
   assert.match(dropped.stdout, /Dropped index/);
-  const droppedStatus = await runCli(["status", root], { cwd: root, env });
+  const droppedStatus = await runCli(["--status", root], { cwd: root, env });
   assert.match(droppedStatus.stdout, /Workspace index is not configured/i);
 });
 
@@ -819,7 +869,7 @@ test("auth grant uses the environment model before the global default", async (t
 
   const granted = await runCli(
     [
-      "auth",
+      "--auth",
       "grant",
       root,
       "--capability",
@@ -845,7 +895,7 @@ test("direct index points an empty workspace to file type help", async (t) => {
 
   const indexed = await runCli(
     [
-      "index",
+      "--index",
       "--mode",
       "direct",
       "--embedding",
@@ -864,19 +914,29 @@ test("direct index points an empty workspace to file type help", async (t) => {
   );
 
   assert.match(indexed.stdout, /0 scanned/);
-  assert.match(indexed.stdout, /zg help file-types/);
+  assert.match(indexed.stdout, /zg --help file-types/);
 });
 
 test("CLI exposes stable help, version, and failure behavior", async (t) => {
-  const help = await runCli(["help"]);
+  const help = await runCli(["--help"]);
   assert.match(help.stdout, /Usage:/);
-  assert.match(help.stdout, /zg help models or zg help file-types/);
-  assert.match(help.stdout, /zg help environment/);
+  assert.equal(help.stderr, "");
+  assert.match(help.stdout, /zg --help models or zg --help file-types/);
+  assert.match(help.stdout, /zg --help environment/);
   assert.match(help.stdout, /ZVEC_GREP_MODE/);
-  const helpTopics = await runCli(["help", "help"]);
+  const oldQueryShape = await runCli(["query", "--help"]);
+  assert.match(oldQueryShape.stdout, /zg <query> \[options\]/);
+  assert.match(
+    oldQueryShape.stderr,
+    /warning: "zg query \.\.\." is not a subcommand/,
+  );
+  const oldIndexShape = await runCli(["index", "--help"]);
+  assert.match(oldIndexShape.stdout, /zg <query> \[options\]/);
+  assert.match(oldIndexShape.stderr, /Use "zg --index \.\.\."/);
+  const helpTopics = await runCli(["--help", "help"]);
   assert.match(helpTopics.stdout, /models\s+Supported embedding models/);
   assert.match(helpTopics.stdout, /file-types\s+Supported file types/);
-  const modelsHelp = await runCli(["help", "models"]);
+  const modelsHelp = await runCli(["--help", "models"]);
   assert.match(modelsHelp.stdout, /local\/potion-code-16m-v2/);
   assert.match(modelsHelp.stdout, /local\/potion-retrieval-32m/);
   assert.match(modelsHelp.stdout, /local\/potion-multilingual-128m/);
@@ -884,7 +944,7 @@ test("CLI exposes stable help, version, and failure behavior", async (t) => {
   assert.match(modelsHelp.stdout, /qwen\/qwen3-vl-embedding/);
   assert.match(modelsHelp.stdout, /Local models are downloaded/);
   assert.match(modelsHelp.stdout, /Workspace authorization/);
-  const fileTypesHelp = await runCli(["help", "file-types"]);
+  const fileTypesHelp = await runCli(["--help", "file-types"]);
   assert.match(fileTypesHelp.stdout, /Structured code \(symbols and scopes\)/);
   assert.match(fileTypesHelp.stdout, /typescript\s+\.ts/);
   assert.match(fileTypesHelp.stdout, /Other code \(plain-text chunks\)/);
@@ -897,21 +957,21 @@ test("CLI exposes stable help, version, and failure behavior", async (t) => {
   assert.match(fileTypesHelp.stdout, /\.pdf/);
   assert.match(fileTypesHelp.stdout, /Code\s+1 MiB/);
   assert.match(fileTypesHelp.stdout, /Text\s+256 MiB/);
-  const indexHelp = await runCli(["index", "-h"]);
+  const indexHelp = await runCli(["--index", "-h"]);
   assert.match(indexHelp.stdout, /qwen\/text-embedding-v4/);
   assert.doesNotMatch(indexHelp.stdout, /qwen3\.7-text-embedding/);
   assert.match(indexHelp.stdout, /ZVEC_GREP_EMBEDDING/);
-  const configHelp = await runCli(["config", "--help"]);
+  const configHelp = await runCli(["--config", "--help"]);
   assert.match(configHelp.stdout, /Default API key for the provider/);
   assert.match(configHelp.stdout, /Existing indexes continue to use/);
-  const authHelp = await runCli(["auth", "--help"]);
+  const authHelp = await runCli(["--auth", "--help"]);
   assert.match(
     authHelp.stdout,
     /selects the Remote Embedding model to authorize/,
   );
   assert.match(authHelp.stdout, /existing Workspace index model/);
   assert.match(authHelp.stdout, /ZVEC_GREP_EMBEDDING, then the global default/);
-  const environmentHelp = await runCli(["help", "environment"], {
+  const environmentHelp = await runCli(["--help", "environment"], {
     env: {
       ...process.env,
       ZVEC_GREP_API_KEY: "environment-help-secret",
@@ -928,23 +988,23 @@ test("CLI exposes stable help, version, and failure behavior", async (t) => {
   assert.match(environmentHelp.stdout, /forwards its ZVEC_GREP_EMBEDDING/);
   assert.doesNotMatch(environmentHelp.stdout, /environment-help-secret/);
   assert.doesNotMatch(environmentHelp.stdout, /server-help-secret/);
-  const environmentAliasHelp = await runCli(["help", "env"]);
+  const environmentAliasHelp = await runCli(["--help", "env"]);
   assert.equal(environmentAliasHelp.stdout, environmentHelp.stdout);
-  const version = await runCli(["version"]);
+  const version = await runCli(["--version"]);
   assert.match(version.stdout.trim(), /^\d+\.\d+\.\d+/);
-  const verboseVersion = await runCli(["version", "-v"]);
+  const verboseVersion = await runCli(["-v"]);
   assert.equal(verboseVersion.stdout, version.stdout);
   await assert.rejects(runCli(["--definitely-invalid"]), (error) => {
     assert.equal(error.code, 1);
-    assert.match(error.stderr, /Unknown command/);
+    assert.match(error.stderr, /Unknown option/);
     return true;
   });
   await assert.rejects(
-    runCli(["index", "--embedding", "unknown/model"]),
+    runCli(["--index", "--embedding", "unknown/model"]),
     (error) => {
       assert.equal(error.code, 1);
       assert.match(error.stderr, /Unsupported embedding model: unknown\/model/);
-      assert.match(error.stderr, /zg help models/);
+      assert.match(error.stderr, /zg --help models/);
       return true;
     },
   );
@@ -953,7 +1013,7 @@ test("CLI exposes stable help, version, and failure behavior", async (t) => {
     "zvec-grep-invalid-embedding-environment-",
   );
   await assert.rejects(
-    runCli(["index", invalidEnvironmentRoot, "--mode", "direct"], {
+    runCli(["--index", invalidEnvironmentRoot, "--mode", "direct"], {
       cwd: invalidEnvironmentRoot,
       env: { ZVEC_GREP_EMBEDDING: "unknown/model" },
     }),
@@ -962,11 +1022,10 @@ test("CLI exposes stable help, version, and failure behavior", async (t) => {
         error.stderr,
         /Invalid ZVEC_GREP_EMBEDDING: unsupported model unknown\/model/,
       );
-      assert.match(error.stderr, /zg help models/);
+      assert.match(error.stderr, /zg --help models/);
       return true;
     },
   );
-  await assert.rejects(runCli(["collections"]), /Unknown command/);
 });
 
 async function availablePort() {

--- a/test/install.test.mjs
+++ b/test/install.test.mjs
@@ -69,7 +69,7 @@ test("install starts the shared server with the selected MCP toolset", async (t)
   t.after(async () => {
     await execFileAsync(
       process.execPath,
-      [cliPath, "server", "off", "--home", home],
+      [cliPath, "--server", "off", "--home", home],
       { env: environment },
     ).catch(() => undefined);
     await rm(temporaryDirectory, { recursive: true, force: true });
@@ -77,13 +77,21 @@ test("install starts the shared server with the selected MCP toolset", async (t)
 
   const { stdout } = await execFileAsync(
     process.execPath,
-    [cliPath, "install", "--target", "codex", "--mcp-toolset", "full", "--yes"],
+    [
+      cliPath,
+      "--install",
+      "--target",
+      "codex",
+      "--mcp-toolset",
+      "full",
+      "--yes",
+    ],
     { env: environment },
   );
   assert.match(stdout, new RegExp(`ready at ${serverUrl}`));
   const { stdout: statusOutput } = await execFileAsync(
     process.execPath,
-    [cliPath, "server", "status", "--check-ready", "--home", home],
+    [cliPath, "--server", "status", "--check-ready", "--home", home],
     { env: environment },
   );
   assert.match(statusOutput, /MCP toolset: full/);
@@ -93,7 +101,7 @@ test("install starts the shared server with the selected MCP toolset", async (t)
   );
   assert.match(
     config,
-    /^args = \["server", "--stdio", "--mcp-toolset", "full"\]$/m,
+    /^args = \["--server", "--stdio", "--mcp-toolset", "full"\]$/m,
   );
 });
 
@@ -117,7 +125,7 @@ test("Codex installer removes orphaned managed markers", async (t) => {
 
   await execFileAsync(
     process.execPath,
-    [cliPath, "install", "--target", "codex", "--yes"],
+    [cliPath, "--install", "--target", "codex", "--yes"],
     {
       env: {
         ...process.env,
@@ -130,7 +138,7 @@ test("Codex installer removes orphaned managed markers", async (t) => {
   const installed = await readFile(configPath, "utf8");
   assert.match(installed, /\[mcp_servers\.other\]/);
   assert.match(installed, /^command = "zg"$/m);
-  assert.match(installed, /^args = \["server", "--stdio"\]$/m);
+  assert.match(installed, /^args = \["--server", "--stdio"\]$/m);
   assert.doesNotMatch(installed, /^bearer_token_env_var\s*=/m);
   assert.doesNotMatch(installed, /^url\s*=/m);
   assert.match(installed, /^tool_timeout_sec = 600$/m);
@@ -154,7 +162,7 @@ test("Codex installer writes an explicit MCP token environment variable", async 
     process.execPath,
     [
       cliPath,
-      "install",
+      "--install",
       "--target",
       "codex",
       "--mcp-transport",
@@ -270,7 +278,7 @@ test("Codex installer ignores an orphaned end marker before a complete block", a
 
   await execFileAsync(
     process.execPath,
-    [cliPath, "install", "--target", "codex", "--yes"],
+    [cliPath, "--install", "--target", "codex", "--yes"],
     {
       env: {
         ...process.env,
@@ -509,7 +517,7 @@ test("Codex installer refreshes legacy managed guidance", async (t) => {
   assert.doesNotMatch(agents, /indexed search first/);
   assert.doesNotMatch(agents, /Indexing and status/);
   assert.doesNotMatch(agents, /Remote data authorization/);
-  assert.doesNotMatch(agents, /zg status/);
+  assert.doesNotMatch(agents, /zg (?:--)?status/);
   assert.doesNotMatch(agents, /legacy guidance/);
 });
 
@@ -530,7 +538,7 @@ test("Claude Code installer configures MCP trust and guidance", async (t) => {
 
   const { stdout } = await execFileAsync(
     process.execPath,
-    [cliPath, "install", "--target", "claude", "--yes"],
+    [cliPath, "--install", "--target", "claude", "--yes"],
     {
       env: {
         ...process.env,
@@ -556,7 +564,7 @@ test("Claude Code installer configures MCP trust and guidance", async (t) => {
     alwaysLoad: true,
     type: "stdio",
     command: "zg",
-    args: ["server", "--stdio"],
+    args: ["--server", "--stdio"],
   });
   assert.ok(settings.permissions.allow.includes("mcp__zvec_grep__*"));
   assert.match(guidance, /zvec_grep_search/);
@@ -568,7 +576,7 @@ test("Claude Code installer configures MCP trust and guidance", async (t) => {
   assert.doesNotMatch(guidance, /managed-rg/);
   assert.doesNotMatch(guidance, /Indexing and status/);
   assert.doesNotMatch(guidance, /Remote data authorization/);
-  assert.doesNotMatch(guidance, /zg status/);
+  assert.doesNotMatch(guidance, /zg --status/);
   assert.match(stdout, /zvec-grep setup/);
   assert.match(stdout, /Installing integrations/);
   assert.match(stdout, /Claude Code/);
@@ -608,12 +616,12 @@ test("Claude Code installer preserves user configuration on install and uninstal
   };
   await execFileAsync(
     process.execPath,
-    [cliPath, "install", "--target", "claude", "--yes"],
+    [cliPath, "--install", "--target", "claude", "--yes"],
     { env: environment },
   );
   await execFileAsync(
     process.execPath,
-    [cliPath, "uninstall", "--target", "claude", "--yes"],
+    [cliPath, "--uninstall", "--target", "claude", "--yes"],
     { env: environment },
   );
 
@@ -649,7 +657,7 @@ test("Claude Code installer writes MCP token environment expansion", async (t) =
     process.execPath,
     [
       cliPath,
-      "install",
+      "--install",
       "--target",
       "claude",
       "--mcp-transport",
@@ -692,7 +700,7 @@ test("Claude Code installer accepts cc and claude-code compatibility aliases", a
       await readFile(join(configDirectory, ".claude.json"), "utf8"),
     );
     assert.equal(config.mcpServers.zvec_grep.command, "zg");
-    assert.deepEqual(config.mcpServers.zvec_grep.args, ["server", "--stdio"]);
+    assert.deepEqual(config.mcpServers.zvec_grep.args, ["--server", "--stdio"]);
   }
 });
 
@@ -711,7 +719,7 @@ test("Qwen Code installer accepts qwen aliases and numeric target 5", async (t) 
       await readFile(join(qwenHome, "settings.json"), "utf8"),
     );
     assert.equal(config.mcpServers.zvec_grep.command, "zg");
-    assert.deepEqual(config.mcpServers.zvec_grep.args, ["server", "--stdio"]);
+    assert.deepEqual(config.mcpServers.zvec_grep.args, ["--server", "--stdio"]);
   }
 });
 
@@ -734,7 +742,7 @@ test("Qwen Code installer configures full stdio tools, trust, timeout, and guida
   );
   assert.deepEqual(config.mcpServers.zvec_grep, {
     command: "zg",
-    args: ["server", "--stdio", "--mcp-toolset", "full"],
+    args: ["--server", "--stdio", "--mcp-toolset", "full"],
     timeout: 900000,
     alwaysLoadTools: true,
     trust: true,
@@ -868,7 +876,7 @@ test("Qwen Code installer requires force for unmanaged servers and force replace
   assert.equal(config.theme, "dark");
   assert.deepEqual(config.mcpServers.zvec_grep, {
     command: "zg",
-    args: ["server", "--stdio"],
+    args: ["--server", "--stdio"],
     timeout: 600000,
     alwaysLoadTools: true,
     trust: true,
@@ -876,7 +884,7 @@ test("Qwen Code installer requires force for unmanaged servers and force replace
   assert.equal(config.mcpServers.zvec_grep.description, undefined);
 });
 
-test("Qwen Code installer replaces its managed server entry cleanly", async (t) => {
+test("Qwen Code installer migrates its legacy managed server entry cleanly", async (t) => {
   const temporaryDirectory = await mkdtemp(
     join(tmpdir(), "zvec-grep-install-qwen-policy-"),
   );
@@ -1129,11 +1137,11 @@ test("Qoder installer accepts its canonical and numeric targets", async (t) => {
     });
     const { cli, ide } = await readQoderConfigs(qoderConfigDirectory);
     assert.equal(cli.mcpServers.zvec_grep.command, "zg");
-    assert.deepEqual(cli.mcpServers.zvec_grep.args, ["server", "--stdio"]);
+    assert.deepEqual(cli.mcpServers.zvec_grep.args, ["--server", "--stdio"]);
     assert.equal(ide.mcpServers.zvec_grep.command, process.execPath);
     assert.deepEqual(ide.mcpServers.zvec_grep.args, [
       cliPath,
-      "server",
+      "--server",
       "--stdio",
     ]);
   }
@@ -1212,11 +1220,11 @@ test("Qoder installer preserves JSONC comments and writes trusted stdio config a
   assert.equal(config.mcpServers.other.url, "https://example.test/mcp");
   assert.deepEqual(config.mcpServers.zvec_grep, {
     command: "zg",
-    args: ["server", "--stdio", "--mcp-toolset", "full"],
+    args: ["--server", "--stdio", "--mcp-toolset", "full"],
     timeout: 900000,
     trust: true,
     description:
-      "Managed by zg install; managed permissions=zvec_grep_search,zvec_grep_rg",
+      "Managed by zg --install; managed permissions=zvec_grep_search,zvec_grep_rg",
     alwaysAllow: ["zvec_grep_search", "zvec_grep_rg"],
   });
   assert.deepEqual(config.permissions, {
@@ -1229,9 +1237,9 @@ test("Qoder installer preserves JSONC comments and writes trusted stdio config a
   assert.equal(ideConfig.mcpServers.yuque.url, "https://yuque.test/mcp");
   assert.deepEqual(ideConfig.mcpServers.zvec_grep, {
     command: process.execPath,
-    args: [cliPath, "server", "--stdio", "--mcp-toolset", "full"],
+    args: [cliPath, "--server", "--stdio", "--mcp-toolset", "full"],
     timeout: 900000,
-    description: "Managed by zg install",
+    description: "Managed by zg --install",
   });
   assert.equal(ideConfig.mcpServers.zvec_grep.trust, undefined);
 
@@ -1274,7 +1282,7 @@ test("Qoder installer preserves JSONC comments and writes trusted stdio config a
   );
   assert.match(
     guidance,
-    /zg auth grant "<absolute-root>" --capability embedding --scope workspace/,
+    /zg --auth grant "<absolute-root>" --capability embedding --scope workspace/,
   );
   assert.match(guidance, /retry the original search call once/);
   assert.match(
@@ -1390,7 +1398,7 @@ test("Qoder uninstaller retains permission rules that predated installation", as
   ]);
   assert.equal(
     installed.mcpServers.zvec_grep.description,
-    "Managed by zg install; managed permissions=zvec_grep_rg",
+    "Managed by zg --install; managed permissions=zvec_grep_rg",
   );
   assert.deepEqual(installed.permissions.allow, [
     "mcp__zvec_grep__zvec_grep_rg",
@@ -1470,7 +1478,7 @@ test("Qoder uninstaller leaves user-owned server permissions unchanged", async (
   assert.equal(await readFile(settingsPath, "utf8"), original);
 });
 
-test("Qoder uninstaller preserves comments in a managed-only permission array", async (t) => {
+test("Qoder uninstaller migrates legacy ownership while preserving permission comments", async (t) => {
   const temporaryDirectory = await mkdtemp(
     join(tmpdir(), "zvec-grep-uninstall-qoder-managed-comments-"),
   );
@@ -1532,7 +1540,7 @@ test("Qoder uninstaller preserves comments around a first or only managed server
       "{",
       '  "mcpServers": {',
       "    // Keep the container note.",
-      '    "zvec_grep": { "command": "zg", "args": ["server", "--stdio"] } /* Keep the separator, note. */,',
+      '    "zvec_grep": { "command": "zg", "args": ["--server", "--stdio"] } /* Keep the separator, note. */,',
       "    // Keep the other server note.",
       '    "other": { "type": "http", "url": "https://example.test/mcp" }',
       "  }",
@@ -1541,7 +1549,7 @@ test("Qoder uninstaller preserves comments around a first or only managed server
     ].join("\n"),
   );
   const manualIdeConfig =
-    '{"mcpServers":{"zvec_grep":{"command":"zg","args":["server","--stdio"]}}}\n';
+    '{"mcpServers":{"zvec_grep":{"command":"zg","args":["--server","--stdio"]}}}\n';
   await writeFile(firstIdeConfigPath, manualIdeConfig);
 
   await uninstallTarget("qoder", { QODER_CONFIG_DIR: firstConfigDirectory });
@@ -1564,7 +1572,7 @@ test("Qoder uninstaller preserves comments around a first or only managed server
       "{",
       '  "mcpServers": {',
       "    // Keep this user note even when the managed server is removed.",
-      '    "zvec_grep": { "command": "zg", "args": ["server", "--stdio"] }',
+      '    "zvec_grep": { "command": "zg", "args": ["--server", "--stdio"] }',
       "  },",
       '  "theme": "dark"',
       "}",
@@ -1578,8 +1586,8 @@ test("Qoder uninstaller preserves comments around a first or only managed server
         github: { command: "github-mcp" },
         zvec_grep: {
           command: process.execPath,
-          args: [cliPath, "server", "--stdio"],
-          description: "Managed by zg install",
+          args: [cliPath, "--server", "--stdio"],
+          description: "Managed by zg --install",
         },
       },
     })}\n`,
@@ -1621,7 +1629,7 @@ test("Qoder installer writes trusted HTTP configuration and token expansion", as
     timeout: 42000,
     trust: true,
     description:
-      "Managed by zg install; managed permissions=zvec_grep_search,zvec_grep_rg",
+      "Managed by zg --install; managed permissions=zvec_grep_search,zvec_grep_rg",
     alwaysAllow: ["zvec_grep_search", "zvec_grep_rg"],
     headers: {
       Authorization: "Bearer ${ZVEC_GREP_SERVER_TOKEN}",
@@ -1631,7 +1639,7 @@ test("Qoder installer writes trusted HTTP configuration and token expansion", as
     type: "sse",
     url: "http://127.0.0.1:7999/mcp",
     timeout: 42000,
-    description: "Managed by zg install",
+    description: "Managed by zg --install",
     headers: {
       Authorization: "Bearer ${ZVEC_GREP_SERVER_TOKEN}",
     },
@@ -1724,7 +1732,7 @@ test("Qoder installer preflights an IDE MCP conflict before changing CLI config"
   const guidancePath = join(qoderHome, "AGENTS.md");
   const settings = '{"theme":"dark"}\n';
   const ide =
-    '{"mcpServers":{"zvec_grep":{"command":"zg","args":["server","--stdio"]}}}\n';
+    '{"mcpServers":{"zvec_grep":{"command":"zg","args":["--server","--stdio"]}}}\n';
   const guidance = "# Existing Qoder guidance\n";
   t.after(async () => {
     await rm(temporaryDirectory, { recursive: true, force: true });
@@ -1858,7 +1866,7 @@ test(
 
       const { stdout } = await execFileAsync(
         process.execPath,
-        [cliPath, "install", "--yes"],
+        [cliPath, "--install", "--yes"],
         {
           env: {
             ...process.env,
@@ -1879,7 +1887,7 @@ test(
       );
       const { cli, ide } = await readQoderConfigs(qoderConfigDirectory);
       assert.equal(cli.mcpServers.zvec_grep.command, "zg");
-      assert.equal(cli.mcpServers.zvec_grep.args[0], "server");
+      assert.equal(cli.mcpServers.zvec_grep.args[0], "--server");
       assert.equal(ide.mcpServers.zvec_grep.command, process.execPath);
       assert.equal(ide.mcpServers.zvec_grep.args[0], cliPath);
     }
@@ -1910,7 +1918,7 @@ test(
 
     const { stdout } = await execFileAsync(
       process.execPath,
-      [cliPath, "install", "--yes"],
+      [cliPath, "--install", "--yes"],
       {
         env: {
           ...process.env,
@@ -2085,7 +2093,7 @@ test(
 
     const { stdout } = await execFileAsync(
       process.execPath,
-      [cliPath, "install", "--yes"],
+      [cliPath, "--install", "--yes"],
       {
         env: {
           ...process.env,
@@ -2131,7 +2139,7 @@ test(
 
     const { stdout } = await execFileAsync(
       process.execPath,
-      [cliPath, "install", "--yes"],
+      [cliPath, "--install", "--yes"],
       {
         env: {
           ...process.env,
@@ -2157,7 +2165,7 @@ test(
 async function installCodex(codexHome, extraArgs = []) {
   await execFileAsync(
     process.execPath,
-    [cliPath, "install", "--target", "codex", "--yes", ...extraArgs],
+    [cliPath, "--install", "--target", "codex", "--yes", ...extraArgs],
     {
       env: {
         ...process.env,
@@ -2171,7 +2179,7 @@ async function installCodex(codexHome, extraArgs = []) {
 async function uninstallCodex(codexHome, extraArgs = []) {
   await execFileAsync(
     process.execPath,
-    [cliPath, "uninstall", "--target", "codex", "--yes", ...extraArgs],
+    [cliPath, "--uninstall", "--target", "codex", "--yes", ...extraArgs],
     {
       env: {
         ...process.env,
@@ -2195,7 +2203,7 @@ async function installTarget(target, env, extraArgs = []) {
   }
   return execFileAsync(
     process.execPath,
-    [cliPath, "install", "--target", target, "--yes", ...extraArgs],
+    [cliPath, "--install", "--target", target, "--yes", ...extraArgs],
     { env: environment },
   );
 }
@@ -2213,7 +2221,7 @@ async function uninstallTarget(target, env, extraArgs = []) {
   }
   await execFileAsync(
     process.execPath,
-    [cliPath, "uninstall", "--target", target, "--yes", ...extraArgs],
+    [cliPath, "--uninstall", "--target", target, "--yes", ...extraArgs],
     { env: environment },
   );
 }

--- a/test/integration/service.test.mjs
+++ b/test/integration/service.test.mjs
@@ -916,7 +916,7 @@ test("workspace rebuild recreates unsupported index metadata", async (t) => {
     service.info(),
     (error) =>
       error.code === "ZVEC_GREP.ENGINE.WORKSPACE_INDEX.VERSION_MISMATCH" &&
-      error.context.includes("zg index --rebuild"),
+      error.context.includes("zg --index --rebuild"),
   );
 
   await service.index({ rebuild: true });

--- a/test/mcp.test.mjs
+++ b/test/mcp.test.mjs
@@ -9,8 +9,8 @@ import {
 } from "../dist/mcp/schemas.js";
 
 test("stdio MCP entry points are not public CLI commands", () => {
-  assert.throws(() => parseArgs(["serve", "--mcp"]), /removed/i);
-  assert.throws(() => parseArgs(["--mcp"]), /Unknown command/i);
+  assert.throws(() => parseArgs(["serve", "--mcp"]), /Unknown option/i);
+  assert.throws(() => parseArgs(["--mcp"]), /Unknown option/i);
 });
 
 test("public MCP search omits runtime overrides while CLI admin preserves them", () => {

--- a/test/package/package.test.mjs
+++ b/test/package/package.test.mjs
@@ -124,11 +124,11 @@ test("npm package contains and exposes the supported public surface", async (t) 
     );
     assert.equal(installedCli.mode & 0o111, 0o111);
   }
-  const version = await runExecutable(cli, ["version"], {
+  const version = await runExecutable(cli, ["--version"], {
     cwd: consumerDirectory,
   });
   assert.equal(version.stdout.trim(), packageJson.version);
-  const help = await runExecutable(cli, ["help"], {
+  const help = await runExecutable(cli, ["--help"], {
     cwd: consumerDirectory,
   });
   assert.match(help.stdout, /Usage:/);
@@ -139,7 +139,7 @@ test("npm package contains and exposes the supported public surface", async (t) 
   );
   const rg = await runExecutable(
     cli,
-    ["query", "--rg", "-g", "*.ts", "-t", "ts", "PackageIndexedNeedle", "."],
+    ["--rg", "-g", "*.ts", "-t", "ts", "PackageIndexedNeedle", "."],
     { cwd: consumerDirectory },
   );
   assert.match(rg.stdout, /fixture\.ts/);
@@ -155,7 +155,7 @@ test("npm package contains and exposes the supported public surface", async (t) 
   await runExecutable(
     cli,
     [
-      "index",
+      "--index",
       "--embedding",
       "qwen/qwen3.7-text-embedding",
       "--api-key",
@@ -173,17 +173,7 @@ test("npm package contains and exposes the supported public surface", async (t) 
   );
   const indexed = await runExecutable(
     cli,
-    [
-      "query",
-      "--fts",
-      "PackageIndexedNeedle",
-      "--limit",
-      "5",
-      "-g",
-      "*.ts",
-      "-t",
-      "ts",
-    ],
+    ["--fts", "PackageIndexedNeedle", "--limit", "5", "-g", "*.ts", "-t", "ts"],
     { cwd: consumerDirectory, env: cliEnvironment, timeout: 120_000 },
   );
   assert.match(indexed.stdout, /PackageIndexedNeedle/);

--- a/test/rg-cli.test.mjs
+++ b/test/rg-cli.test.mjs
@@ -24,7 +24,7 @@ test("managed rg runs locally when indexed operations use server mode", async (t
 
   const result = await execFileAsync(
     process.execPath,
-    [cliPath, "query", "--rg", "-n", "exactNeedle", "src"],
+    [cliPath, "--rg", "-n", "exactNeedle", "src"],
     {
       cwd: root,
       env: { ...process.env, ZVEC_GREP_MODE: "server" },
@@ -51,7 +51,7 @@ test("managed rg bypasses workspace index state in direct and server modes", asy
   for (const mode of ["direct", "server"]) {
     const result = await execFileAsync(
       process.execPath,
-      [cliPath, "query", "--mode", mode, "--rg", "fastPathNeedle", "src"],
+      [cliPath, "--mode", mode, "--rg", "fastPathNeedle", "src"],
       { cwd: root, env: { ...process.env, NO_COLOR: "1" } },
     );
 
@@ -82,7 +82,7 @@ test("managed rg ignores stale index status in direct and server modes", async (
   for (const mode of ["direct", "server"]) {
     const result = await execFileAsync(
       process.execPath,
-      [cliPath, "query", "--mode", mode, "--rg", "deletedNeedle"],
+      [cliPath, "--mode", mode, "--rg", "deletedNeedle"],
       { cwd: root, env: { ...process.env, NO_COLOR: "1" } },
     );
 
@@ -119,7 +119,7 @@ test("managed rg emits a compact file and adaptive symbol hierarchy", async (t) 
 
   const result = await execFileAsync(
     process.execPath,
-    [cliPath, "query", "--rg", "-n", "grouped_needle", "src/grouped.py"],
+    [cliPath, "--rg", "-n", "grouped_needle", "src/grouped.py"],
     { cwd: root },
   );
 

--- a/test/server-cli.test.mjs
+++ b/test/server-cli.test.mjs
@@ -25,7 +25,7 @@ const packageVersion = JSON.parse(
 ).version;
 
 test("server run parses a loopback listen address", () => {
-  const parsed = parseArgs(["server", "run", "--listen", "127.0.0.1:8123"]);
+  const parsed = parseArgs(["--server", "run", "--listen", "127.0.0.1:8123"]);
   assert.equal(parsed.command, "server");
   assert.equal(parsed.options.serverAction, "run");
   assert.equal(parsed.options.listen, "127.0.0.1:8123");
@@ -36,45 +36,39 @@ test("server run parses a loopback listen address", () => {
 });
 
 test("server lifecycle and client mode arguments are parsed", () => {
-  assert.equal(parseArgs(["server", "--stdio"]).options.serverStdio, true);
+  assert.equal(parseArgs(["--server", "--stdio"]).options.serverStdio, true);
   assert.throws(
-    () => parseArgs(["server", "on", "--stdio"]),
+    () => parseArgs(["--server", "on", "--stdio"]),
     /cannot be combined/i,
   );
   for (const action of ["on", "off", "status"]) {
-    const parsed = parseArgs(["server", action]);
+    const parsed = parseArgs(["--server", action]);
     assert.equal(parsed.options.serverAction, action);
   }
   assert.equal(
-    parseArgs(["server", "on", "--mcp-toolset", "full"]).options.mcpToolset,
+    parseArgs(["--server", "on", "--mcp-toolset", "full"]).options.mcpToolset,
     "full",
   );
   assert.equal(
-    parseArgs(["server", "run", "--mcp-toolset=agent"]).options.mcpToolset,
+    parseArgs(["--server", "run", "--mcp-toolset=agent"]).options.mcpToolset,
     "agent",
   );
   assert.throws(
-    () => parseArgs(["server", "on", "--mcp-toolset", "all"]),
+    () => parseArgs(["--server", "on", "--mcp-toolset", "all"]),
     /agent.*full/i,
   );
   assert.throws(
-    () => parseArgs(["server", "off", "--mcp-toolset", "full"]),
-    /only be used with zg server on or run/i,
+    () => parseArgs(["--server", "off", "--mcp-toolset", "full"]),
+    /only be used with zg --server on or run/i,
   );
-  assert.equal(
-    parseArgs(["query", "--mode", "server", "query"]).options.mode,
-    "server",
-  );
-  assert.equal(
-    parseArgs(["query", "--mode=auto", "query"]).options.mode,
-    "auto",
-  );
+  assert.equal(parseArgs(["--mode", "server", "query"]).options.mode, "server");
+  assert.equal(parseArgs(["--mode=auto", "query"]).options.mode, "auto");
   assert.throws(
-    () => parseArgs(["query", "--mode", "invalid", "query"]),
+    () => parseArgs(["--mode", "invalid", "query"]),
     /direct, server, or auto/i,
   );
   assert.throws(
-    () => parseArgs(["query", "--force-direct", "query"]),
+    () => parseArgs(["--force-direct", "query"]),
     /requires --mode direct/i,
   );
 });
@@ -85,7 +79,7 @@ test("stdio bootstrap starts and reuses the shared daemon", async (t) => {
   t.after(async () => {
     await execFileAsync(process.execPath, [
       cliPath,
-      "server",
+      "--server",
       "off",
       "--home",
       home,
@@ -98,7 +92,7 @@ test("stdio bootstrap starts and reuses the shared daemon", async (t) => {
     command: process.execPath,
     args: [
       cliPath,
-      "server",
+      "--server",
       "--stdio",
       "--home",
       home,
@@ -132,23 +126,17 @@ test("server queries map refresh modes to search policy", () => {
     autoUpdate: false,
   });
   assert.equal(
-    parseArgs(["query", "--refresh", "background", "query"]).options.refresh,
+    parseArgs(["--refresh", "background", "query"]).options.refresh,
     "background",
   );
-  assert.equal(
-    parseArgs(["query", "--refresh=wait", "query"]).options.refresh,
-    "wait",
-  );
+  assert.equal(parseArgs(["--refresh=wait", "query"]).options.refresh, "wait");
   assert.throws(
-    () => parseArgs(["query", "--refresh", "invalid", "query"]),
+    () => parseArgs(["--refresh", "invalid", "query"]),
     /background, wait, or off/i,
   );
+  assert.throws(() => parseArgs(["--fresh", "query"]), /Unknown option/);
   assert.throws(
-    () => parseArgs(["query", "--fresh", "query"]),
-    /Unknown option/,
-  );
-  assert.throws(
-    () => parseArgs(["query", "--no-auto-update", "query"]),
+    () => parseArgs(["--no-auto-update", "query"]),
     /Unknown option/,
   );
 });
@@ -182,8 +170,8 @@ test("server run rejects non-loopback addresses and unrelated listen flags", () 
     /loopback/i,
   );
   assert.throws(
-    () => parseArgs(["query", "--listen", "127.0.0.1:7999", "query"]),
-    /zg server on or run/i,
+    () => parseArgs(["--listen", "127.0.0.1:7999", "query"]),
+    /zg --server on or run/i,
   );
 });
 
@@ -194,7 +182,7 @@ test("server on, status and off are idempotent", async (t) => {
   t.after(async () => {
     await execFileAsync(process.execPath, [
       cliPath,
-      "server",
+      "--server",
       "off",
       ...args,
     ]).catch(() => undefined);
@@ -203,7 +191,7 @@ test("server on, status and off are idempotent", async (t) => {
 
   const first = await execFileAsync(process.execPath, [
     cliPath,
-    "server",
+    "--server",
     "on",
     "--listen",
     `127.0.0.1:${port}`,
@@ -213,14 +201,14 @@ test("server on, status and off are idempotent", async (t) => {
   assert.equal((await readInstanceRecord(home)).mcpToolset, "agent");
   const second = await execFileAsync(process.execPath, [
     cliPath,
-    "server",
+    "--server",
     "on",
     ...args,
   ]);
   assert.match(second.stdout, /Server: ready/);
   const status = await execFileAsync(process.execPath, [
     cliPath,
-    "server",
+    "--server",
     "status",
     "--check-ready",
     ...args,
@@ -250,14 +238,14 @@ test("server on, status and off are idempotent", async (t) => {
   });
   const stopped = await execFileAsync(process.execPath, [
     cliPath,
-    "server",
+    "--server",
     "off",
     ...args,
   ]);
   assert.match(stopped.stdout, /Server: stopped/);
   const stoppedAgain = await execFileAsync(process.execPath, [
     cliPath,
-    "server",
+    "--server",
     "off",
     ...args,
   ]);
@@ -272,7 +260,7 @@ test("server toolset flag overrides the environment and the environment is a fal
   t.after(async () => {
     await execFileAsync(
       process.execPath,
-      [cliPath, "server", "off", "--home", home],
+      [cliPath, "--server", "off", "--home", home],
       { env },
     ).catch(() => undefined);
     await rm(home, { recursive: true, force: true });
@@ -280,31 +268,31 @@ test("server toolset flag overrides the environment and the environment is a fal
 
   await execFileAsync(
     process.execPath,
-    [cliPath, "server", "on", "--mcp-toolset", "agent", ...commonArgs],
+    [cliPath, "--server", "on", "--mcp-toolset", "agent", ...commonArgs],
     { env },
   );
   assert.equal((await readInstanceRecord(home)).mcpToolset, "agent");
   const agentStatus = await execFileAsync(
     process.execPath,
-    [cliPath, "server", "status", "--home", home],
+    [cliPath, "--server", "status", "--home", home],
     { env },
   );
   assert.match(agentStatus.stdout, /MCP toolset: agent/);
 
   await execFileAsync(
     process.execPath,
-    [cliPath, "server", "off", "--home", home],
+    [cliPath, "--server", "off", "--home", home],
     { env },
   );
   await execFileAsync(
     process.execPath,
-    [cliPath, "server", "on", ...commonArgs],
+    [cliPath, "--server", "on", ...commonArgs],
     { env },
   );
   assert.equal((await readInstanceRecord(home)).mcpToolset, "full");
   const fullStatus = await execFileAsync(
     process.execPath,
-    [cliPath, "server", "status", "--home", home],
+    [cliPath, "--server", "status", "--home", home],
     { env },
   );
   assert.match(fullStatus.stdout, /MCP toolset: full/);
@@ -319,7 +307,7 @@ test("server token file enables authentication", async (t) => {
   t.after(async () => {
     await execFileAsync(process.execPath, [
       cliPath,
-      "server",
+      "--server",
       "off",
       "--home",
       home,
@@ -331,7 +319,7 @@ test("server token file enables authentication", async (t) => {
 
   await execFileAsync(process.execPath, [
     cliPath,
-    "server",
+    "--server",
     "on",
     "--listen",
     `127.0.0.1:${port}`,
@@ -352,7 +340,7 @@ test("server token file enables authentication", async (t) => {
   assert.equal(clientStatus.version, packageVersion);
   const stopped = await execFileAsync(process.execPath, [
     cliPath,
-    "server",
+    "--server",
     "off",
     "--home",
     home,
@@ -378,7 +366,7 @@ test(
       [
         "--liftoff-only",
         cliPath,
-        "server",
+        "--server",
         "run",
         "--listen",
         `127.0.0.1:${port}`,

--- a/test/smoke/local-model-package.test.mjs
+++ b/test/smoke/local-model-package.test.mjs
@@ -105,6 +105,7 @@ test("packed package runs a real local embedding model end to end", async (t) =>
     USERPROFILE: packageHome,
     NO_COLOR: "1",
     ZVEC_GREP_HOME: packageHome,
+    ZVEC_GREP_EMBEDDING: modelReference,
     ZVEC_GREP_MODEL_CACHE: modelCache,
   };
 
@@ -157,35 +158,9 @@ test("packed package runs a real local embedding model end to end", async (t) =>
       "",
     ].join("\n"),
   );
-  const indexed = await runExecutable(
-    cli,
-    [
-      "index",
-      "--mode",
-      "direct",
-      "--embedding",
-      modelReference,
-      "--device",
-      "cpu",
-      "-g",
-      "fixture.ts",
-      "-t",
-      "ts",
-      ".",
-    ],
-    {
-      cwd: consumerDirectory,
-      env: runtimeEnvironment,
-      timeout: 600_000,
-    },
-  );
-  assert.match(indexed.stdout, /^Workspace index$/m);
-  assert.match(indexed.stdout, /1 added/);
-
   const queried = await runExecutable(
     cli,
     [
-      "query",
       "--mode",
       "direct",
       "--vector",
@@ -206,12 +181,22 @@ test("packed package runs a real local embedding model end to end", async (t) =>
   );
   assert.match(queried.stdout, /CrossPlatformPotionNeedle/);
   assert.match(queried.stdout, /fixture\.ts/);
+  assert.match(
+    queried.stderr,
+    new RegExp(
+      `No index found; creating one with ${modelReference.replaceAll("/", "\\/")}\\.`,
+    ),
+  );
 
-  const status = await runExecutable(cli, ["status", "--mode", "direct", "."], {
-    cwd: consumerDirectory,
-    env: runtimeEnvironment,
-    timeout: 120_000,
-  });
+  const status = await runExecutable(
+    cli,
+    ["--status", "--mode", "direct", "."],
+    {
+      cwd: consumerDirectory,
+      env: runtimeEnvironment,
+      timeout: 120_000,
+    },
+  );
   assert.match(
     status.stdout,
     new RegExp(modelReference.replaceAll("/", "\\/")),

--- a/test/unit/cli-format.test.mjs
+++ b/test/unit/cli-format.test.mjs
@@ -955,7 +955,7 @@ test("status formatters cover workspace states, failures, filters, and color", a
         indexPath: "/repo/.zvec-grep/index.zvec",
         workspaceIndex: info,
         status: stale,
-        suggestion: "zg index",
+        suggestion: "zg --index",
       },
       { color: "never" },
     );
@@ -1034,7 +1034,7 @@ test("status formatters cover workspace states, failures, filters, and color", a
             entities: 7,
             truncated_fragments: 4,
           },
-          suggestion: "zg index",
+          suggestion: "zg --index",
         },
         runtime: {
           job_state: "running",
@@ -1073,7 +1073,7 @@ test("status formatters cover workspace states, failures, filters, and color", a
   assert.match(output.logs.join("\n"), /1m 5s/);
   assert.match(output.logs.join("\n"), /ignore-file=\.rgignore/);
   assert.match(output.logs.join("\n"), /Default indexing skips/);
-  assert.match(output.logs.join("\n"), /zg help file-types/);
+  assert.match(output.logs.join("\n"), /zg --help file-types/);
   assert.match(
     output.logs.join("\n"),
     new RegExp(
@@ -1139,7 +1139,7 @@ test("status formatters cover workspace states, failures, filters, and color", a
       indexPath: "/repo/.zvec-grep/index.zvec",
       workspaceIndex: stateInfo.workspaceIndex,
       status: stateInfo.status,
-      suggestion: "zg index",
+      suggestion: "zg --index",
     };
     const rendered = await captureConsole(() =>
       printWorkspaceInfo(workspace, { color: "never" }),
@@ -1496,7 +1496,7 @@ test("Remote Embedding authorization status uses grouped colors and compact path
     "  /repo",
     "",
     "Run",
-    "  zg auth grant --capability embedding --scope workspace",
+    "  zg --auth grant --capability embedding --scope workspace",
   ]);
 });
 

--- a/test/unit/core.test.mjs
+++ b/test/unit/core.test.mjs
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import test from "node:test";
 import {
+  compatibilityWarningForArgs,
   parseArgs,
   parseDevice,
   parseModifiedTime,
@@ -57,8 +58,7 @@ import { contextOptionsFromRgInput } from "../../dist/mcp/input-normalization.js
 
 test("CLI argument parser handles command, provider, path, and rg options", () => {
   const parsed = parseArgs([
-    "query",
-    "--human",
+    "--compact",
     "--trace",
     "--preview",
     "short",
@@ -74,7 +74,7 @@ test("CLI argument parser handles command, provider, path, and rg options", () =
   ]);
   assert.equal(parsed.command, "query");
   assert.deepEqual(parsed.positionals, ["query text"]);
-  assert.equal(parsed.options.human, true);
+  assert.equal(parsed.options.human, false);
   assert.equal(parsed.options.trace, true);
   assert.equal(parsed.options.preview, "short");
   assert.equal(parsed.options.limit, 7);
@@ -82,7 +82,7 @@ test("CLI argument parser handles command, provider, path, and rg options", () =
   assert.equal(typeof parsed.options.modifiedAfter, "number");
 
   const index = parseArgs([
-    "index",
+    "--index",
     "--embedding",
     "qwen/text-embedding-v4",
     "--api-key",
@@ -103,7 +103,6 @@ test("CLI argument parser handles command, provider, path, and rg options", () =
   assert.equal(index.options.embeddingConcurrency, 4);
 
   const queryRuntime = parseArgs([
-    "query",
     "--api-key",
     "secret",
     "--model-cache",
@@ -117,7 +116,6 @@ test("CLI argument parser handles command, provider, path, and rg options", () =
   assert.equal(queryRuntime.options.device, "cpu");
 
   const rg = parseArgs([
-    "query",
     "--rg",
     "-F",
     "-i",
@@ -140,12 +138,11 @@ test("CLI parsers reject invalid values and normalize supported values", () => {
   assert.throws(
     () =>
       parseArgs([
-        "query",
         "--endpoint",
         "https://example.test/embeddings",
         "query text",
       ]),
-    /--endpoint is not supported with zg query/,
+    /--endpoint is not supported while searching/,
   );
   assert.equal(parseDevice("cpu"), "cpu");
   assert.equal(parseDevice("CUDA"), "cuda");
@@ -163,25 +160,54 @@ test("CLI parsers reject invalid values and normalize supported values", () => {
     1700000000000,
   );
   assert.throws(() => parseDevice("magic"), /Unsupported device/);
+  assert.throws(() => parseArgs(["--limit", "0", "query"]), /positive integer/);
   assert.throws(
-    () => parseArgs(["query", "--limit", "0", "query"]),
+    () => parseArgs(["--limit", "2x", "query"]),
     /positive integer/,
   );
   assert.throws(
-    () => parseArgs(["query", "--limit", "2x", "query"]),
-    /positive integer/,
-  );
-  assert.throws(
-    () => parseArgs(["query", "--preview", "huge", "query"]),
+    () => parseArgs(["--preview", "huge", "query"]),
     /Unsupported preview mode/,
   );
-  assert.throws(() => parseArgs(["query", "--json", "query"]), /removed/);
+  assert.throws(() => parseArgs(["--json", "query"]), /not supported/);
+  assert.throws(() => parseArgs(["--human", "query"]), /removed/);
   assert.throws(
-    () =>
-      parseArgs(["query", "--embedding", "local/embeddinggemma-300m", "query"]),
-    /--embedding is not supported with zg query/,
+    () => parseArgs(["--embedding", "local/embeddinggemma-300m", "query"]),
+    /--embedding is not supported while searching/,
   );
-  assert.throws(() => parseArgs(["--unknown"]), /Unknown command/);
+  assert.throws(() => parseArgs(["--unknown"]), /Unknown option/);
+});
+
+test("CLI warns about command-shaped leading queries without restoring aliases", () => {
+  assert.match(
+    compatibilityWarningForArgs(["query", "xxx"]),
+    /search is already the default/,
+  );
+  assert.match(
+    compatibilityWarningForArgs(["search", "authentication"]),
+    /search is already the default/,
+  );
+  for (const word of [
+    "index",
+    "status",
+    "install",
+    "uninstall",
+    "config",
+    "auth",
+    "server",
+    "help",
+    "version",
+  ]) {
+    const warning = compatibilityWarningForArgs([word, "literal"]);
+    assert.match(warning, /is parsed as search input/);
+    assert.match(warning, new RegExp(`zg --${word}`));
+  }
+  assert.equal(compatibilityWarningForArgs(["--", "query"]), undefined);
+  assert.equal(
+    compatibilityWarningForArgs(["authentication", "query"]),
+    undefined,
+  );
+  assert.deepEqual(parseArgs(["query", "xxx"]).positionals, ["query", "xxx"]);
 });
 
 test("MCP rg command normalization preserves quoted patterns, paths, and globs", () => {
@@ -291,7 +317,7 @@ test("MCP rg command parsing rejects shell syntax, non-rg flags, and root escape
 
 test("CLI parser covers utility commands, provider controls, routes, and equals syntax", () => {
   const install = parseArgs([
-    "install",
+    "--install",
     "--target=codex, claude",
     "--target",
     "cursor",
@@ -310,37 +336,55 @@ test("CLI parser covers utility commands, provider controls, routes, and equals 
   assert.equal(install.options.installMcpTransport, "stdio");
   assert.equal(install.options.mcpToolset, "full");
   assert.throws(
-    () => parseArgs(["install", "--mcp-token-env", "TOKEN"]),
+    () => parseArgs(["--install", "--mcp-token-env", "TOKEN"]),
     /requires --mcp-transport http/,
   );
 
-  assert.throws(() => parseArgs(["serve", "--mcp"]), /removed/i);
+  assert.throws(() => parseArgs(["serve", "--mcp"]), /Unknown option/i);
   assert.equal(parseArgs(["-h"]).command, "help");
-  assert.equal(parseArgs(["help", "query"]).helpTopic, "query");
-  assert.equal(parseArgs(["help", "environment"]).helpTopic, "environment");
-  assert.equal(parseArgs(["help", "env"]).helpTopic, "env");
+  assert.equal(parseArgs(["--help", "search"]).helpTopic, "search");
+  assert.equal(parseArgs(["--help", "environment"]).helpTopic, "environment");
+  assert.equal(parseArgs(["--help=env"]).helpTopic, "env");
   assert.equal(parseArgs(["-v"]).command, "version");
-  assert.equal(parseArgs(["version", "-v"]).command, "version");
-  assert.equal(parseArgs(["version", "--version"]).command, "version");
+  assert.equal(parseArgs(["version"]).command, "query");
   assert.deepEqual(
-    parseArgs(["query", "--rg", "-v", "needle"]).options.rgOptions?.extraArgs,
+    parseArgs(["--rg", "-v", "needle"]).options.rgOptions?.extraArgs,
     ["-v"],
   );
-  assert.equal(parseArgs(["index", "--drop", "--yes"]).options.drop, true);
-  assert.equal(parseArgs(["status"]).command, "status");
-  assert.equal(parseArgs(["status", "--check-ready"]).options.checkReady, true);
+  assert.equal(parseArgs(["--index", "--drop", "--yes"]).options.drop, true);
+  const formerCommands = [
+    "query",
+    "index",
+    "status",
+    "install",
+    "uninstall",
+    "config",
+    "auth",
+    "server",
+    "help",
+    "version",
+  ];
+  assert.deepEqual(parseArgs(formerCommands), {
+    command: "query",
+    options: {},
+    positionals: formerCommands,
+  });
   assert.equal(
-    parseArgs(["server", "status", "--check-ready"]).options.checkReady,
+    parseArgs(["--status", "--check-ready"]).options.checkReady,
+    true,
+  );
+  assert.equal(
+    parseArgs(["--server", "status", "--check-ready"]).options.checkReady,
     true,
   );
   assert.throws(
-    () => parseArgs(["query", "--check-ready", "query"]),
-    /zg status or zg server status/,
+    () => parseArgs(["--check-ready", "query"]),
+    /zg --status or zg --server status/,
   );
-  assert.throws(() => parseArgs(["collections"]), /Unknown command/);
+  assert.deepEqual(parseArgs(["collections"]).positionals, ["collections"]);
   assert.deepEqual(
     parseArgs([
-      "auth",
+      "--auth",
       "grant",
       "/tmp/workspace",
       "--capability",
@@ -358,22 +402,21 @@ test("CLI parser covers utility commands, provider controls, routes, and equals 
     },
   );
   assert.equal(
-    parseArgs(["query", "--allow-remote", "query"]).options.allowRemote,
+    parseArgs(["--allow-remote", "query"]).options.allowRemote,
     true,
   );
   assert.throws(
-    () => parseArgs(["query", "--allow-remote=once", "query"]),
+    () => parseArgs(["--allow-remote=once", "query"]),
     /does not accept a value/,
   );
   assert.throws(
-    () => parseArgs(["query", "--allow-remote", "workspace", "query"]),
+    () => parseArgs(["--allow-remote", "workspace", "query"]),
     /does not accept a value/,
   );
 
   const query = parseArgs([
-    "query",
     "--debug",
-    "--human",
+    "--compact",
     "--preview=full",
     "--refresh=off",
     "--prefer-symbol",
@@ -404,6 +447,7 @@ test("CLI parser covers utility commands, provider controls, routes, and equals 
     "-literal-query",
   ]);
   assert.equal(query.options.debug, true);
+  assert.equal(query.options.human, false);
   assert.deepEqual(query.options.hybridQueries, ["zero"]);
   assert.deepEqual(query.options.routes, [
     { mode: "fts", query: "one" },
@@ -414,25 +458,25 @@ test("CLI parser covers utility commands, provider controls, routes, and equals 
   assert.deepEqual(query.options.globs, ["src/**", "docs/**", "!dist/**"]);
   assert.deepEqual(query.options.fileTypes, ["ts"]);
   assert.deepEqual(query.positionals, ["-literal-query"]);
-  assert.equal(parseArgs(["index", "--debug"]).options.debug, true);
+  assert.equal(parseArgs(["--index", "--debug"]).options.debug, true);
 });
 
 test("CLI parser limits debug output to query, index, and workspace status", () => {
   const supported = [
-    ["query", "--debug", "needle"],
-    ["index", "--debug"],
-    ["status", "--debug"],
-    ["status", "--check-ready", "--debug"],
+    ["--debug", "needle"],
+    ["--index", "--debug"],
+    ["--status", "--debug"],
+    ["--status", "--check-ready", "--debug"],
   ];
   for (const args of supported) {
     assert.equal(parseArgs(args).options.debug, true, args.join(" "));
   }
 
   const unsupported = [
-    ["install", "--debug"],
-    ["uninstall", "--debug"],
-    ["server", "start", "--debug"],
-    ["server", "status", "--debug"],
+    ["--install", "--debug"],
+    ["--uninstall", "--debug"],
+    ["--server", "start", "--debug"],
+    ["--server", "status", "--debug"],
   ];
   for (const args of unsupported) {
     assert.throws(
@@ -445,7 +489,6 @@ test("CLI parser limits debug output to query, index, and workspace status", () 
 
 test("CLI parser covers managed rg long and short compatibility options", () => {
   const long = parseArgs([
-    "query",
     "--rg",
     "--ignore-case",
     "--word-regexp",
@@ -506,7 +549,6 @@ test("CLI parser covers managed rg long and short compatibility options", () => 
   assert.ok(long.options.rgOptions?.extraArgs?.includes("--word-regexp"));
 
   const short = parseArgs([
-    "query",
     "--rg",
     "-nHFiwPSsuvxUzL",
     "-einline",
@@ -537,57 +579,53 @@ test("CLI parser covers managed rg long and short compatibility options", () => 
 
 test("CLI shape validation rejects every incompatible command family", () => {
   const invalid = [
-    [["serve"], /removed/i],
-    [["serve", "--mcp", "--fts", "query"], /removed/i],
-    [["query", "--mcp", "query"], /Unknown option/],
-    [["query", "--collection", "docs", "query"], /Unknown option/],
-    [["index", "--fts", "query"], /only be used with zg query/],
-    [["status", "--rg", "query"], /only be used with zg query/],
-    [["index", "--refresh", "off"], /only be used with zg query/],
-    [["query", "--rg", "query", "--fts", "query"], /cannot be combined/],
-    [["query", "--rg", "query", "--hybrid", "query"], /cannot be combined/],
-    [["query", "--rg", "query", "--fuse"], /cannot be combined/],
+    [["serve", "--mcp", "--fts", "query"], /Unknown option/i],
+    [["--mcp", "query"], /Unknown option/],
+    [["--collection", "docs", "query"], /Unknown option/],
+    [["--index", "--fts", "query"], /only be used for search/],
+    [["--status", "--rg", "query"], /only be used for search/],
+    [["--index", "--refresh", "off"], /only be used for search/],
+    [["--rg", "query", "--fts", "query"], /cannot be combined/],
+    [["--rg", "query", "--hybrid", "query"], /cannot be combined/],
+    [["--rg", "query", "--fuse"], /cannot be combined/],
+    [["--rg", "query", "--preview", "short"], /not supported with --rg/],
+    [["--rg", "query", "--trace"], /cannot be combined/],
+    [["--rg", "query", "--prefer-symbol"], /indexed symbol options/],
+    [["--rg", "query", "--refresh", "off"], /indexed refresh options/],
     [
-      ["query", "--rg", "query", "--preview", "short"],
-      /not supported with --rg/,
-    ],
-    [["query", "--rg", "query", "--trace"], /cannot be combined/],
-    [["query", "--rg", "query", "--prefer-symbol"], /indexed symbol options/],
-    [["query", "--rg", "query", "--refresh", "off"], /indexed refresh options/],
-    [
-      ["query", "--rg", "query", "--embedding-concurrency", "2"],
+      ["--rg", "query", "--embedding-concurrency", "2"],
       /indexed refresh options/,
     ],
-    [["query", "--reset-paths", "query"], /only be used with zg index/],
-    [["query", "--ignore-case", "query"], /only be used with --rg/],
-    [["query", "--hidden", "query"], /index commands or zg query --rg/],
-    [["install", "-g", "src/**"], /query or index commands/],
-    [["query", "--drop", "query"], /only be used with zg index/],
-    [["index", "--drop", "--rebuild"], /cannot be combined/],
-    [["index", "--drop", "-g", "src/**"], /cannot be combined/],
-    [["uninstall", "--force"], /only be used with zg install/],
-    [["status", "--target", "codex"], /only be used with zg install/],
-    [["auth", "grant", "--scope", "session"], /only workspace scope/],
-    [["status", "--allow-remote"], /query or index commands/],
+    [["--reset-paths", "query"], /only be used with zg --index/],
+    [["--ignore-case", "query"], /only be used with --rg/],
+    [["--hidden", "query"], /--index or --rg/],
+    [["--install", "-g", "src/**"], /search or --index/],
+    [["--drop", "query"], /only be used with zg --index/],
+    [["--index", "--drop", "--rebuild"], /cannot be combined/],
+    [["--index", "--drop", "-g", "src/**"], /cannot be combined/],
+    [["--uninstall", "--force"], /only be used with zg --install/],
+    [["--status", "--target", "codex"], /only be used with --install/],
+    [["--auth", "grant", "--scope", "session"], /only workspace scope/],
+    [["--status", "--allow-remote"], /search or --index/],
   ];
   for (const [args, message] of invalid) {
     assert.throws(() => parseArgs(args), message, args.join(" "));
   }
 
   for (const args of [
-    ["query", "--color", "sometimes", "query"],
-    ["query", "--symbol-type", "method", "query"],
-    ["query", "--modified-after", "not-a-date", "query"],
-    ["query", "--modified-after", "999999999999999999999", "query"],
-    ["query", "--modified-after", "2026-13-40", "query"],
-    ["query", "--rg", "--context", "-1", "query"],
-    ["query", "--count", "query"],
-    ["query", "--rg", "-l", "query"],
-    ["query", "--rg", "-q", "query"],
-    ["query", "--rg", "--stats", "query"],
-    ["query", "--include", "src/**", "query"],
-    ["query", "--fts"],
-    ["install", "--target"],
+    ["--color", "sometimes", "query"],
+    ["--symbol-type", "method", "query"],
+    ["--modified-after", "not-a-date", "query"],
+    ["--modified-after", "999999999999999999999", "query"],
+    ["--modified-after", "2026-13-40", "query"],
+    ["--rg", "--context", "-1", "query"],
+    ["--count", "query"],
+    ["--rg", "-l", "query"],
+    ["--rg", "-q", "query"],
+    ["--rg", "--stats", "query"],
+    ["--include", "src/**", "query"],
+    ["--fts"],
+    ["--install", "--target"],
   ]) {
     assert.throws(() => parseArgs(args), undefined, args.join(" "));
   }


### PR DESCRIPTION
## Background

The current human-facing CLI requires command families such as `zg query`, `zg index`, and `zg install`, while readable terminal output needs `--human`. This makes the common search path unnecessarily verbose and reserves ordinary search words as commands.

## Changes

- Make search the default interface: `zg <query>`.
- Move management operations to unambiguous long actions: `zg --index`, `zg --install`, `zg --status`, `zg --server`, `zg --config`, and `zg --auth`.
- Remove the old `query/index/install/...` word aliases instead of keeping two ambiguous command grammars.
- Auto-create a missing index on the first indexed search, using a local embedding model only.
- Make TTY output human-readable automatically; redirected output stays compact and `--compact` remains available.
- Emit migration warnings on stderr for command-shaped leading query words without changing their meaning. For example, `zg query xxx` warns and still searches the original `query` and `xxx` inputs; `zg -- query xxx` expresses literal intent without a warning.
- Update installed MCP integration commands, help, English/Chinese docs, benchmark runners, and tests to the new interface.

## Interface examples

```bash
zg "where authentication is validated"
zg --rg -F "AuthService" src
zg --index
zg --status
zg --server on
zg --install
```

## Verification

- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm run test:coverage`
  - root: 231 passed
  - unit: 114 passed, 1 skipped
  - integration: 26 passed
  - E2E: 9 passed
  - coverage: 89.17% statements/lines, 83.43% branches, 94.8% functions
- Targeted real CLI E2E for warning-then-search behavior
- `npm run test:package`
- `npm run test:smoke:local-model`
- SWE-QA benchmark tests: 47 passed, 14 subtests

## Compatibility and rollback

This intentionally breaks the old word-subcommand grammar. Risky legacy-looking invocations warn on stderr but remain literal searches; stdout stays clean for pipelines. Existing installed integration configuration is recognized for migration/uninstall, but old CLI aliases are not restored. Implicit indexing cannot silently select a configured remote provider.

Rollback is a revert of commit `43a8b07`.
