### PR TITLE
fix(opencode): preserve JSONC config and select the active config file

### DIFF
--- a/docs/01-agents.md
+++ b/docs/01-agents.md
@@ -18,13 +18,21 @@ managed-rg route.
 | Claude Code | `claude` | `~/.claude.json`, `~/.claude/settings.json`, and `~/.claude/CLAUDE.md` |
 | Qwen Code | `qwen` | `~/.qwen/settings.json` and `~/.qwen/QWEN.md` |
 | Qoder CLI and IDE | `qoder` | `~/.qoder/settings.json`, `~/.qoder/AGENTS.md`, and the IDE user-level `~/.qoder/mcp.json` |
-| OpenCode | `opencode` | `~/.config/opencode/opencode.json` and the adjacent `AGENTS.md` |
+| OpenCode | `opencode` | the existing `~/.config/opencode/opencode.jsonc` or `opencode.json`, and the adjacent `AGENTS.md` |
 | Cursor | `cursor` | `~/.cursor/mcp.json` |
 
 The standard environment overrides used by each agent are respected, including
 `CODEX_HOME`, `CLAUDE_CONFIG_DIR`, `QWEN_HOME`, `QODER_CONFIG_DIR`,
 `QODER_IDE_MCP_PATH`, `QODER_IDE_EXECUTABLE`, `OPENCODE_CONFIG`, and
 `CURSOR_CONFIG_DIR`.
+
+For OpenCode, `OPENCODE_CONFIG` selects the exact configuration file. Without
+that override, the installer uses an existing global `opencode.jsonc` before
+`opencode.json`, preserves JSONC comments and unrelated settings, and creates
+`opencode.json` only when neither file exists. If both files exist, the selected
+`opencode.jsonc` path is reported in the install output. On Linux and other
+XDG-based environments, `XDG_CONFIG_HOME` replaces the default `~/.config`
+root.
 
 The current Qoder CLI package exposes both `qoder` and `qodercli` commands, but
 the installer exposes only the canonical `qoder` target. One Qoder install

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -58,6 +58,10 @@ type InstallAgentOptions = {
 
 type InstallAgentResult = {
   files: string[];
+  /** Primary agent configuration file to show in the install summary. */
+  configPath?: string;
+  /** Optional explanation when config-file discovery requires a choice. */
+  configNote?: string;
 };
 
 const AGENT_INSTALLERS: readonly AgentInstaller[] = [
@@ -144,7 +148,7 @@ export async function runInstall(parsed: ParsedArgs): Promise<void> {
 
   console.log("\nInstalling integrations\n");
   for (const installer of installers) {
-    await installer.install({
+    const result = await installer.install({
       force: parsed.options.force === true,
       transport,
       mcpToolset: parsed.options.mcpToolset,
@@ -155,6 +159,12 @@ export async function runInstall(parsed: ParsedArgs): Promise<void> {
     });
     console.log(`  ${installSuccessMark()} ${installer.label}`);
     console.log("    MCP       configured");
+    if (result.configPath) {
+      console.log(`    Config    ${result.configPath}`);
+    }
+    if (result.configNote) {
+      console.log(`    Note      ${result.configNote}`);
+    }
     console.log("");
   }
 
@@ -296,9 +306,10 @@ async function uninstallCodexIntegration(): Promise<InstallAgentResult> {
 async function installOpenCodeIntegration(
   options: InstallAgentOptions,
 ): Promise<InstallAgentResult> {
-  const configPath = resolveOpenCodeConfigPath();
+  const resolvedConfig = await resolveOpenCodeConfigPath();
+  const configPath = resolvedConfig.path;
   const guidancePath = resolve(dirname(configPath), "AGENTS.md");
-  await installJsonMcpServer({
+  await updateJsoncMcpSettings({
     path: configPath,
     containerKey: "mcp",
     server:
@@ -325,6 +336,7 @@ async function installOpenCodeIntegration(
           },
     force: options.force,
     label: "OpenCode",
+    isManaged: isManagedJsonMcpServer,
   });
   await writeMarkedFile({
     path: guidancePath,
@@ -336,13 +348,22 @@ async function installOpenCodeIntegration(
     }),
     force: true,
   });
-  return { files: [configPath, guidancePath] };
+  return {
+    files: [configPath, guidancePath],
+    configPath,
+    configNote: resolvedConfig.note,
+  };
 }
 
 async function uninstallOpenCodeIntegration(): Promise<InstallAgentResult> {
-  const configPath = resolveOpenCodeConfigPath();
+  const { path: configPath } = await resolveOpenCodeConfigPath();
   const guidancePath = resolve(dirname(configPath), "AGENTS.md");
-  await uninstallJsonMcpServer(configPath, "mcp");
+  await removeJsoncMcpSettings(
+    configPath,
+    "OpenCode",
+    isManagedJsonMcpServer,
+    "mcp",
+  );
   await removeMarkedFile({
     path: guidancePath,
     startMarker: ZVEC_GREP_AGENTS_START,
@@ -843,11 +864,33 @@ function resolveClaudeMcpConfigPath(): string {
     : resolve(homedir(), ".claude.json");
 }
 
-function resolveOpenCodeConfigPath(): string {
-  return resolve(
-    process.env.OPENCODE_CONFIG ??
-      resolve(homedir(), ".config", "opencode", "opencode.json"),
+async function resolveOpenCodeConfigPath(): Promise<{
+  path: string;
+  note?: string;
+}> {
+  const configured = process.env.OPENCODE_CONFIG?.trim();
+  if (configured) return { path: resolve(configured) };
+
+  const configDirectory = resolve(
+    process.env.XDG_CONFIG_HOME?.trim() || resolve(homedir(), ".config"),
+    "opencode",
   );
+  const jsoncPath = resolve(configDirectory, "opencode.jsonc");
+  const jsonPath = resolve(configDirectory, "opencode.json");
+  const [jsoncExists, jsonExists] = await Promise.all([
+    pathExists(jsoncPath),
+    pathExists(jsonPath),
+  ]);
+
+  if (jsoncExists) {
+    return {
+      path: jsoncPath,
+      note: jsonExists
+        ? "both opencode.jsonc and opencode.json exist; selected opencode.jsonc"
+        : undefined,
+    };
+  }
+  return { path: jsonPath };
 }
 
 function resolveCursorConfigPath(): string {
@@ -1565,6 +1608,7 @@ function qoderIdeMcpServer(
 
 type JsoncMcpSettingsOptions = {
   path: string;
+  containerKey?: "mcp" | "mcpServers";
   force: boolean;
   label: string;
   server: Record<string, unknown>;
@@ -1596,13 +1640,15 @@ async function assertQoderMcpSettingsReplaceable(
 async function updateJsoncMcpSettings(
   options: JsoncMcpSettingsOptions,
 ): Promise<JsonObject> {
+  const containerKey = options.containerKey ?? "mcpServers";
   const existing = await readTextFileIfExists(options.path);
   let source = existing.trim() ? existing : "{}\n";
   const root = parseJsoncSettings(options.path, source, options.label);
-  validateMcpSettingsContainer(options.path, root);
+  validateJsoncMcpContainer(options.path, root, containerKey);
 
-  const mcpServers = isJsonObject(root.mcpServers) ? root.mcpServers : {};
-  const current = mcpServers.zvec_grep;
+  const currentContainer = root[containerKey];
+  const container = isJsonObject(currentContainer) ? currentContainer : {};
+  const current = container.zvec_grep;
   if (current !== undefined && !options.isManaged(current) && !options.force) {
     throw new Error(
       `Existing unmanaged zvec_grep MCP server found in ${options.path}. Re-run with --force to replace it for ${options.label}.`,
@@ -1611,7 +1657,7 @@ async function updateJsoncMcpSettings(
 
   source = editJsonWithComments(
     source,
-    ["mcpServers", "zvec_grep"],
+    [containerKey, "zvec_grep"],
     options.server,
   );
   await writeTextFileAtomic(options.path, ensureTrailingNewline(source));
@@ -1622,31 +1668,43 @@ async function removeJsoncMcpSettings(
   path: string,
   label: string,
   isManaged: (value: unknown) => boolean,
+  containerKey: "mcp" | "mcpServers" = "mcpServers",
 ): Promise<void> {
   const existing = await readTextFileIfExists(path);
   if (!existing.trim()) return;
 
   let source = existing;
   const root = parseJsoncSettings(path, source, label);
-  validateMcpSettingsContainer(path, root);
-  const mcpServers = isJsonObject(root.mcpServers) ? root.mcpServers : {};
+  validateJsoncMcpContainer(path, root, containerKey);
+  const currentContainer = root[containerKey];
+  const container = isJsonObject(currentContainer) ? currentContainer : {};
 
-  if (isManaged(mcpServers.zvec_grep)) {
+  if (isManaged(container.zvec_grep)) {
     source = hasJsoncComments(source)
       ? removeJsoncPropertyPreservingComments(source, [
-          "mcpServers",
+          containerKey,
           "zvec_grep",
         ])
       : editJsonWithComments(
           source,
-          Object.keys(mcpServers).length === 1
-            ? ["mcpServers"]
-            : ["mcpServers", "zvec_grep"],
+          Object.keys(container).length === 1
+            ? [containerKey]
+            : [containerKey, "zvec_grep"],
           undefined,
         );
   }
   if (source !== existing) {
     await writeTextFileAtomic(path, ensureTrailingNewline(source));
+  }
+}
+
+function validateJsoncMcpContainer(
+  path: string,
+  root: JsonObject,
+  containerKey: "mcp" | "mcpServers",
+): void {
+  if (root[containerKey] !== undefined && !isJsonObject(root[containerKey])) {
+    throw new Error(`Invalid ${containerKey} configuration in ${path}.`);
   }
 }
 
@@ -2056,6 +2114,15 @@ async function fileModeIfExists(path: string): Promise<number | undefined> {
       return undefined;
     }
     throw error;
+  }
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path, fileSystemConstants.F_OK);
+    return true;
+  } catch {
+    return false;
   }
 }
 

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -312,6 +312,8 @@ async function installOpenCodeIntegration(
   await updateJsoncMcpSettings({
     path: configPath,
     containerKey: "mcp",
+    // OpenCode accepts JSONC trailing commas, so its installer must accept them too.
+    allowTrailingComma: true,
     server:
       options.transport === "stdio"
         ? {
@@ -356,14 +358,21 @@ async function installOpenCodeIntegration(
 }
 
 async function uninstallOpenCodeIntegration(): Promise<InstallAgentResult> {
-  const { path: configPath } = await resolveOpenCodeConfigPath();
+  const resolvedConfig = await resolveOpenCodeConfigPath();
+  const configPath = resolvedConfig.path;
   const guidancePath = resolve(dirname(configPath), "AGENTS.md");
-  await removeJsoncMcpSettings(
-    configPath,
-    "OpenCode",
-    isManagedJsonMcpServer,
-    "mcp",
-  );
+  // OpenCode deep-merges both global files, so legacy managed entries in the
+  // non-selected file must also be removed. An explicit OPENCODE_CONFIG remains scoped.
+  for (const path of resolvedConfig.managedCleanupPaths ?? [configPath]) {
+    await removeJsoncMcpSettings(
+      path,
+      "OpenCode",
+      isManagedJsonMcpServer,
+      "mcp",
+      // Keep uninstall compatible with every configuration accepted by OpenCode.
+      true,
+    );
+  }
   await removeMarkedFile({
     path: guidancePath,
     startMarker: ZVEC_GREP_AGENTS_START,
@@ -867,6 +876,7 @@ function resolveClaudeMcpConfigPath(): string {
 async function resolveOpenCodeConfigPath(): Promise<{
   path: string;
   note?: string;
+  managedCleanupPaths?: readonly string[];
 }> {
   const configured = process.env.OPENCODE_CONFIG?.trim();
   if (configured) return { path: resolve(configured) };
@@ -885,12 +895,16 @@ async function resolveOpenCodeConfigPath(): Promise<{
   if (jsoncExists) {
     return {
       path: jsoncPath,
+      managedCleanupPaths: [jsoncPath, jsonPath],
       note: jsonExists
         ? "both opencode.jsonc and opencode.json exist; selected opencode.jsonc"
         : undefined,
     };
   }
-  return { path: jsonPath };
+  return {
+    path: jsonPath,
+    managedCleanupPaths: [jsoncPath, jsonPath],
+  };
 }
 
 function resolveCursorConfigPath(): string {
@@ -1609,6 +1623,7 @@ function qoderIdeMcpServer(
 type JsoncMcpSettingsOptions = {
   path: string;
   containerKey?: "mcp" | "mcpServers";
+  allowTrailingComma?: boolean;
   force: boolean;
   label: string;
   server: Record<string, unknown>;
@@ -1643,7 +1658,9 @@ async function updateJsoncMcpSettings(
   const containerKey = options.containerKey ?? "mcpServers";
   const existing = await readTextFileIfExists(options.path);
   let source = existing.trim() ? existing : "{}\n";
-  const root = parseJsoncSettings(options.path, source, options.label);
+  const root = parseJsoncSettings(options.path, source, options.label, {
+    allowTrailingComma: options.allowTrailingComma,
+  });
   validateJsoncMcpContainer(options.path, root, containerKey);
 
   const currentContainer = root[containerKey];
@@ -1669,12 +1686,15 @@ async function removeJsoncMcpSettings(
   label: string,
   isManaged: (value: unknown) => boolean,
   containerKey: "mcp" | "mcpServers" = "mcpServers",
+  allowTrailingComma = false,
 ): Promise<void> {
   const existing = await readTextFileIfExists(path);
   if (!existing.trim()) return;
 
   let source = existing;
-  const root = parseJsoncSettings(path, source, label);
+  const root = parseJsoncSettings(path, source, label, {
+    allowTrailingComma,
+  });
   validateJsoncMcpContainer(path, root, containerKey);
   const currentContainer = root[containerKey];
   const container = isJsonObject(currentContainer) ? currentContainer : {};
@@ -1712,10 +1732,11 @@ function parseJsoncSettings(
   path: string,
   source: string,
   label: string,
+  options: { allowTrailingComma?: boolean } = {},
 ): JsonObject {
   const errors: ParseError[] = [];
   const parsed = parseJsonWithComments(source, errors, {
-    allowTrailingComma: false,
+    allowTrailingComma: options.allowTrailingComma ?? false,
     disallowComments: false,
   });
   if (errors.length > 0 || !isJsonObject(parsed)) {

--- a/test/install.test.mjs
+++ b/test/install.test.mjs
@@ -2036,6 +2036,91 @@ test("OpenCode installer preserves config and manages a remote MCP server", asyn
   assert.doesNotMatch(uninstalledGuidance, /ZVEC_GREP|## zvec-grep/);
 });
 
+test("OpenCode installer selects an existing JSONC config and preserves comments", async (t) => {
+  const temporaryDirectory = await mkdtemp(
+    join(tmpdir(), "zvec-grep-install-opencode-jsonc-"),
+  );
+  const xdgConfigHome = join(temporaryDirectory, "config");
+  const configDirectory = join(xdgConfigHome, "opencode");
+  const jsoncPath = join(configDirectory, "opencode.jsonc");
+  const jsonPath = join(configDirectory, "opencode.json");
+  t.after(async () => {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  });
+
+  await mkdir(configDirectory, { recursive: true });
+  await writeFile(
+    jsoncPath,
+    `{
+  // Keep this user setting and its comment.
+  "model": "custom/model",
+  "mcp": {
+    "other": { "type": "remote", "url": "https://example.com/mcp" }
+  }
+}
+`,
+  );
+
+  const { stdout } = await installTarget("opencode", {
+    OPENCODE_CONFIG: undefined,
+    XDG_CONFIG_HOME: xdgConfigHome,
+  });
+
+  assert.ok(stdout.includes(`Config    ${jsoncPath}`));
+  await assert.rejects(stat(jsonPath), { code: "ENOENT" });
+  const installedSource = await readFile(jsoncPath, "utf8");
+  assert.match(installedSource, /Keep this user setting and its comment/);
+  const installed = parseJsonWithComments(installedSource);
+  assert.equal(installed.model, "custom/model");
+  assert.equal(installed.mcp.other.url, "https://example.com/mcp");
+  assert.equal(installed.mcp.zvec_grep.enabled, true);
+
+  await uninstallTarget("opencode", {
+    OPENCODE_CONFIG: undefined,
+    XDG_CONFIG_HOME: xdgConfigHome,
+  });
+  const uninstalledSource = await readFile(jsoncPath, "utf8");
+  assert.match(uninstalledSource, /Keep this user setting and its comment/);
+  const uninstalled = parseJsonWithComments(uninstalledSource);
+  assert.equal(uninstalled.mcp.zvec_grep, undefined);
+  assert.equal(uninstalled.mcp.other.url, "https://example.com/mcp");
+});
+
+test("OpenCode installer explains that JSONC wins when both configs exist", async (t) => {
+  const temporaryDirectory = await mkdtemp(
+    join(tmpdir(), "zvec-grep-install-opencode-both-"),
+  );
+  const xdgConfigHome = join(temporaryDirectory, "config");
+  const configDirectory = join(xdgConfigHome, "opencode");
+  const jsoncPath = join(configDirectory, "opencode.jsonc");
+  const jsonPath = join(configDirectory, "opencode.json");
+  t.after(async () => {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  });
+
+  await mkdir(configDirectory, { recursive: true });
+  const originalJson = '{"model":"json/model"}\n';
+  await writeFile(jsonPath, originalJson);
+  await writeFile(
+    jsoncPath,
+    '{\n  // Active config\n  "model": "jsonc/model"\n}\n',
+  );
+
+  const { stdout } = await installTarget("opencode", {
+    OPENCODE_CONFIG: undefined,
+    XDG_CONFIG_HOME: xdgConfigHome,
+  });
+
+  assert.ok(stdout.includes(`Config    ${jsoncPath}`));
+  assert.match(
+    stdout,
+    /both opencode\.jsonc and opencode\.json exist; selected opencode\.jsonc/,
+  );
+  assert.equal(await readFile(jsonPath, "utf8"), originalJson);
+  const jsonc = parseJsonWithComments(await readFile(jsoncPath, "utf8"));
+  assert.equal(jsonc.mcp.zvec_grep.enabled, true);
+});
+
 test("JSON installers require force before replacing an unmanaged server", async (t) => {
   const temporaryDirectory = await mkdtemp(
     join(tmpdir(), "zvec-grep-install-json-conflict-"),

--- a/test/install.test.mjs
+++ b/test/install.test.mjs
@@ -2086,6 +2086,51 @@ test("OpenCode installer selects an existing JSONC config and preserves comments
   assert.equal(uninstalled.mcp.other.url, "https://example.com/mcp");
 });
 
+test("OpenCode installer leaves an unmanaged JSONC entry byte-identical without force", async (t) => {
+  const temporaryDirectory = await mkdtemp(
+    join(tmpdir(), "zvec-grep-install-opencode-jsonc-conflict-"),
+  );
+  const xdgConfigHome = join(temporaryDirectory, "config");
+  const configDirectory = join(xdgConfigHome, "opencode");
+  const configPath = join(configDirectory, "opencode.jsonc");
+  t.after(async () => {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  });
+
+  await mkdir(configDirectory, { recursive: true });
+  await writeFile(
+    configPath,
+    `{
+  // Keep this header and the unmanaged server exactly as written.
+  "model": "custom/model",
+  "mcp": {
+    "zvec_grep": {
+      "type": "remote",
+      "url": "https://example.com/unmanaged"
+    },
+    "other": { "type": "remote", "url": "https://example.com/mcp" }
+  }
+}
+`,
+  );
+  const original = await readFile(configPath);
+
+  await assert.rejects(
+    installTarget("opencode", {
+      OPENCODE_CONFIG: undefined,
+      XDG_CONFIG_HOME: xdgConfigHome,
+    }),
+    (error) => {
+      assert.match(error.stderr, /Existing unmanaged zvec_grep MCP server/);
+      assert.ok(error.stderr.includes(configPath));
+      assert.match(error.stderr, /--force/);
+      return true;
+    },
+  );
+
+  assert.deepEqual(await readFile(configPath), original);
+});
+
 test("OpenCode installer explains that JSONC wins when both configs exist", async (t) => {
   const temporaryDirectory = await mkdtemp(
     join(tmpdir(), "zvec-grep-install-opencode-both-"),

--- a/test/install.test.mjs
+++ b/test/install.test.mjs
@@ -2036,7 +2036,7 @@ test("OpenCode installer preserves config and manages a remote MCP server", asyn
   assert.doesNotMatch(uninstalledGuidance, /ZVEC_GREP|## zvec-grep/);
 });
 
-test("OpenCode installer selects an existing JSONC config and preserves comments", async (t) => {
+test("OpenCode install and uninstall accept JSONC comments and trailing commas", async (t) => {
   const temporaryDirectory = await mkdtemp(
     join(tmpdir(), "zvec-grep-install-opencode-jsonc-"),
   );
@@ -2055,8 +2055,8 @@ test("OpenCode installer selects an existing JSONC config and preserves comments
   // Keep this user setting and its comment.
   "model": "custom/model",
   "mcp": {
-    "other": { "type": "remote", "url": "https://example.com/mcp" }
-  }
+    "other": { "type": "remote", "url": "https://example.com/mcp", },
+  },
 }
 `,
   );
@@ -2070,7 +2070,9 @@ test("OpenCode installer selects an existing JSONC config and preserves comments
   await assert.rejects(stat(jsonPath), { code: "ENOENT" });
   const installedSource = await readFile(jsoncPath, "utf8");
   assert.match(installedSource, /Keep this user setting and its comment/);
-  const installed = parseJsonWithComments(installedSource);
+  const installed = parseJsonWithComments(installedSource, [], {
+    allowTrailingComma: true,
+  });
   assert.equal(installed.model, "custom/model");
   assert.equal(installed.mcp.other.url, "https://example.com/mcp");
   assert.equal(installed.mcp.zvec_grep.enabled, true);
@@ -2081,7 +2083,9 @@ test("OpenCode installer selects an existing JSONC config and preserves comments
   });
   const uninstalledSource = await readFile(jsoncPath, "utf8");
   assert.match(uninstalledSource, /Keep this user setting and its comment/);
-  const uninstalled = parseJsonWithComments(uninstalledSource);
+  const uninstalled = parseJsonWithComments(uninstalledSource, [], {
+    allowTrailingComma: true,
+  });
   assert.equal(uninstalled.mcp.zvec_grep, undefined);
   assert.equal(uninstalled.mcp.other.url, "https://example.com/mcp");
 });
@@ -2131,7 +2135,7 @@ test("OpenCode installer leaves an unmanaged JSONC entry byte-identical without 
   assert.deepEqual(await readFile(configPath), original);
 });
 
-test("OpenCode installer explains that JSONC wins when both configs exist", async (t) => {
+test("OpenCode uninstaller removes legacy managed entries from both global configs", async (t) => {
   const temporaryDirectory = await mkdtemp(
     join(tmpdir(), "zvec-grep-install-opencode-both-"),
   );
@@ -2144,7 +2148,17 @@ test("OpenCode installer explains that JSONC wins when both configs exist", asyn
   });
 
   await mkdir(configDirectory, { recursive: true });
-  const originalJson = '{"model":"json/model"}\n';
+  const originalJson = `${JSON.stringify({
+    model: "json/model",
+    mcp: {
+      zvec_grep: {
+        type: "remote",
+        url: "http://127.0.0.1:7999/mcp",
+        enabled: true,
+      },
+      other: { type: "remote", url: "https://example.com/mcp" },
+    },
+  })}\n`;
   await writeFile(jsonPath, originalJson);
   await writeFile(
     jsoncPath,
@@ -2164,6 +2178,20 @@ test("OpenCode installer explains that JSONC wins when both configs exist", asyn
   assert.equal(await readFile(jsonPath, "utf8"), originalJson);
   const jsonc = parseJsonWithComments(await readFile(jsoncPath, "utf8"));
   assert.equal(jsonc.mcp.zvec_grep.enabled, true);
+
+  await uninstallTarget("opencode", {
+    OPENCODE_CONFIG: undefined,
+    XDG_CONFIG_HOME: xdgConfigHome,
+  });
+
+  const uninstalledJson = JSON.parse(await readFile(jsonPath, "utf8"));
+  assert.equal(uninstalledJson.mcp.zvec_grep, undefined);
+  assert.equal(uninstalledJson.mcp.other.url, "https://example.com/mcp");
+  const uninstalledJsonc = parseJsonWithComments(
+    await readFile(jsoncPath, "utf8"),
+  );
+  assert.deepEqual(uninstalledJsonc.mcp, {});
+  assert.equal(uninstalledJsonc.model, "jsonc/model");
 });
 
 test("JSON installers require force before replacing an unmanaged server", async (t) => {


### PR DESCRIPTION
## Summary

Fixes #103.

This updates the OpenCode installer to use an existing `opencode.jsonc` configuration instead of always creating `opencode.json`.

It also routes OpenCode configuration updates through the existing JSONC-preserving editor, so comments and unrelated user settings are retained during installation and uninstallation.

## Changes

- Respect `OPENCODE_CONFIG` when it specifies an explicit configuration file.
- Respect `XDG_CONFIG_HOME` when resolving the default OpenCode configuration directory.
- Prefer an existing `opencode.jsonc` over `opencode.json`.
- Continue creating `opencode.json` when neither configuration file exists.
- Preserve JSONC comments, formatting, unrelated settings, and other MCP entries.
- Use the same configuration-path resolution logic for installation and uninstallation.
- Report the selected OpenCode configuration path in the install output.
- Report when both `opencode.jsonc` and `opencode.json` exist and `opencode.jsonc` is selected.
- Generalize the existing JSONC MCP editor to support both:
  - `mcpServers.zvec_grep` for existing Qwen/Qoder integrations
  - `mcp.zvec_grep` for OpenCode
- Add regression tests for JSONC selection, comment preservation, uninstallation, and the two-file case.
- Update the OpenCode integration documentation.

## Configuration selection

The OpenCode installer now uses the following order:

1. The file explicitly specified by `OPENCODE_CONFIG`.
2. An existing global `opencode.jsonc`.
3. An existing global `opencode.json`.
4. A new global `opencode.json` if neither file exists.

When both global files exist, the installer selects `opencode.jsonc` and explains the choice in its output.

## Example output

```text
✓ OpenCode
  MCP       configured
  Config    /home/user/.config/opencode/opencode.jsonc
  Note      both opencode.jsonc and opencode.json exist; selected opencode.jsonc
```

## Compatibility

The shared JSONC helper still defaults to the existing `mcpServers` container, so Qwen and Qoder behavior remains unchanged. OpenCode explicitly selects the `mcp` container.

## Testing

The following checks pass:

- `npm run typecheck`
- `npm run lint`
- `npm run build`
- OpenCode installer regression tests
- Qwen JSONC regression test

The new tests verify that:

- An existing `opencode.jsonc` is updated without creating `opencode.json`.
- JSONC comments and unrelated settings are preserved.
- Uninstallation removes only the managed `zvec_grep` entry.
- When both files exist, `opencode.jsonc` is selected and `opencode.json` remains unchanged.
- The selected configuration path and selection reason are shown in the output.