### PR TITLE
docs: add Trendshift badges to bilingual READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@
   </p>
 
   <p>
+    <a href="https://trendshift.io/repositories/200612?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-200612" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/200612/daily?language=TypeScript" alt="zvec-ai/zvec-grep | Trendshift TypeScript daily ranking" width="250" height="55" /></a>
+    <a href="https://trendshift.io/repositories/200612?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-200612" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/200612/daily" alt="zvec-ai/zvec-grep | Trendshift all-language daily ranking" width="250" height="55" /></a>
+  </p>
+
+  <p>
     <a href="#tour">🎬 <strong>Tour</strong></a> |
     <a href="#features">💫 <strong>Features</strong></a> |
     <a href="#try-it-yourself">🚀 <strong>Try it yourself</strong></a> |

--- a/README_CN.md
+++ b/README_CN.md
@@ -18,6 +18,11 @@
   </p>
 
   <p>
+    <a href="https://trendshift.io/repositories/200612?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-200612" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/200612/daily?language=TypeScript" alt="zvec-ai/zvec-grep | Trendshift TypeScript 日榜" width="250" height="55" /></a>
+    <a href="https://trendshift.io/repositories/200612?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-200612" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/200612/daily" alt="zvec-ai/zvec-grep | Trendshift 全语言日榜" width="250" height="55" /></a>
+  </p>
+
+  <p>
     <a href="#tour">🎬 <strong>功能演示</strong></a> |
     <a href="#features">💫 <strong>核心特性</strong></a> |
     <a href="#try-it-yourself">🚀 <strong>动手体验</strong></a> |


### PR DESCRIPTION
Add Trendshift TypeScript and all-language daily ranking badges to the English and Chinese READMEs. Both badges appear centered between the existing status badges and the navigation links, with localized alt text and 250×55 dimensions.

Validation: Prettier checks pass for both READMEs, and `git diff --check origin/main...HEAD` passes.
