### PR TITLE
feat: add Oh My Pi (ohmypi) agent install target

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ Embedding.
 
 | Guide | What you can do |
 | :--- | :--- |
-| [Agent integrations](./docs/01-agents.md) | Connect zg to Codex, Claude Code, Qwen Code, Qoder, Cursor, or OpenCode and verify that it works. |
+| [Agent integrations](./docs/01-agents.md) | Connect zg to Codex, Claude Code, Qwen Code, Qoder, Cursor, OpenCode, or Oh My Pi and verify that it works. |
 | [CLI guide](./docs/02-cli.md) | Search, index, and manage your local workspaces from the terminal. |
 | [MCP guide](./docs/03-mcp.md) | Understand which zg tools your agent can use and how access is secured. |
 | [Retrieval pipeline](./docs/04-pipeline.md) | Choose what to index, keep it fresh, and get better search results. |

--- a/README_CN.md
+++ b/README_CN.md
@@ -210,7 +210,7 @@ Profile 均使用 Qwen3.7 Text Embedding。
 
 | 指南 | 你可以完成什么 |
 | :--- | :--- |
-| [Agent 集成](./docs/01-agents.md) | 将 zg 接入 Codex、Claude Code、Qwen Code、Qoder、Cursor 或 OpenCode，并验证是否正常工作。 |
+| [Agent 集成](./docs/01-agents.md) | 将 zg 接入 Codex、Claude Code、Qwen Code、Qoder、Cursor、OpenCode 或 Oh My Pi，并验证是否正常工作。 |
 | [CLI 指南](./docs/02-cli.md) | 在终端中搜索、索引和管理本地工作区。 |
 | [MCP 指南](./docs/03-mcp.md) | 了解 Agent 可以使用哪些 zg 工具，以及访问权限如何受到保护。 |
 | [检索 Pipeline](./docs/04-pipeline.md) | 选择索引范围、保持内容新鲜，并获得更好的检索结果。 |

--- a/docs/01-agents.md
+++ b/docs/01-agents.md
@@ -19,12 +19,13 @@ managed-rg route.
 | Qwen Code | `qwen` | `~/.qwen/settings.json` and `~/.qwen/QWEN.md` |
 | Qoder CLI and IDE | `qoder` | `~/.qoder/settings.json`, `~/.qoder/AGENTS.md`, and the IDE user-level `~/.qoder/mcp.json` |
 | OpenCode | `opencode` | `~/.config/opencode/opencode.json` and the adjacent `AGENTS.md` |
+| Oh My Pi | `ohmypi` | `~/.omp/agent/mcp.json` and the adjacent `AGENTS.md` |
 | Cursor | `cursor` | `~/.cursor/mcp.json` |
 
 The standard environment overrides used by each agent are respected, including
 `CODEX_HOME`, `CLAUDE_CONFIG_DIR`, `QWEN_HOME`, `QODER_CONFIG_DIR`,
-`QODER_IDE_MCP_PATH`, `QODER_IDE_EXECUTABLE`, `OPENCODE_CONFIG`, and
-`CURSOR_CONFIG_DIR`.
+`QODER_IDE_MCP_PATH`, `QODER_IDE_EXECUTABLE`, `OPENCODE_CONFIG`,
+`CURSOR_CONFIG_DIR`, and `PI_CODING_AGENT_DIR`.
 
 The current Qoder CLI package exposes both `qoder` and `qodercli` commands, but
 the installer exposes only the canonical `qoder` target. One Qoder install
@@ -48,6 +49,7 @@ zg install --target codex --yes
 zg install --target claude --target cursor --yes
 zg install --target qwen --yes
 zg install --target qoder --yes
+zg install --target ohmypi --yes
 zg install --target all --yes
 ```
 
@@ -171,7 +173,7 @@ zg server status --check-ready
 Then start a new agent session and confirm that the client-specific search tool
 is available. It is `zvec_grep_search` in Codex and Claude Code,
 `mcp__zvec_grep__zvec_grep_search` in Qwen Code and Qoder CLI, and
-`zvec_grep_zvec_grep_search` in OpenCode. With the optional `full` MCP toolset,
+`zvec_grep_zvec_grep_search` in OpenCode, and `mcp__zvec_grep_search` in Oh My Pi. With the optional `full` MCP toolset,
 Qoder CLI exposes managed rg as `mcp__zvec_grep__zvec_grep_rg`. For Qoder IDE,
 confirm after restart that the `zvec_grep` server and its tools appear; the exact
 host-qualified tool label remains part of the real-machine smoke test. If the

--- a/docs/02-cli.md
+++ b/docs/02-cli.md
@@ -146,8 +146,8 @@ scripts.
 ## `zg install` and `zg uninstall`
 
 ```text
-zg install [--target codex|claude|qwen|qoder|opencode|cursor|all|auto] [--mcp-transport stdio|http] [--mcp-toolset agent|full] [--yes] [--force]
-zg uninstall [--target codex|claude|qwen|qoder|opencode|cursor|all|auto] [--yes]
+zg install [--target codex|claude|qwen|qoder|opencode|ohmypi|cursor|all|auto] [--mcp-transport stdio|http] [--mcp-toolset agent|full] [--yes] [--force]
+zg uninstall [--target codex|claude|qwen|qoder|opencode|ohmypi|cursor|all|auto] [--yes]
 ```
 
 `--target` is repeatable. `qoder` is the single Qoder target and configures
@@ -157,7 +157,7 @@ Qoder CLI and Qoder IDE together. `zg install` also accepts:
 | --- | --- |
 | `--mcp-transport <stdio\|http>` | MCP connection mode; default `stdio` |
 | `--mcp-toolset <agent\|full>` | Daemon MCP surface; default `agent` |
-| `--mcp-tool-timeout <seconds>` | Codex, Qwen Code, both Qoder clients, and OpenCode MCP timeout; default 600 seconds |
+| `--mcp-tool-timeout <seconds>` | Codex, Qwen Code, both Qoder clients, OpenCode, and Oh My Pi MCP timeout; default 600 seconds |
 | `--mcp-token-env <name>` | Environment variable containing the server token |
 | `--force` | Replace a conflicting unmanaged `zvec_grep` entry |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@ interfaces.
 
 | I want to… | Read |
 | --- | --- |
-| Connect Codex, Claude Code, Qwen Code, Cursor, or OpenCode | [Agent integrations](./01-agents.md) |
+| Connect Codex, Claude Code, Qwen Code, Cursor, OpenCode, or Oh My Pi | [Agent integrations](./01-agents.md) |
 | Use zg directly from a terminal | [CLI guide](./02-cli.md) |
 | Understand the tools exposed to an agent | [MCP guide](./03-mcp.md) |
 | Understand indexing, updates, and search routes | [Retrieval pipeline](./04-pipeline.md) |

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -302,10 +302,10 @@ ${formatEnvironmentVariables([
 See zg help environment for daemon startup scope.`;
     case "install":
       return `Usage:
-  zg install [--target codex|claude|qwen|qoder|opencode|cursor|all|auto] [--mcp-transport stdio|http] [--mcp-toolset agent|full] [--yes] [--force]
+  zg install [--target codex|claude|qwen|qoder|opencode|ohmypi|cursor|all|auto] [--mcp-transport stdio|http] [--mcp-toolset agent|full] [--yes] [--force]
 
 Options:
-  --target <agent>                  codex, claude, qwen, qoder, opencode, cursor, auto, or all; repeatable
+  --target <agent>                  codex, claude, qwen, qoder, opencode, ohmypi, cursor, auto, or all; repeatable
   --mcp-transport <stdio|http>      MCP connection mode (default: stdio)
   --mcp-toolset <agent|full>        Daemon MCP toolset (default: agent)
   --mcp-tool-timeout <seconds>      MCP tool timeout where supported (default: 600)
@@ -318,7 +318,7 @@ The qoder target configures Qoder CLI and Qoder IDE together.
 Interactive setup detects supported agents, configures stdio by default, and
 starts the shared daemon. In stdio mode an agent reconnect also starts the
 daemon automatically after a reboot. HTTP users manage later daemon restarts.
-Codex, Claude Code, Qwen Code, Qoder CLI, and OpenCode also receive managed
+Codex, Claude Code, Qwen Code, Qoder CLI, OpenCode, and Oh My Pi also receive managed
 guidance. Qoder IDE has no supported global Rules file, so only its MCP
 configuration is managed.
 Codex and Claude Code receive local tool pre-approval. Qoder's CLI-backed
@@ -328,7 +328,7 @@ use. Restart the agent or open a new session after installation. This does not
 install the npm package.`;
     case "uninstall":
       return `Usage:
-  zg uninstall [--target codex|claude|qwen|qoder|opencode|cursor|all|auto] [--yes]
+  zg uninstall [--target codex|claude|qwen|qoder|opencode|ohmypi|cursor|all|auto] [--yes]
 
 Removes zvec-grep-managed MCP configuration, agent-specific approval, and
 guidance. The qoder target removes the managed Qoder CLI and IDE integration

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -84,6 +84,13 @@ const AGENT_INSTALLERS: readonly AgentInstaller[] = [
     uninstall: uninstallOpenCodeIntegration,
   },
   {
+    id: "ohmypi",
+    label: "Oh My Pi",
+    executables: ["omp"],
+    install: installOhMyPiIntegration,
+    uninstall: uninstallOhMyPiIntegration,
+  },
+  {
     id: "cursor",
     label: "Cursor",
     executables: ["cursor"],
@@ -291,6 +298,64 @@ async function uninstallCodexIntegration(): Promise<InstallAgentResult> {
   });
 
   return { files: [configPath, agentsPath] };
+}
+
+async function installOhMyPiIntegration(
+  options: InstallAgentOptions,
+): Promise<InstallAgentResult> {
+  const configPath = resolveOhMyPiConfigPath();
+  const guidancePath = resolve(dirname(configPath), "AGENTS.md");
+  await installJsonMcpServer({
+    path: configPath,
+    containerKey: "mcp",
+    server:
+      options.transport === "stdio"
+        ? {
+            type: "local",
+            command: stdioCommand(options.mcpToolset),
+            enabled: true,
+            timeout: options.mcpToolTimeoutSeconds * 1_000,
+          }
+        : {
+            type: "remote",
+            url: resolveServerUrl(),
+            enabled: true,
+            timeout: options.mcpToolTimeoutSeconds * 1_000,
+            oauth: false,
+            ...(options.mcpTokenEnv
+              ? {
+                  headers: {
+                    Authorization: `Bearer {env:${options.mcpTokenEnv}}`,
+                  },
+                }
+              : {}),
+          },
+    force: options.force,
+    label: "Oh My Pi",
+  });
+  await writeMarkedFile({
+    path: guidancePath,
+    startMarker: ZVEC_GREP_AGENTS_START,
+    endMarker: ZVEC_GREP_AGENTS_END,
+    block: agentGuidanceBlock({
+      search: "zvec_grep_zvec_grep_search",
+      rg: "zvec_grep_zvec_grep_rg",
+    }),
+    force: true,
+  });
+  return { files: [configPath, guidancePath] };
+}
+
+async function uninstallOhMyPiIntegration(): Promise<InstallAgentResult> {
+  const configPath = resolveOhMyPiConfigPath();
+  const guidancePath = resolve(dirname(configPath), "AGENTS.md");
+  await uninstallJsonMcpServer(configPath, "mcp");
+  await removeMarkedFile({
+    path: guidancePath,
+    startMarker: ZVEC_GREP_AGENTS_START,
+    endMarker: ZVEC_GREP_AGENTS_END,
+  });
+  return { files: [configPath, guidancePath] };
 }
 
 async function installOpenCodeIntegration(
@@ -847,6 +912,15 @@ function resolveOpenCodeConfigPath(): string {
   return resolve(
     process.env.OPENCODE_CONFIG ??
       resolve(homedir(), ".config", "opencode", "opencode.json"),
+  );
+}
+
+function resolveOhMyPiConfigPath(): string {
+  // oh my pi (omp.sh) is built on top of pi (pi.dev)
+  // installing support for oh my pi, and we use PI_CONFIG_DIR
+  return resolve(
+    process.env.PI_CODING_AGENT_DIR ??
+      resolve(homedir(), ".omp", "agent", "mcp.json"),
   );
 }
 

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -122,6 +122,8 @@ const ZVEC_GREP_AGENTS_END = "<!-- ZVEC_GREP_END -->";
 const CLAUDE_MCP_PERMISSION = "mcp__zvec_grep__*";
 const NAMESPACED_SEARCH_TOOL = "mcp__zvec_grep__zvec_grep_search";
 const NAMESPACED_RG_TOOL = "mcp__zvec_grep__zvec_grep_rg";
+const OMP_MCP_SEARCH_TOOL = "mcp__zvec_grep_search";
+const OMP_MCP_RG_TOOL = "mcp__zvec_grep_rg";
 const QODER_MCP_PERMISSION_RULES = [
   {
     permission: NAMESPACED_SEARCH_TOOL,
@@ -307,29 +309,8 @@ async function installOhMyPiIntegration(
   const guidancePath = resolve(dirname(configPath), "AGENTS.md");
   await installJsonMcpServer({
     path: configPath,
-    containerKey: "mcp",
-    server:
-      options.transport === "stdio"
-        ? {
-            type: "local",
-            command: stdioCommand(options.mcpToolset),
-            enabled: true,
-            timeout: options.mcpToolTimeoutSeconds * 1_000,
-          }
-        : {
-            type: "remote",
-            url: resolveServerUrl(),
-            enabled: true,
-            timeout: options.mcpToolTimeoutSeconds * 1_000,
-            oauth: false,
-            ...(options.mcpTokenEnv
-              ? {
-                  headers: {
-                    Authorization: `Bearer {env:${options.mcpTokenEnv}}`,
-                  },
-                }
-              : {}),
-          },
+    containerKey: "mcpServers",
+    server: ohMyPiMcpServer(options),
     force: options.force,
     label: "Oh My Pi",
   });
@@ -338,8 +319,8 @@ async function installOhMyPiIntegration(
     startMarker: ZVEC_GREP_AGENTS_START,
     endMarker: ZVEC_GREP_AGENTS_END,
     block: agentGuidanceBlock({
-      search: "zvec_grep_zvec_grep_search",
-      rg: "zvec_grep_zvec_grep_rg",
+      search: OMP_MCP_SEARCH_TOOL,
+      rg: OMP_MCP_RG_TOOL,
     }),
     force: true,
   });
@@ -349,7 +330,7 @@ async function installOhMyPiIntegration(
 async function uninstallOhMyPiIntegration(): Promise<InstallAgentResult> {
   const configPath = resolveOhMyPiConfigPath();
   const guidancePath = resolve(dirname(configPath), "AGENTS.md");
-  await uninstallJsonMcpServer(configPath, "mcp");
+  await uninstallJsonMcpServer(configPath, "mcpServers");
   await removeMarkedFile({
     path: guidancePath,
     startMarker: ZVEC_GREP_AGENTS_START,
@@ -916,11 +897,11 @@ function resolveOpenCodeConfigPath(): string {
 }
 
 function resolveOhMyPiConfigPath(): string {
-  // oh my pi (omp.sh) is built on top of pi (pi.dev)
-  // installing support for oh my pi, and we use PI_CONFIG_DIR
+  // Oh My Pi (omp.sh) is built on pi (pi.dev). PI_CODING_AGENT_DIR
+  // overrides the agent directory, which defaults to ~/.omp/agent.
   return resolve(
-    process.env.PI_CODING_AGENT_DIR ??
-      resolve(homedir(), ".omp", "agent", "mcp.json"),
+    process.env.PI_CODING_AGENT_DIR ?? resolve(homedir(), ".omp", "agent"),
+    "mcp.json",
   );
 }
 
@@ -1570,6 +1551,44 @@ function qwenMcpServer(options: InstallAgentOptions): Record<string, unknown> {
         }
       : {}),
   };
+}
+
+function ohMyPiMcpServer(
+  options: InstallAgentOptions,
+): Record<string, unknown> {
+  const timeout = options.mcpToolTimeoutSeconds * 1_000;
+  if (options.transport === "stdio") {
+    return {
+      command: "zg",
+      args: stdioArgs(options.mcpToolset),
+      enabled: true,
+      timeout,
+    };
+  }
+
+  return {
+    type: "http",
+    url: resolveServerUrl(),
+    enabled: true,
+    timeout,
+    ...(options.mcpTokenEnv
+      ? {
+          headers: {
+            Authorization: `Bearer ${resolveOhMyPiMcpToken(options.mcpTokenEnv)}`,
+          },
+        }
+      : {}),
+  };
+}
+
+function resolveOhMyPiMcpToken(envName: string): string {
+  const token = process.env[envName];
+  if (!token) {
+    throw new Error(
+      `Environment variable ${envName} is not set. Oh My Pi does not expand environment variables in MCP headers, so set it and re-run zg install.`,
+    );
+  }
+  return token;
 }
 
 function qoderMcpServer(

--- a/test/install.test.mjs
+++ b/test/install.test.mjs
@@ -28,17 +28,20 @@ test("interactive installer marker follows the active agent", () => {
   const detected = new Set(["claude", "codex"]);
   const claude = installerSelectionLines(0, detected);
   const codex = installerSelectionLines(1, detected);
-  const qwen = installerSelectionLines(4, detected);
+  const ohMyPi = installerSelectionLines(3, detected);
+  const qwen = installerSelectionLines(5, detected);
 
   assert.match(claude[0], /● Claude Code\s+detected/);
   assert.match(claude[1], /○ Codex\s+detected/);
   assert.match(codex[0], /○ Claude Code\s+detected/);
   assert.match(codex[1], /● Codex\s+detected/);
+  assert.match(ohMyPi[3], /● Oh My Pi\s+not found/);
   assert.match(qwen[0], /○ Claude Code\s+detected/);
   assert.match(qwen[1], /○ Codex\s+detected/);
   assert.match(qwen[2], /○ OpenCode\s+not found/);
-  assert.match(qwen[3], /○ Cursor\s+not found/);
-  assert.match(qwen[4], /● Qwen Code\s+not found/);
+  assert.match(qwen[3], /○ Oh My Pi\s+not found/);
+  assert.match(qwen[4], /○ Cursor\s+not found/);
+  assert.match(qwen[5], /● Qwen Code\s+not found/);
   assert.match(codex.at(-1), /Use ↑↓ to move · Enter to select/);
   assert.doesNotMatch(codex.join("\n"), /Space|\[●\]/);
 });
@@ -696,7 +699,7 @@ test("Claude Code installer accepts cc and claude-code compatibility aliases", a
   }
 });
 
-test("Qwen Code installer accepts qwen aliases and numeric target 5", async (t) => {
+test("Qwen Code installer accepts qwen aliases and numeric target 6", async (t) => {
   const temporaryDirectory = await mkdtemp(
     join(tmpdir(), "zvec-grep-install-qwen-aliases-"),
   );
@@ -704,7 +707,7 @@ test("Qwen Code installer accepts qwen aliases and numeric target 5", async (t) 
     await rm(temporaryDirectory, { recursive: true, force: true });
   });
 
-  for (const target of ["qwen", "qwen-code", "qwencode", "5"]) {
+  for (const target of ["qwen", "qwen-code", "qwencode", "6"]) {
     const qwenHome = join(temporaryDirectory, target);
     await installTarget(target, { QWEN_HOME: qwenHome });
     const config = JSON.parse(
@@ -1122,7 +1125,7 @@ test("Qoder installer accepts its canonical and numeric targets", async (t) => {
     await rm(temporaryDirectory, { recursive: true, force: true });
   });
 
-  for (const target of ["qoder", "6"]) {
+  for (const target of ["qoder", "7"]) {
     const qoderConfigDirectory = join(temporaryDirectory, target);
     await installTarget(target, {
       QODER_CONFIG_DIR: qoderConfigDirectory,
@@ -2033,6 +2036,79 @@ test("OpenCode installer preserves config and manages a remote MCP server", asyn
   assert.equal(uninstalled.mcp.other.url, "https://example.com/mcp");
   const uninstalledGuidance = await readFile(guidancePath, "utf8");
   assert.match(uninstalledGuidance, /# Existing OpenCode guidance/);
+  assert.doesNotMatch(uninstalledGuidance, /ZVEC_GREP|## zvec-grep/);
+});
+
+test("Oh My Pi installer preserves config and manages MCP servers", async (t) => {
+  const temporaryDirectory = await mkdtemp(
+    join(tmpdir(), "zvec-grep-install-ohmypi-"),
+  );
+  const agentDir = join(temporaryDirectory, ".omp", "agent");
+  const configPath = join(agentDir, "mcp.json");
+  const guidancePath = join(agentDir, "AGENTS.md");
+  t.after(async () => {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  });
+
+  await mkdir(agentDir, { recursive: true });
+  await writeFile(guidancePath, "# Existing Oh My Pi guidance\n");
+  await writeFile(
+    configPath,
+    `${JSON.stringify({ mcpServers: { other: { type: "http", url: "https://example.com/mcp" } } }, null, 2)}\n`,
+  );
+
+  await installTarget("ohmypi", { PI_CODING_AGENT_DIR: agentDir }, [
+    "--mcp-tool-timeout=900",
+  ]);
+  const stdioConfig = JSON.parse(await readFile(configPath, "utf8"));
+  assert.equal(stdioConfig.mcpServers.other.url, "https://example.com/mcp");
+  assert.deepEqual(stdioConfig.mcpServers.zvec_grep, {
+    command: "zg",
+    args: ["server", "--stdio"],
+    enabled: true,
+    timeout: 900000,
+  });
+  const stdioGuidance = await readFile(guidancePath, "utf8");
+  assert.match(stdioGuidance, /# Existing Oh My Pi guidance/);
+  assert.match(
+    stdioGuidance,
+    /Use `mcp__zvec_grep_search` when wording or location is unknown/,
+  );
+  assert.match(stdioGuidance, /`mcp__zvec_grep_rg` when it is listed/);
+  assert.equal(countOccurrences(stdioGuidance, "<!-- ZVEC_GREP_START -->"), 1);
+  assert.equal(countOccurrences(stdioGuidance, "<!-- ZVEC_GREP_END -->"), 1);
+
+  await installTarget(
+    "ohmypi",
+    {
+      PI_CODING_AGENT_DIR: agentDir,
+      ZVEC_GREP_SERVER_TOKEN: "secret-token",
+    },
+    ["--mcp-transport=http", "--mcp-token-env=ZVEC_GREP_SERVER_TOKEN"],
+  );
+  const httpConfig = JSON.parse(await readFile(configPath, "utf8"));
+  assert.deepEqual(httpConfig.mcpServers.zvec_grep, {
+    type: "http",
+    url: "http://127.0.0.1:7999/mcp",
+    enabled: true,
+    timeout: 600000,
+    headers: { Authorization: "Bearer secret-token" },
+  });
+
+  await assert.rejects(
+    installTarget("ohmypi", { PI_CODING_AGENT_DIR: agentDir }, [
+      "--mcp-transport=http",
+      "--mcp-token-env=ZVEC_GREP_UNSET_TOKEN",
+    ]),
+    /ZVEC_GREP_UNSET_TOKEN/,
+  );
+
+  await uninstallTarget("ohmypi", { PI_CODING_AGENT_DIR: agentDir });
+  const uninstalled = JSON.parse(await readFile(configPath, "utf8"));
+  assert.equal(uninstalled.mcpServers.zvec_grep, undefined);
+  assert.equal(uninstalled.mcpServers.other.url, "https://example.com/mcp");
+  const uninstalledGuidance = await readFile(guidancePath, "utf8");
+  assert.match(uninstalledGuidance, /# Existing Oh My Pi guidance/);
   assert.doesNotMatch(uninstalledGuidance, /ZVEC_GREP|## zvec-grep/);
 });
 


### PR DESCRIPTION
Adds `ohmypi` as an install/uninstall target for [Oh My Pi](https://omp.sh) (`omp`).

## What changes
- `zg install --target ohmypi` writes a managed `zvec_grep` MCP server into `<agent dir>/mcp.json` (default `~/.omp/agent`, overridable with `PI_CODING_AGENT_DIR`) and appends a marked guidance block to the adjacent `AGENTS.md`.
- stdio transport (default): `{command: "zg", args: ["server", "--stdio"], enabled, timeout}`. http transport: `{type: "http", url, enabled, timeout, headers?}`, with `--mcp-token-env` resolved to a literal `Authorization` header at install time — omp does not expand environment variables in MCP headers, so an unset variable is a clear install-time error.
- `zg uninstall --target ohmypi` removes only the managed entry and guidance block; existing user servers are preserved.
- Guidance references omp's registered tool names `mcp__zvec_grep_search` / `mcp__zvec_grep_rg`.
- `ohmypi` added to auto-detection (`omp` on PATH), the numbered target list, help text, and docs (EN/CN).

## Verification

### Automated checks
- `npm run check` green end-to-end: lint, format, typecheck, coverage (>= 80% thresholds), package test.
- `node --test test/install.test.mjs`: 49/49 pass, including a new Oh My Pi installer test covering config preservation, exact stdio/http entry shapes, the unset-token error path, and uninstall idempotency.

### Sandbox runtime test (no real config touched)
- `PI_CODING_AGENT_DIR=$(mktemp -d)/agent zg install --target ohmypi --yes` into a throwaway agent directory: produced exactly the expected `mcp.json` (`mcpServers.zvec_grep = {command: "zg", args: ["server","--stdio"], enabled, timeout}`) and a marked `<!-- ZVEC_GREP_START/END -->` block in `AGENTS.md`; parent directories are created for fresh machines.

### Live verification against a real omp installation (omp 18.1.11)
- Installed into a real user `~/.omp/agent`: pre-existing user MCP entry (`context7`) preserved byte-for-byte, `$schema` retained, `zvec_grep` added alongside it, guidance block appended to `AGENTS.md`.
- A live `omp -p` session listed the server and its tools; invoking `mcp__zvec_grep_search` in-session reached the stdio daemon (`zg server --stdio`) and returned a well-formed `[INDEX_MISSING]` response for an unindexed workspace — full chain omp → mcp.json → stdio spawn → MCP protocol → tool handler verified.
- End-to-end semantic search: built a workspace index for this repository (347 files, 3,079 entities, `local/potion-code-16m-v2` on CPU), then asked a live omp session a paraphrased question about the installer's token handling. The model invoked `mcp__zvec_grep_search`, received real index results, and answered correctly with file/line citations — confirming the guidance routes the model to the tool and results flow back through MCP.
- Tool naming confirmed against omp's dist: registered names are `mcp__<server>_<tool-with-server-prefix-stripped>`, i.e. `mcp__zvec_grep_search` / `mcp__zvec_grep_rg` — exactly what the guidance block tells the model to call.

### Real uninstall verified on the same live installation
- `zg uninstall --target ohmypi --yes`: `zvec_grep` removed from `mcp.json` (the `context7` entry byte-for-byte identical, `$schema` retained) and the entire marked block stripped from `AGENTS.md` with zero markers remaining.
- Note: in that installation `AGENTS.md` contained only the managed block, so uninstall leaves a 1-line empty file rather than deleting it — functionally inert (loaded as empty context). This is pre-existing shared behavior for all agents' guidance files, not specific to this target.

### Build/test environment
- Fedora Linux 42 (Workstation Edition), kernel 6.19.14-108.fc42.x86_64, x86_64
- AMD Ryzen Threadripper PRO 7965WX (24 cores / 48 threads), 251 GiB RAM
- NVIDIA GeForce RTX 5090 (32 GB), driver 580.159.03, CUDA 13 — note: `npm ci` on this host requires `ONNXRUNTIME_NODE_INSTALL_CUDA=skip` because onnxruntime-node@1.21 prebuilts do not cover CUDA 13 (CPU binaries are used; local-only workaround, no dependency changes in this PR)
- Node v24.16.0, omp 18.1.11