### PR TITLE
fix(server): make daemon lease publication race-safe

### DIFF
--- a/src/daemon/root-lease.ts
+++ b/src/daemon/root-lease.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { mkdir, open, readFile, unlink, writeFile } from "node:fs/promises";
+import { mkdir, open, readFile, unlink } from "node:fs/promises";
 import { hostname } from "node:os";
 import { dirname } from "node:path";
 import {
@@ -9,6 +9,7 @@ import {
   processIsAlive,
   type DaemonLeaseRecord,
 } from "../engine/utils/daemon-lease.js";
+import { replaceFileAtomically } from "../engine/utils/atomic-file.js";
 import { DaemonError } from "./errors.js";
 
 export type RootLease = {
@@ -161,20 +162,27 @@ export class RootLeaseManager {
     const timer = setInterval(() => {
       const heartbeat = (async () => {
         if (managed.stopped) return;
-        const current = await readLeaseFile(daemonLeasePath(root));
-        if (
-          managed.stopped ||
-          current?.pid !== managed.record.pid ||
-          current.instanceToken !== managed.record.instanceToken
-        )
-          return;
-        managed.record.updatedAt = Date.now();
-        if (managed.stopped) return;
-        await writeFile(
-          daemonLeasePath(root),
-          `${JSON.stringify(managed.record)}\n`,
-          { mode: 0o600 },
-        );
+        const guard = acquireDaemonLeaseGuard(root, this.instanceToken);
+        if (!guard) return;
+        try {
+          const path = daemonLeasePath(root);
+          const current = await readLeaseFile(path);
+          if (
+            managed.stopped ||
+            current?.pid !== managed.record.pid ||
+            current.instanceToken !== managed.record.instanceToken
+          )
+            return;
+          const updatedAt = Date.now();
+          await replaceFileAtomically(
+            path,
+            `${JSON.stringify({ ...managed.record, updatedAt })}\n`,
+            { mode: 0o600 },
+          );
+          managed.record.updatedAt = updatedAt;
+        } finally {
+          guard.release();
+        }
       })().catch(() => undefined);
       managed.heartbeatInFlight = heartbeat;
       void heartbeat.finally(() => {

--- a/src/daemon/root-lease.ts
+++ b/src/daemon/root-lease.ts
@@ -160,8 +160,8 @@ export class RootLeaseManager {
     managed: ManagedLease,
   ): ReturnType<typeof setInterval> {
     const timer = setInterval(() => {
+      if (managed.stopped || managed.heartbeatInFlight) return;
       const heartbeat = (async () => {
-        if (managed.stopped) return;
         const guard = acquireDaemonLeaseGuard(root, this.instanceToken);
         if (!guard) return;
         try {

--- a/src/daemon/server-controller.ts
+++ b/src/daemon/server-controller.ts
@@ -1,14 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { spawn } from "node:child_process";
-import {
-  link,
-  mkdir,
-  open,
-  readFile,
-  rename,
-  unlink,
-  writeFile,
-} from "node:fs/promises";
+import { link, mkdir, open, readFile, unlink } from "node:fs/promises";
 import { createServer } from "node:net";
 import { hostname } from "node:os";
 import { join } from "node:path";
@@ -18,6 +10,7 @@ import {
   resolveClientToken,
 } from "./config.js";
 import { processIsAlive } from "../engine/utils/daemon-lease.js";
+import { replaceFileAtomically } from "../engine/utils/atomic-file.js";
 import {
   DEFAULT_MCP_TOOLSET,
   MCP_TOOLSET_ENV,
@@ -134,16 +127,9 @@ export class DaemonInstanceLock {
       throw new Error("zvec-grep server no longer owns its instance lock.");
     }
     // Keep the old record readable until the complete replacement is ready.
-    const temporaryPath = `${this.path}.${randomUUID()}.tmp`;
-    try {
-      await writeFile(temporaryPath, `${JSON.stringify(this.record)}\n`, {
-        mode: 0o600,
-        flag: "wx",
-      });
-      await rename(temporaryPath, this.path);
-    } finally {
-      await unlink(temporaryPath).catch(() => undefined);
-    }
+    await replaceFileAtomically(this.path, `${JSON.stringify(this.record)}\n`, {
+      mode: 0o600,
+    });
   }
 }
 

--- a/src/engine/utils/atomic-file.ts
+++ b/src/engine/utils/atomic-file.ts
@@ -1,0 +1,48 @@
+import { randomUUID } from "node:crypto";
+import { rename, unlink, writeFile } from "node:fs/promises";
+
+const REPLACE_RETRY_DELAYS_MS = [5, 10, 20, 40, 80, 160, 320] as const;
+
+export async function replaceFileAtomically(
+  path: string,
+  contents: string,
+  options: { mode?: number } = {},
+): Promise<void> {
+  const temporaryPath = `${path}.${process.pid}.${randomUUID()}.tmp`;
+  try {
+    await writeFile(temporaryPath, contents, {
+      encoding: "utf8",
+      mode: options.mode,
+      flag: "wx",
+    });
+    await renameWithTransientRetries(temporaryPath, path);
+  } finally {
+    await unlink(temporaryPath).catch(() => undefined);
+  }
+}
+
+async function renameWithTransientRetries(
+  source: string,
+  destination: string,
+): Promise<void> {
+  for (const delayMs of REPLACE_RETRY_DELAYS_MS) {
+    try {
+      await rename(source, destination);
+      return;
+    } catch (error) {
+      if (!isTransientReplacementError(error)) throw error;
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
+  await rename(source, destination);
+}
+
+function isTransientReplacementError(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException | undefined)?.code;
+  return (
+    code === "EACCES" ||
+    code === "EBUSY" ||
+    code === "EEXIST" ||
+    code === "EPERM"
+  );
+}

--- a/test/instance-lock-race.test.mjs
+++ b/test/instance-lock-race.test.mjs
@@ -156,3 +156,30 @@ test("failed readiness replacement preserves the lock and cleans temporary files
     await fs.rm(home, { recursive: true, force: true });
   }
 });
+
+test("readiness publication retries transient replacement conflicts", async () => {
+  const home = await fs.mkdtemp(join(tmpdir(), "zg-instance-retry-"));
+  const lock = await DaemonInstanceLock.acquire(home, "http://127.0.0.1:1/mcp");
+  const originalRename = fs.rename;
+  let attempts = 0;
+  try {
+    fs.rename = async (...args) => {
+      attempts += 1;
+      if (attempts === 1) {
+        throw Object.assign(new Error("file temporarily busy"), {
+          code: "EPERM",
+        });
+      }
+      return originalRename(...args);
+    };
+    syncBuiltinESMExports();
+    await lock.markReady();
+    assert.equal(attempts, 2);
+    assert.equal((await readInstanceRecord(home)).ready, true);
+  } finally {
+    fs.rename = originalRename;
+    syncBuiltinESMExports();
+    await lock.release();
+    await fs.rm(home, { recursive: true, force: true });
+  }
+});

--- a/test/root-lease.test.mjs
+++ b/test/root-lease.test.mjs
@@ -211,3 +211,78 @@ test("lease heartbeats never expose a truncated record", async (t) => {
     await rm(temporaryDirectory, { recursive: true, force: true });
   }
 });
+
+for (const action of ["release", "close"]) {
+  test(`lease ${action} waits for a slow heartbeat across subsequent ticks`, async (t) => {
+    const root = await mkdtemp(join(tmpdir(), "zvec-grep-lease-overlap-"));
+    let heartbeat;
+    t.mock.method(globalThis, "setInterval", (callback) => {
+      heartbeat = callback;
+      return { unref() {} };
+    });
+    const manager = new RootLeaseManager();
+    const lease = await manager.acquire(root);
+    const originalRename = fs.rename;
+    const renameEntered = Promise.withResolvers();
+    const resumeRename = Promise.withResolvers();
+    const renameFinished = Promise.withResolvers();
+    let cleanup;
+    try {
+      fs.rename = async (...args) => {
+        renameEntered.resolve();
+        await resumeRename.promise;
+        try {
+          return await originalRename(...args);
+        } finally {
+          renameFinished.resolve();
+        }
+      };
+      syncBuiltinESMExports();
+      heartbeat();
+      await renameEntered.promise;
+      heartbeat();
+      await new Promise((resolve) => setImmediate(resolve));
+
+      // Exhaust cleanup retries immediately if it fails to wait for the heartbeat.
+      t.mock.method(globalThis, "setTimeout", (callback) => {
+        queueMicrotask(callback);
+      });
+      let settled = false;
+      let cleanupError;
+      cleanup = (action === "release" ? lease.release() : manager.close()).then(
+        () => {
+          settled = true;
+        },
+        (error) => {
+          settled = true;
+          cleanupError = error;
+        },
+      );
+      heartbeat();
+      await new Promise((resolve) => setImmediate(resolve));
+      assert.equal(
+        settled,
+        false,
+        "cleanup must wait for the pending heartbeat",
+      );
+      assert.equal(readDaemonLease(root)?.instanceToken, manager.instanceToken);
+
+      resumeRename.resolve();
+      await cleanup;
+      assert.equal(cleanupError, undefined);
+      await assert.rejects(access(daemonLeasePath(root)), { code: "ENOENT" });
+      const permit = assertDaemonWriteAllowed(root);
+      assert.ok(permit);
+      permit.release();
+    } finally {
+      resumeRename.resolve();
+      await renameFinished.promise;
+      await cleanup;
+      fs.rename = originalRename;
+      syncBuiltinESMExports();
+      await lease.release();
+      await manager.close();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+}

--- a/test/root-lease.test.mjs
+++ b/test/root-lease.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import fs from "node:fs/promises";
 import {
   access,
   mkdir,
@@ -8,6 +9,7 @@ import {
   utimes,
   writeFile,
 } from "node:fs/promises";
+import { syncBuiltinESMExports } from "node:module";
 import { hostname } from "node:os";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -16,6 +18,7 @@ import { RootLeaseManager } from "../dist/daemon/root-lease.js";
 import {
   assertDaemonWriteAllowed,
   daemonLeasePath,
+  readDaemonLease,
 } from "../dist/engine/utils/daemon-lease.js";
 import { createZvecGrep } from "../dist/index.js";
 import { printError } from "../dist/cli/errors.js";
@@ -154,6 +157,56 @@ test("a Direct write permit prevents daemon activation until the write completes
     await lease.release();
   } finally {
     permit?.release();
+    await manager.close();
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  }
+});
+
+test("lease heartbeats never expose a truncated record", async (t) => {
+  const temporaryDirectory = await mkdtemp(
+    join(tmpdir(), "zvec-grep-lease-heartbeat-"),
+  );
+  const root = join(temporaryDirectory, "repo");
+  await mkdir(root);
+  const callbacks = [];
+  t.mock.method(globalThis, "setInterval", (callback) => {
+    callbacks.push(callback);
+    return { unref() {} };
+  });
+  const manager = new RootLeaseManager();
+  const lease = await manager.acquire(root);
+  const originalWriteFile = fs.writeFile;
+  let observedRecord;
+  let permitError;
+  const heartbeatWritten = Promise.withResolvers();
+  try {
+    fs.writeFile = async (path, data, options) => {
+      const handle = await fs.open(path, options?.flag ?? "w", options?.mode);
+      try {
+        observedRecord = readDaemonLease(root);
+        try {
+          assertDaemonWriteAllowed(root, manager.instanceToken);
+        } catch (error) {
+          permitError = error;
+        }
+        await handle.writeFile(data);
+      } finally {
+        await handle.close();
+        heartbeatWritten.resolve();
+      }
+    };
+    syncBuiltinESMExports();
+    assert.equal(callbacks.length, 1);
+    callbacks[0]();
+    await heartbeatWritten.promise;
+    await manager.close();
+
+    assert.equal(permitError, undefined);
+    assert.equal(observedRecord?.instanceToken, manager.instanceToken);
+  } finally {
+    fs.writeFile = originalWriteFile;
+    syncBuiltinESMExports();
+    await lease.release();
     await manager.close();
     await rm(temporaryDirectory, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

- atomically publish complete daemon instance records and tolerate transient status gaps
- serialize root-lease heartbeats with the lease guard and atomically replace heartbeat records
- retry bounded transient file-replacement conflicts such as Windows EPERM and EACCES
- add deterministic regression coverage for partial writes, ownership loss, and replacement contention

## Root cause

The root-lease heartbeat rewrote daemon.json in place. Readers could observe the file after truncation but before the JSON write completed and misclassify the current daemon as a conflicting owner. Instance readiness already used a temporary file, but a transient Windows replacement conflict could still abort startup.

## Validation

- npm run check on release/v0.2.2
- lint, format check, typecheck, and build on this branch
- 24 focused daemon lease, server controller, and stdio bridge tests

Fixes #106