### PR TITLE
docs: recommend adding .zvec-grep to .gitignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ zg index --embedding local/potion-retrieval-32m
 ```
 
 > [!NOTE]
-> The index is stored in `.zvec-grep/` under the indexed project root.
+> The index is stored in `.zvec-grep/` under the indexed project root. Add `.zvec-grep/` to your `.gitignore`—the index stores host-specific paths and local filesystem timestamps that are not portable across machines or platforms.
 
 > [!TIP]
 > If `zg index` or `zg query` fails, rerun the same command with `--debug`

--- a/README_CN.md
+++ b/README_CN.md
@@ -76,7 +76,7 @@ zg index --embedding local/potion-retrieval-32m
 ```
 
 > [!NOTE]
-> 索引保存在被索引项目根目录的 `.zvec-grep/` 中。
+> 索引保存在被索引项目根目录的 `.zvec-grep/` 中。建议将 `.zvec-grep/` 添加至 `.gitignore`（索引包含本机特定路径及本地文件时间戳，不适用于跨机器或跨平台共享）。
 
 > [!TIP]
 > `zg index` 或 `zg query` 失败时，在原命令后加 `--debug` 重跑，查看诊断信息（direct 和 server 模式均支持）。

--- a/docs/04-pipeline.md
+++ b/docs/04-pipeline.md
@@ -29,9 +29,12 @@ zg index /absolute/path/to/your-repository \
 ```
 
 The workspace index is stored under `<root>/.zvec-grep/`. `.git` and
-`.zvec-grep` are always excluded. Common dependency, build, generated, cache,
-and log directories are excluded by default, as are files ignored by the
-repository's ignore rules.
+`.zvec-grep` are always excluded from indexing. Add `.zvec-grep/` to your
+repository's `.gitignore`—the index stores machine-local absolute paths and
+tracks filesystem timestamps (`mtime`), so it is not portable across machines
+or operating systems. Common dependency, build, generated, cache, and log
+directories are excluded by default, as are files ignored by the repository's
+ignore rules.
 
 The main workspace files are `manifest.json`, `files.zvec`, and `index.zvec`.
 The manifest stores index metadata and the workspace Embedding runtime settings,


### PR DESCRIPTION
### Summary
Clarifies in README.md, README_CN.md, and docs/04-pipeline.md that .zvec-grep/ should be added to .gitignore.

### Context
When working across multiple machines or operating systems (e.g. Windows and Linux), it's easy to wonder whether the workspace index can be checked into Git. Because zvec-grep stores host-specific absolute paths and tracks filesystem mtime (which Git checkout resets), sharing prebuilt index binaries across machines or platforms is not supported and will trigger immediate re-indexes.

Adding a quick note in the setup and pipeline docs helps users avoid accidentally committing .zvec-grep/ binaries to their repositories.