### PR TITLE
fix: prevent spurious stdio bridge exits

### DIFF
--- a/src/daemon/server-controller.ts
+++ b/src/daemon/server-controller.ts
@@ -1,6 +1,14 @@
 import { randomUUID } from "node:crypto";
 import { spawn } from "node:child_process";
-import { open, readFile, unlink } from "node:fs/promises";
+import {
+  link,
+  mkdir,
+  open,
+  readFile,
+  rename,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
 import { createServer } from "node:net";
 import { hostname } from "node:os";
 import { join } from "node:path";
@@ -41,8 +49,6 @@ export type DaemonControlStatus = {
 };
 
 export class DaemonInstanceLock {
-  private heartbeat?: ReturnType<typeof setInterval>;
-
   private constructor(
     readonly path: string,
     readonly record: DaemonInstanceRecord,
@@ -64,52 +70,51 @@ export class DaemonInstanceLock {
       ready: false,
       mcpToolset,
     };
-    for (let attempt = 0; attempt < 3; attempt++) {
+    await mkdir(daemonHome(home), { recursive: true, mode: 0o700 });
+    const temporaryPath = `${path}.${record.instanceToken}.tmp`;
+    try {
+      const handle = await open(temporaryPath, "wx", 0o600);
       try {
-        const handle = await open(path, "wx", 0o600);
-        try {
-          await handle.writeFile(`${JSON.stringify(record)}\n`);
-        } finally {
-          await handle.close();
-        }
-        return new DaemonInstanceLock(path, record);
-      } catch (error) {
-        if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-          const { mkdir } = await import("node:fs/promises");
-          await mkdir(daemonHome(home), { recursive: true, mode: 0o700 });
-          continue;
-        }
-        if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
-        const existing = await readInstanceRecord(home);
-        if (
-          existing &&
-          existing.hostname === hostname() &&
-          processIsAlive(existing.pid)
-        ) {
-          throw new Error(
-            `zvec-grep server is already running with PID ${existing.pid}`,
-            {
-              cause: error,
-            },
-          );
-        }
-        await unlink(path).catch(() => undefined);
+        await handle.writeFile(`${JSON.stringify(record)}\n`);
+      } finally {
+        await handle.close();
       }
+      for (let attempt = 0; attempt < 3; attempt++) {
+        try {
+          // Publish a complete record without replacing another owner. Unlike
+          // rename, link fails with EEXIST if a competing daemon published first.
+          await link(temporaryPath, path);
+          return new DaemonInstanceLock(path, record);
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+          const existing = await readInstanceRecord(home);
+          if (
+            existing &&
+            existing.hostname === hostname() &&
+            processIsAlive(existing.pid)
+          ) {
+            throw new Error(
+              `zvec-grep server is already running with PID ${existing.pid}`,
+              { cause: error },
+            );
+          }
+          await unlink(path).catch(() => undefined);
+        }
+      }
+      throw new Error("Could not acquire the zvec-grep server instance lock.");
+    } finally {
+      await unlink(temporaryPath).catch(() => undefined);
     }
-    throw new Error("Could not acquire the zvec-grep server instance lock.");
   }
 
   async markReady(): Promise<void> {
     this.record.ready = true;
     await this.write();
-    this.heartbeat = setInterval(() => {
-      void this.write();
-    }, 5_000);
-    this.heartbeat.unref?.();
+    // Liveness is checked using the PID and /healthz, not updatedAt.
+    // Persist state transitions only; no disk heartbeat is needed.
   }
 
   async release(): Promise<void> {
-    if (this.heartbeat) clearInterval(this.heartbeat);
     const current = await readRecordPath(this.path);
     if (
       current?.instanceToken === this.record.instanceToken &&
@@ -125,12 +130,20 @@ export class DaemonInstanceLock {
     if (
       current?.instanceToken !== this.record.instanceToken ||
       current.pid !== process.pid
-    )
-      return;
-    const { writeFile } = await import("node:fs/promises");
-    await writeFile(this.path, `${JSON.stringify(this.record)}\n`, {
-      mode: 0o600,
-    });
+    ) {
+      throw new Error("zvec-grep server no longer owns its instance lock.");
+    }
+    // Keep the old record readable until the complete replacement is ready.
+    const temporaryPath = `${this.path}.${randomUUID()}.tmp`;
+    try {
+      await writeFile(temporaryPath, `${JSON.stringify(this.record)}\n`, {
+        mode: 0o600,
+        flag: "wx",
+      });
+      await rename(temporaryPath, this.path);
+    } finally {
+      await unlink(temporaryPath).catch(() => undefined);
+    }
   }
 }
 

--- a/src/mcp/stdio-bridge.ts
+++ b/src/mcp/stdio-bridge.ts
@@ -137,6 +137,7 @@ export async function runStdioBootstrapBridge(options: {
   downstream.onclose = finish;
 
   const downstreamTransport = new StdioServerTransport();
+  const shouldStop = createStdioBridgeStopCheck(status);
   let monitorRunning = false;
   let daemonFailure: Error | undefined;
   const monitor = setInterval(() => {
@@ -144,7 +145,7 @@ export async function runStdioBootstrapBridge(options: {
     monitorRunning = true;
     void serverStatus(options.home)
       .then(async (current) => {
-        if (!shouldStopStdioBridge(status, current)) {
+        if (!shouldStop(current)) {
           return;
         }
         daemonFailure = new Error(
@@ -166,6 +167,19 @@ export async function runStdioBootstrapBridge(options: {
     await Promise.allSettled([upstream.close(), downstream.close()]);
   }
   if (daemonFailure) throw daemonFailure;
+}
+
+export function createStdioBridgeStopCheck(
+  connected: DaemonControlStatus,
+): (current: DaemonControlStatus) => boolean {
+  let consecutiveMissing = 0;
+  return (current) => {
+    // An unreadable lock is ambiguous. Allow two polls to recover, while
+    // still stopping immediately when a different live daemon is observed.
+    if (!current.running) return ++consecutiveMissing >= 3;
+    consecutiveMissing = 0;
+    return shouldStopStdioBridge(connected, current);
+  };
 }
 
 export function shouldStopStdioBridge(

--- a/test/instance-lock-race.test.mjs
+++ b/test/instance-lock-race.test.mjs
@@ -1,0 +1,158 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import { syncBuiltinESMExports } from "node:module";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import {
+  DaemonInstanceLock,
+  readInstanceRecord,
+  serverStatus,
+} from "../dist/daemon/server-controller.js";
+import { shouldStopStdioBridge } from "../dist/mcp/stdio-bridge.js";
+
+test("concurrent initial lock writes publish exactly one complete owner", async () => {
+  const home = await fs.mkdtemp(join(tmpdir(), "zg-instance-acquire-"));
+  const originalOpen = fs.open;
+  const paused = Promise.withResolvers();
+  const resume = Promise.withResolvers();
+  let pauseFirstWrite = true;
+  let first;
+  let second;
+  try {
+    fs.open = async (...args) => {
+      const handle = await originalOpen(...args);
+      if (pauseFirstWrite && args[1] === "wx") {
+        pauseFirstWrite = false;
+        const originalHandleWrite = handle.writeFile.bind(handle);
+        handle.writeFile = async (...writeArgs) => {
+          paused.resolve();
+          await resume.promise;
+          return originalHandleWrite(...writeArgs);
+        };
+      }
+      return handle;
+    };
+    syncBuiltinESMExports();
+    first = DaemonInstanceLock.acquire(home, "http://127.0.0.1:1/mcp").then(
+      (lock) => ({ lock }),
+      (error) => ({ error }),
+    );
+    await paused.promise;
+    second = await DaemonInstanceLock.acquire(home, "http://127.0.0.1:1/mcp");
+    await second.markReady();
+    resume.resolve();
+    const outcome = await first;
+    assert.match(outcome.error?.message ?? "", /already running/);
+    const record = await readInstanceRecord(home);
+    assert.equal(record.instanceToken, second.record.instanceToken);
+    assert.equal(record.ready, true);
+    assert.deepEqual(await fs.readdir(join(home, "daemon")), ["instance.lock"]);
+  } finally {
+    resume.resolve();
+    fs.open = originalOpen;
+    syncBuiltinESMExports();
+    await (await first)?.lock?.release();
+    await second?.release();
+    await fs.rm(home, { recursive: true, force: true });
+  }
+});
+
+test("markReady fails explicitly after instance ownership is lost", async () => {
+  const home = await fs.mkdtemp(join(tmpdir(), "zg-instance-lost-"));
+  const first = await DaemonInstanceLock.acquire(
+    home,
+    "http://127.0.0.1:1/mcp",
+  );
+  let second;
+  try {
+    await first.release();
+    second = await DaemonInstanceLock.acquire(home, "http://127.0.0.1:1/mcp");
+    await assert.rejects(first.markReady(), /no longer owns/);
+    assert.equal(
+      (await readInstanceRecord(home)).instanceToken,
+      second.record.instanceToken,
+    );
+    assert.equal((await readInstanceRecord(home)).ready, false);
+  } finally {
+    await first.release();
+    await second?.release();
+    await fs.rm(home, { recursive: true, force: true });
+  }
+});
+
+test("instance readiness writes never expose a truncated lock to bridge polls", async () => {
+  const home = await fs.mkdtemp(join(tmpdir(), "zg-instance-race-"));
+  const lock = await DaemonInstanceLock.acquire(home, "http://127.0.0.1:1/mcp");
+  const originalWrite = fs.writeFile;
+  const observations = [];
+  try {
+    const connected = await serverStatus(home);
+    // Hold each actual write between truncate/create and writing the JSON.
+    fs.writeFile = async (path, data, options) => {
+      const handle = await fs.open(path, options.flag ?? "w", options.mode);
+      try {
+        observations.push({
+          record: await readInstanceRecord(home),
+          stop: shouldStopStdioBridge(connected, await serverStatus(home)),
+        });
+        await handle.writeFile(data);
+      } finally {
+        await handle.close();
+      }
+    };
+    syncBuiltinESMExports();
+    await lock.markReady();
+    assert.equal(observations.length, 1);
+    assert.equal(
+      observations[0].record?.instanceToken,
+      lock.record.instanceToken,
+    );
+    assert.equal(observations[0].stop, false);
+    assert.equal((await readInstanceRecord(home)).ready, true);
+    assert.deepEqual(await fs.readdir(join(home, "daemon")), ["instance.lock"]);
+  } finally {
+    fs.writeFile = originalWrite;
+    syncBuiltinESMExports();
+    await lock.release();
+    await fs.rm(home, { recursive: true, force: true });
+  }
+});
+
+test("ready instances do not schedule redundant disk heartbeats", async (t) => {
+  const home = await fs.mkdtemp(join(tmpdir(), "zg-instance-heartbeat-"));
+  const lock = await DaemonInstanceLock.acquire(home, "http://127.0.0.1:1/mcp");
+  const interval = t.mock.method(globalThis, "setInterval");
+  try {
+    await lock.markReady();
+    assert.equal(interval.mock.callCount(), 0);
+  } finally {
+    await lock.release();
+    await fs.rm(home, { recursive: true, force: true });
+  }
+});
+
+test("failed readiness replacement preserves the lock and cleans temporary files", async () => {
+  const home = await fs.mkdtemp(join(tmpdir(), "zg-instance-replace-"));
+  const lock = await DaemonInstanceLock.acquire(home, "http://127.0.0.1:1/mcp");
+  const originalRename = fs.rename;
+  try {
+    const before = await readInstanceRecord(home);
+    fs.rename = async () => {
+      throw Object.assign(new Error("replacement denied"), { code: "EPERM" });
+    };
+    syncBuiltinESMExports();
+    await assert.rejects(lock.markReady(), { code: "EPERM" });
+    assert.deepEqual(await readInstanceRecord(home), before);
+    assert.deepEqual(await fs.readdir(join(home, "daemon")), ["instance.lock"]);
+    fs.rename = originalRename;
+    syncBuiltinESMExports();
+    await lock.markReady();
+    assert.equal((await readInstanceRecord(home)).ready, true);
+  } finally {
+    fs.rename = originalRename;
+    syncBuiltinESMExports();
+    await lock.release();
+    await fs.rm(home, { recursive: true, force: true });
+  }
+});

--- a/test/server-controller.test.mjs
+++ b/test/server-controller.test.mjs
@@ -15,7 +15,7 @@ import {
   stopServer,
 } from "../dist/daemon/server-controller.js";
 
-test("daemon instance lock is exclusive, heartbeat-safe and owner-released", async (t) => {
+test("daemon instance lock is exclusive and owner-released", async (t) => {
   const home = await mkdtemp(join(tmpdir(), "zvec-grep-controller-"));
   t.after(async () => rm(home, { recursive: true, force: true }));
   const port = await availablePort();

--- a/test/stdio-bridge.test.mjs
+++ b/test/stdio-bridge.test.mjs
@@ -4,6 +4,7 @@ import { Client, InMemoryTransport } from "@modelcontextprotocol/client";
 import { Server } from "@modelcontextprotocol/server";
 import { REMOTE_EMBEDDING_ELICITATION_UNSUPPORTED_MESSAGE } from "../dist/authorization/prompt.js";
 import {
+  createStdioBridgeStopCheck,
   registerStdioBridgeElicitationForwarding,
   shouldStopStdioBridge,
 } from "../dist/mcp/stdio-bridge.js";
@@ -15,6 +16,26 @@ const connectedDaemon = {
   serverUrl: "http://127.0.0.1:7999/mcp",
   mcpToolset: "agent",
 };
+
+test("stdio monitor requires consecutive missing statuses and resets on recovery", () => {
+  const check = createStdioBridgeStopCheck(connectedDaemon);
+  const missing = { running: false, ready: false };
+  assert.equal(check(missing), false);
+  assert.equal(check(missing), false);
+  assert.equal(check({ ...connectedDaemon, ready: false }), false);
+  assert.equal(check(missing), false);
+  assert.equal(check(missing), false);
+  assert.equal(check(missing), true);
+});
+
+test("stdio monitor stops immediately on a confirmed identity change", () => {
+  for (const changed of [
+    { ...connectedDaemon, pid: 5678 },
+    { ...connectedDaemon, serverUrl: "http://127.0.0.1:8000/mcp" },
+  ]) {
+    assert.equal(createStdioBridgeStopCheck(connectedDaemon)(changed), true);
+  }
+});
 
 test("stdio bridge tolerates a transient health-check timeout", () => {
   assert.equal(


### PR DESCRIPTION
The stdio bridge could report that a healthy daemon had stopped when its status poll read `instance.lock` between truncation and completion of a heartbeat write. Concurrent daemon startup could also expose an empty initial record, allowing another process to replace the lock before its owner finished writing.

Remove the unused disk heartbeat, publish complete initial records through an exclusive hard link, and atomically replace the lock when readiness changes. Fail explicitly if readiness publication has lost lock ownership. Require three consecutive missing daemon statuses before closing a bridge, resetting on recovery; a confirmed PID or URL change still closes it immediately. Temporary files are cleaned up after publication attempts.

Fixes #106

## Validation

- Seven regression tests cover initial lock publication, lost ownership, readiness write/read races, removal of periodic writes, failed replacement cleanup, consecutive missing statuses and recovery, and identity changes.
- Latest revision: all 28 related tests passed; concurrent server startup passed 25 consecutive repetitions.
- Latest revision: lint, typecheck, changed-file formatting, and diff whitespace checks passed.
- Before the initial-publication follow-up: full local suite passed 384 tests with 1 skipped; coverage thresholds and package installation passed. CI exposed a Windows concurrent-startup timeout, which prompted the additional publication fix; the latest revision awaits CI validation.
- Repository-wide local formatting is blocked by pre-existing untracked files under `benchmarks/runs/`; those files are excluded from this PR.
