### PR TITLE
feat(embeddings): support self-hosted DGX endpoints with bounded indexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,12 +170,12 @@ provider explicitly as unauthenticated, save the complete endpoint URL, and
 make the DGX model the default for new indexes:
 
 ```bash
-zg config provider set dgx --no-auth
-zg config model set dgx/qwen3-embedding-0.6b \
+zg --config provider set dgx --no-auth
+zg --config model set dgx/qwen3-embedding-0.6b \
   --endpoint http://dgx-spark:11434/v1/embeddings \
   --default
 
-zg index --allow-remote
+zg --index --allow-remote
 ```
 
 Replace `dgx-spark` with the hostname or IP address of your DGX Spark. zg does
@@ -185,7 +185,7 @@ path.
 If the endpoint requires a Bearer token, configure it instead of `--no-auth`:
 
 ```bash
-zg config provider set dgx --api-key "$DGX_EMBEDDING_API_KEY"
+zg --config provider set dgx --api-key "$DGX_EMBEDDING_API_KEY"
 ```
 
 Provider authentication and remote-data authorization are separate.
@@ -194,7 +194,7 @@ create a signed authorization shared by the CLI and MCP server for the current
 workspace, run:
 
 ```bash
-zg auth grant \
+zg --auth grant \
   --capability embedding \
   --scope workspace \
   --embedding dgx/qwen3-embedding-0.6b
@@ -204,7 +204,7 @@ Existing indexes retain their model and endpoint. Use `--rebuild` when moving
 an index to the DGX model or changing its endpoint:
 
 ```bash
-zg index --rebuild \
+zg --index --rebuild \
   --embedding dgx/qwen3-embedding-0.6b \
   --allow-remote
 ```

--- a/README.md
+++ b/README.md
@@ -150,6 +150,68 @@ zg query --human "An unseen creature left a few marks. What did the detective in
 zg returns the relevant passages from `sherlock-holmes.txt`, ranked ahead of
 `alice-in-wonderland.txt`.
 
+### Use a DGX Spark embedding endpoint
+
+zg can use a DGX Spark running an OpenAI-compatible Embeddings API instead of
+loading an embedding model in the local zg process. The supported catalog
+entry uses the served model ID `qwen3-embedding:0.6b`, produces
+1,024-dimensional vectors, and supports inputs up to 32,768 tokens.
+
+First verify that the endpoint accepts `POST /v1/embeddings`:
+
+```bash
+curl http://dgx-spark:11434/v1/embeddings \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"qwen3-embedding:0.6b","input":["DGX Spark is ready"]}'
+```
+
+For an endpoint without authentication on a trusted network, configure the
+provider explicitly as unauthenticated, save the complete endpoint URL, and
+make the DGX model the default for new indexes:
+
+```bash
+zg config provider set dgx --no-auth
+zg config model set dgx/qwen3-embedding-0.6b \
+  --endpoint http://dgx-spark:11434/v1/embeddings \
+  --default
+
+zg index --allow-remote
+```
+
+Replace `dgx-spark` with the hostname or IP address of your DGX Spark. zg does
+not append `/v1/embeddings`, so the configured URL must include the complete
+path.
+
+If the endpoint requires a Bearer token, configure it instead of `--no-auth`:
+
+```bash
+zg config provider set dgx --api-key "$DGX_EMBEDDING_API_KEY"
+```
+
+Provider authentication and remote-data authorization are separate.
+`--allow-remote` approves sending repository content for that one command. To
+create a signed authorization shared by the CLI and MCP server for the current
+workspace, run:
+
+```bash
+zg auth grant \
+  --capability embedding \
+  --scope workspace \
+  --embedding dgx/qwen3-embedding-0.6b
+```
+
+Existing indexes retain their model and endpoint. Use `--rebuild` when moving
+an index to the DGX model or changing its endpoint:
+
+```bash
+zg index --rebuild \
+  --embedding dgx/qwen3-embedding-0.6b \
+  --allow-remote
+```
+
+See [Embedding models](./docs/07-embedding.md#dgx-spark) for authentication,
+authorization, and troubleshooting details.
+
 <a id="benchmarks"></a>
 
 ## 📊 Benchmarks

--- a/docs/02-cli.md
+++ b/docs/02-cli.md
@@ -187,6 +187,9 @@ Examples:
 ```bash
 zg --config provider set qwen --api-key "$DASHSCOPE_API_KEY"
 zg --config model set qwen/text-embedding-v4 --default
+zg --config provider set dgx --no-auth
+zg --config model set dgx/qwen3-embedding-0.6b \
+  --endpoint http://dgx-spark:11434/v1/embeddings --default
 zg --config model set local/potion-code-16m-v2 --device metal
 ```
 
@@ -197,6 +200,9 @@ unrelated credential is not sent to a trusted-network endpoint:
 ```bash
 zg --config provider set dgx --no-auth
 ```
+
+The model endpoint must be the complete OpenAI-compatible Embeddings URL,
+including `/v1/embeddings`; zvec-grep does not append that path.
 
 `--api-key` and `--no-auth` are mutually exclusive. Providers such as Qwen that
 require credentials reject `--no-auth`.

--- a/docs/02-cli.md
+++ b/docs/02-cli.md
@@ -178,7 +178,7 @@ See [Agent integrations](./01-agents.md) before using `--force`.
 ## `zg --config`
 
 ```text
-zg --config provider set <provider> --api-key <key>
+zg --config provider set <provider> (--api-key <key> | --no-auth)
 zg --config model set <model> [--endpoint <url> | --device <device>] [--default]
 ```
 
@@ -189,6 +189,17 @@ zg --config provider set qwen --api-key "$DASHSCOPE_API_KEY"
 zg --config model set qwen/text-embedding-v4 --default
 zg --config model set local/potion-code-16m-v2 --device metal
 ```
+
+Providers whose credentials are optional can be explicitly configured without
+authentication. This suppresses the generic `ZVEC_GREP_API_KEY` fallback so an
+unrelated credential is not sent to a trusted-network endpoint:
+
+```bash
+zg --config provider set dgx --no-auth
+```
+
+`--api-key` and `--no-auth` are mutually exclusive. Providers such as Qwen that
+require credentials reject `--no-auth`.
 
 Global configuration is stored in `~/.zvec-grep/config.json`. Existing indexes
 continue to use their stored model until explicitly rebuilt.

--- a/docs/02-cli.md
+++ b/docs/02-cli.md
@@ -111,6 +111,11 @@ zg --index [root] --rebuild [options]
 zg --index [root] --drop [--yes]
 ```
 
+An explicit root, including `.`, targets that directory's index. Without a
+root, the CLI updates the nearest existing workspace index, falling back to the
+current directory. To index a nested Git repository separately, run
+`zg --index .` inside it; parent scans skip nested Git repositories by default.
+
 Core options:
 
 | Option | Meaning |
@@ -126,6 +131,7 @@ Core options:
 | `--model-cache <path>` | Local model cache directory |
 | `--device <device>` | `auto`, `cpu`, `metal`, `vulkan`, or `cuda` |
 | `--embedding-concurrency <n>` | Concurrent Embedding tasks |
+| `--no-prefetch` | Wait for an indexing task slot before preparing the next batch |
 | `--allow-remote` | Authorize Remote Embedding for this command |
 
 Local Potion embedding tasks run on worker threads. They default to two workers;

--- a/docs/07-embedding.md
+++ b/docs/07-embedding.md
@@ -42,6 +42,7 @@ default. Select and authorize a remote model explicitly with `zg --index`.
 | A lightweight English model | `local/all-minilm-l6-v2` | Small local model for short English text |
 | Long English documents | `local/gte-modernbert-base` or `local/nomic-embed-text-v1.5` | 8,192-token local context |
 | No local model runtime | `qwen/qwen3.7-text-embedding` | Managed text Embedding API |
+| A DGX Spark on the local network | `dgx/qwen3-embedding-0.6b` | Self-hosted OpenAI-compatible Qwen3 Embedding |
 | Text and image retrieval | `qwen/qwen3-vl-embedding` | Managed multimodal Embedding API |
 
 The best model still depends on the repository and its real queries. Start with
@@ -69,6 +70,7 @@ file.
 | `qwen/text-embedding-v4` | Remote text | 8,192 | 1,024 |
 | `qwen/qwen3.7-text-embedding` | Remote text | 128,000 | 1,024 |
 | `qwen/qwen3-vl-embedding` | Remote multimodal | 32,000 | 2,560 |
+| `dgx/qwen3-embedding-0.6b` | DGX OpenAI-compatible | 32,768 | 1,024 |
 
 All catalog entries currently use cosine similarity. Exact model revisions are
 pinned by zvec-grep so the same reference resolves consistently for a given
@@ -126,6 +128,45 @@ zg --index \
 ```
 
 ## Remote Embedding and authorization
+
+### DGX Spark
+
+For an unauthenticated endpoint on a trusted network, configure the provider,
+the complete OpenAI-compatible Embeddings URL, and the catalog model:
+
+```bash
+zg --config provider set dgx --no-auth
+zg --config model set dgx/qwen3-embedding-0.6b \
+  --endpoint http://dgx-spark:11434/v1/embeddings \
+  --default
+zg index --allow-remote
+```
+
+The server must accept `POST /v1/embeddings` with the OpenAI-compatible
+`model` and `input` fields. zvec-grep sends the served model identifier
+`qwen3-embedding:0.6b` and expects 1,024-number vectors. It deliberately omits
+the optional `dimensions` and `encoding_format` fields for compatibility with
+Ollama-backed endpoints.
+
+If a reverse proxy protects the endpoint, configure its Bearer credential
+instead:
+
+```bash
+zg --config provider set dgx --api-key "$DGX_EMBEDDING_API_KEY"
+```
+
+Provider authentication and data authorization are separate. Even a no-auth
+LAN endpoint requires `--allow-remote` for each CLI command or a signed
+Workspace grant, because repository content and query text leave the
+zvec-grep process.
+
+Common failures have direct causes: `requires an endpoint` means the model URL
+was not configured; connection failures usually mean the DGX hostname, port,
+or `/v1/embeddings` path is wrong; a wrong-dimension response means the server
+is not serving the cataloged 1,024-dimensional model. Changing either the
+model or endpoint for an existing index requires `--rebuild`.
+
+### Managed Qwen
 
 Configure the Qwen provider credential and, optionally, a model endpoint:
 

--- a/docs/07-embedding.md
+++ b/docs/07-embedding.md
@@ -139,7 +139,7 @@ zg --config provider set dgx --no-auth
 zg --config model set dgx/qwen3-embedding-0.6b \
   --endpoint http://dgx-spark:11434/v1/embeddings \
   --default
-zg index --allow-remote
+zg --index --allow-remote
 ```
 
 The server must accept `POST /v1/embeddings` with the OpenAI-compatible

--- a/docs/07-embedding.md
+++ b/docs/07-embedding.md
@@ -98,6 +98,16 @@ metric unless `--embedding` and `--rebuild` explicitly change them. `zg --index`
 forwards the current CLI environment default in server and auto modes; direct
 MCP calls use the environment inherited by the daemon.
 
+Indexing caps retrieval passages at 3,600 characters with a 15% overlap
+target. Smaller model input limits still take precedence, and heading or
+symbol metadata shares the passage budget. A model's maximum context length
+is a safety ceiling, not the target passage size.
+
+Index version 2 records this chunking policy. Existing version 1 indexes
+require an explicit `zg --index --rebuild` (plus `--allow-remote` for remote
+embedding) to regenerate all passages; ordinary incremental indexing will
+report the required rebuild instead of mixing chunking policies.
+
 ## Local runtime and device
 
 Select a device for local Transformer and GGUF models:
@@ -159,6 +169,27 @@ Provider authentication and data authorization are separate. Even a no-auth
 LAN endpoint requires `--allow-remote` for each CLI command or a signed
 Workspace grant, because repository content and query text leave the
 zvec-grep process.
+
+DGX embedding requests allow up to 30 minutes, including server queue time
+and reading the response. DGX indexing defaults to one in-flight request to
+avoid building a server queue and retrying work that may still be running.
+Requests contain at most 32 fragments and 64,000 total text characters,
+including heading and symbol metadata. Both limits apply to batches spanning
+multiple files and to fragments from a single large file. The text budget is
+a character count, not an exact token count or a JSON/UTF-8 byte limit.
+Indexing prepares the next batch while the current
+batch is in flight.
+Use `zg --index --allow-remote --no-prefetch` to disable this preparation
+overlap when comparing performance.
+Use `--embedding-concurrency` to tune concurrency for your server's capacity:
+
+```bash
+zg --index --allow-remote --embedding-concurrency 2
+```
+
+Explicit concurrency backs off as low as one after transient failures.
+Hosted providers retain their 60-second request timeout. If DGX requests
+still time out, check server logs and inference latency before increasing load.
 
 Common failures have direct causes: `requires an endpoint` means the model URL
 was not configured; connection failures usually mean the DGX hostname, port,

--- a/src/authorization/planner.ts
+++ b/src/authorization/planner.ts
@@ -1,5 +1,6 @@
 import type { NormalizedSearchInput } from "../mcp/input-normalization.js";
 import type { EmbeddingModelInfo } from "../engine/models/index.js";
+import { isRemoteEmbeddingProvider } from "../engine/models/index.js";
 import type { ZvecGrepInfoResult } from "../engine/service/types.js";
 import { createRemoteEmbeddingTarget } from "./target.js";
 import { RemoteEmbeddingAuthorizationStore } from "./store.js";
@@ -12,7 +13,7 @@ export async function planRemoteIndexAuthorization(input: {
   needsUpdate?: boolean;
   store?: RemoteEmbeddingAuthorizationStore;
 }): Promise<RemoteEmbeddingAuthorizationPlan | undefined> {
-  if (input.model.provider !== "qwen") return undefined;
+  if (!isRemoteEmbeddingProvider(input.model.provider)) return undefined;
   const needsEmbedding =
     input.rebuild === true ||
     input.needsUpdate === true ||
@@ -57,7 +58,11 @@ export async function planRemoteSearchAuthorization(input: {
   store?: RemoteEmbeddingAuthorizationStore;
 }): Promise<RemoteEmbeddingAuthorizationPlan | undefined> {
   const schema = input.info.workspaceIndex?.embedding;
-  if (!input.info.indexed || !schema || schema.provider !== "qwen") {
+  if (
+    !input.info.indexed ||
+    !schema ||
+    !isRemoteEmbeddingProvider(schema.provider)
+  ) {
     return undefined;
   }
   if (

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -340,6 +340,8 @@ export function parseArgs(args: readonly string[]): ParsedArgs {
       options.device = parseDevice(readOptionValue(commandArgs, ++index, arg));
     } else if (arg === "--api-key") {
       options.apiKey = readOptionValue(commandArgs, ++index, arg);
+    } else if (arg === "--no-auth") {
+      options.providerNoAuth = true;
     } else if (arg === "--endpoint") {
       options.endpoint = readOptionValue(commandArgs, ++index, arg);
     } else if (arg === "--limit") {
@@ -780,6 +782,12 @@ function validateCliShape(
         "--api-key",
       ],
       [
+        options.configAction === "model-set"
+          ? options.providerNoAuth
+          : undefined,
+        "--no-auth",
+      ],
+      [
         options.configAction === "provider-set" ? options.endpoint : undefined,
         "--endpoint",
       ],
@@ -804,6 +812,8 @@ function validateCliShape(
     }
   } else if (options.defaultModel) {
     throw new Error("--default can only be used with zg --config model set");
+  } else if (options.providerNoAuth) {
+    throw new Error("--no-auth can only be used with zg --config provider set");
   }
 
   if (command === "server") {

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -349,6 +349,8 @@ export function parseArgs(args: readonly string[]): ParsedArgs {
         readOptionValue(commandArgs, ++index, arg),
         arg,
       );
+    } else if (arg === "--no-prefetch") {
+      options.noPrefetch = true;
     } else if (arg === "--embedding-concurrency") {
       options.embeddingConcurrency = parsePositiveInteger(
         readOptionValue(commandArgs, ++index, arg),
@@ -1021,6 +1023,12 @@ function validateCliShape(
   ) {
     throw new Error(
       "zg --index --drop cannot be combined with indexing options",
+    );
+  }
+
+  if (options.noPrefetch && (command !== "index" || options.drop)) {
+    throw new Error(
+      "--no-prefetch can only be used with --index without --drop",
     );
   }
 

--- a/src/cli/auth.ts
+++ b/src/cli/auth.ts
@@ -11,6 +11,7 @@ import {
   type EmbeddingRuntimeConfig,
 } from "../engine/config.js";
 import {
+  findEmbeddingModelCatalogEntry,
   getEmbeddingModelCatalogEntry,
   listRemoteEmbeddingProviders,
   resolveEmbeddingReference,
@@ -203,9 +204,10 @@ export function resolveAuthorizationSchema(
   }
   const provider = reference.slice(0, separator);
   const model = reference.slice(separator + 1);
+  const entry = findEmbeddingModelCatalogEntry(provider, model);
   return {
-    provider,
-    model,
+    provider: entry?.provider ?? provider,
+    model: entry?.model ?? model,
   };
 }
 
@@ -255,7 +257,10 @@ export function configuredEmbeddingReference(
 ): string | undefined {
   return resolveEmbeddingReference({
     explicit: options.embedding,
-    existing: existing ? `${existing.provider}/${existing.model}` : undefined,
+    existing: existing
+      ? (findEmbeddingModelCatalogEntry(existing.provider, existing.model)
+          ?.reference ?? `${existing.provider}/${existing.model}`)
+      : undefined,
     globalDefault: readGlobalConfig().defaults?.embedding,
   });
 }

--- a/src/cli/auth.ts
+++ b/src/cli/auth.ts
@@ -12,7 +12,7 @@ import {
 } from "../engine/config.js";
 import {
   getEmbeddingModelCatalogEntry,
-  listEmbeddingModels,
+  listRemoteEmbeddingProviders,
   resolveEmbeddingReference,
 } from "../engine/models/index.js";
 import { readWorkspaceManifest } from "../engine/manifest.js";
@@ -277,13 +277,9 @@ export function unsupportedRemoteEmbeddingProvider(
   reference: string,
   message = "Unsupported remote embedding provider",
 ): Error {
-  const providers = [
-    ...new Set(
-      listEmbeddingModels()
-        .map((model) => model.provider)
-        .filter((provider) => provider !== "local"),
-    ),
-  ];
+  const providers = listRemoteEmbeddingProviders().map(
+    ({ provider }) => provider,
+  );
   return new Error(
     [
       `${message}: ${reference}`,

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -17,7 +17,10 @@ import {
   EngineError,
   type EngineErrorCode,
 } from "../engine/errors.js";
-import { getRemoteEmbeddingProviderCatalogEntry } from "../engine/models/index.js";
+import {
+  getRemoteEmbeddingProviderCatalogEntry,
+  isRemoteEmbeddingProvider,
+} from "../engine/models/index.js";
 import { DaemonClient } from "../client/daemon-client.js";
 import {
   resolveDirectSearchPolicy,
@@ -426,7 +429,7 @@ async function runDirectIndex(
       parsed.options.rebuild === true,
     );
     const modelInfo =
-      schema?.provider === "qwen"
+      schema && isRemoteEmbeddingProvider(schema.provider)
         ? await embeddingModelInfo(schema, serviceOptions, workspaceRuntime)
         : undefined;
     const plan = modelInfo
@@ -743,7 +746,7 @@ async function runDirectQuery(
     const schema = info.workspaceIndex?.embedding;
     const workspaceRuntime = workspaceRuntimeFromInfo(info);
     const modelInfo =
-      !commandOptions.rg && schema?.provider === "qwen"
+      !commandOptions.rg && schema && isRemoteEmbeddingProvider(schema.provider)
         ? await embeddingModelInfo(
             schema,
             createServiceOptions(commandOptions, info.root),

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -277,6 +277,7 @@ async function runIndex(parsed: ParsedArgs): Promise<void> {
             maxFileSizeBytes: parsed.options.maxFileSizeBytes,
             follow: parsed.options.follow,
             embeddingConcurrency: parsed.options.embeddingConcurrency,
+            noPrefetch: parsed.options.noPrefetch,
             debug: parsed.options.debug,
             wait: true,
           },
@@ -408,6 +409,7 @@ async function runDirectIndex(
     const infoBefore = await zvecGrep.info({
       root: rootPath.absolutePath,
       includeStatus: parsed.options.rebuild !== true,
+      discoverParents: false,
     });
     const schema = resolveAuthorizationSchema(
       configuredEmbeddingReference(
@@ -463,6 +465,7 @@ async function runDirectIndex(
           maxFileSizeBytes: parsed.options.maxFileSizeBytes,
           follow: parsed.options.follow,
           embeddingConcurrency: parsed.options.embeddingConcurrency,
+          noPrefetch: parsed.options.noPrefetch,
           onProgress: progress.report,
         }),
     );

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -17,7 +17,7 @@ import {
   EngineError,
   type EngineErrorCode,
 } from "../engine/errors.js";
-import { listEmbeddingModels } from "../engine/models/index.js";
+import { getRemoteEmbeddingProviderCatalogEntry } from "../engine/models/index.js";
 import { DaemonClient } from "../client/daemon-client.js";
 import {
   resolveDirectSearchPolicy,
@@ -125,20 +125,36 @@ async function runConfig(parsed: ParsedArgs): Promise<void> {
         "Invalid embedding provider",
       );
     }
-    if (
-      reference === "local" ||
-      !listEmbeddingModels().some((entry) => entry.provider === reference)
-    ) {
+    const provider = getRemoteEmbeddingProviderCatalogEntry(reference);
+    if (reference === "local" || provider === undefined) {
       throw unsupportedRemoteEmbeddingProvider(reference);
     }
-    if (parsed.options.apiKey === undefined) {
-      throw new Error("zg --config provider set requires --api-key");
+    if (
+      parsed.options.apiKey !== undefined &&
+      parsed.options.providerNoAuth === true
+    ) {
+      throw new Error(
+        "zg --config provider set accepts either --api-key or --no-auth, not both",
+      );
+    }
+    if (
+      parsed.options.apiKey === undefined &&
+      parsed.options.providerNoAuth !== true
+    ) {
+      throw new Error(
+        "zg --config provider set requires --api-key or --no-auth",
+      );
+    }
+    if (parsed.options.providerNoAuth && provider.apiKey === "required") {
+      throw new Error(
+        `Embedding provider ${reference} requires an API key and does not support --no-auth`,
+      );
     }
     updateGlobalConfig({
       providers: {
-        [reference]: {
-          apiKey: parsed.options.apiKey,
-        },
+        [reference]: parsed.options.providerNoAuth
+          ? { auth: "none" }
+          : { apiKey: parsed.options.apiKey! },
       },
     });
     console.log(`Provider config: ${reference}`);

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -236,11 +236,12 @@ stored paths, refresh status, and suggested next action.
 Workspace index is ready.`;
     case "config":
       return `Usage:
-  zg --config provider set <provider> --api-key <key>
+  zg --config provider set <provider> (--api-key <key> | --no-auth)
   zg --config model set <model> [--endpoint <url> | --device <device>] [--default]
 
 Provider options:
   --api-key <key>                   Default API key for the provider
+  --no-auth                         Explicitly use an unauthenticated provider
 
 Model options:
   --endpoint <url>                  Endpoint for a remote embedding model

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -195,6 +195,7 @@ Embedding options:
   --model-cache <path>              Local model cache directory
   --device <device>                 auto, cpu, metal, vulkan, cuda
   --embedding-concurrency <n>       Embedding task concurrency
+  --no-prefetch                    Disable preparing the next batch during embedding
   --allow-remote                    Allow Remote Embedding for this command only
 
 File selection:

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -390,7 +390,8 @@ Supported embedding models:
 ${formatEmbeddingModels(models)}
 
 Local models are downloaded to the model cache on first use. Remote models
-require provider credentials plus --allow-remote or a Workspace authorization.
+require provider configuration plus --allow-remote or a Workspace authorization;
+provider credentials are optional when the configured endpoint permits them.
 Only qwen/qwen3-vl-embedding accepts image input.
 
 Existing indexes keep their stored model. See zg --help environment for

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -44,6 +44,7 @@ export type CliOptions = {
   modelCacheDir?: string;
   device?: "auto" | "cpu" | "metal" | "vulkan" | "cuda";
   apiKey?: string;
+  providerNoAuth?: boolean;
   endpoint?: string;
   limit?: number;
   hybridQueries?: string[];

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -70,6 +70,7 @@ export type CliOptions = {
   modifiedBefore?: number;
   symbolTypes?: CodeSymbolType[];
   embeddingConcurrency?: number;
+  noPrefetch?: boolean;
 };
 
 export type CliCommand =

--- a/src/daemon/backend.ts
+++ b/src/daemon/backend.ts
@@ -15,7 +15,10 @@ import type {
   EmbeddingModel,
   EmbeddingModelInfo,
 } from "../engine/models/index.js";
-import { resolveEmbeddingReference } from "../engine/models/index.js";
+import {
+  isRemoteEmbeddingProvider,
+  resolveEmbeddingReference,
+} from "../engine/models/index.js";
 import type {
   FileScanDiagnostics,
   WorkspaceIndexEmbeddingSchema,
@@ -220,10 +223,8 @@ export class DaemonBackend implements ZvecGrepDaemonBackend {
   ): Promise<RemoteEmbeddingAuthorizationPlan | undefined> {
     const requestedRoot = await resolveRequestedRoot(input.root, false);
     let activeRuntime = this.runtimeManager.getByRequestedRoot(requestedRoot);
-    if (
-      activeRuntime?.embeddingProvider() &&
-      activeRuntime.embeddingProvider() !== "qwen"
-    ) {
+    const activeProvider = activeRuntime?.embeddingProvider();
+    if (activeProvider && !isRemoteEmbeddingProvider(activeProvider)) {
       return undefined;
     }
     let canonicalRoot = activeRuntime?.canonicalRoot;
@@ -235,7 +236,7 @@ export class DaemonBackend implements ZvecGrepDaemonBackend {
       const provider =
         activeRuntime?.embeddingProvider() ??
         discoveredInfo.workspaceIndex?.embedding?.provider;
-      if (provider && provider !== "qwen") {
+      if (provider && !isRemoteEmbeddingProvider(provider)) {
         return undefined;
       }
     }
@@ -262,7 +263,11 @@ export class DaemonBackend implements ZvecGrepDaemonBackend {
       }
     }
     const schema = info.workspaceIndex?.embedding;
-    if (!info.indexed || !schema || schema.provider !== "qwen") {
+    if (
+      !info.indexed ||
+      !schema ||
+      !isRemoteEmbeddingProvider(schema.provider)
+    ) {
       return undefined;
     }
     const modelLoadRequest = this.searchModelLoadRequest(info, input);
@@ -1036,11 +1041,15 @@ export class DaemonBackend implements ZvecGrepDaemonBackend {
     authorization?: RemoteEmbeddingOperationPermit;
   }> {
     const knownProvider = runtime.embeddingProvider();
-    if (knownProvider && knownProvider !== "qwen") return { allowed: true };
+    if (knownProvider && !isRemoteEmbeddingProvider(knownProvider)) {
+      return { allowed: true };
+    }
     const root = runtime.canonicalRoot;
     const info = await this.inspectRoot(root, false);
     const schema = info.workspaceIndex?.embedding;
-    if (!schema || schema.provider !== "qwen") return { allowed: true };
+    if (!schema || !isRemoteEmbeddingProvider(schema.provider)) {
+      return { allowed: true };
+    }
     const modelInfo = await this.loadEmbeddingModelInfo(
       this.searchModelLoadRequest(info, {}),
     );

--- a/src/daemon/backend.ts
+++ b/src/daemon/backend.ts
@@ -16,6 +16,7 @@ import type {
   EmbeddingModelInfo,
 } from "../engine/models/index.js";
 import {
+  findEmbeddingModelCatalogEntry,
   isRemoteEmbeddingProvider,
   resolveEmbeddingReference,
 } from "../engine/models/index.js";
@@ -1425,7 +1426,10 @@ function parseEmbeddingModelReference(
 function embeddingModelReference(
   model: EmbeddingModelLoadRequest["model"],
 ): string {
-  return `${model.provider}/${model.name}`;
+  return (
+    findEmbeddingModelCatalogEntry(model.provider, model.name)?.reference ??
+    `${model.provider}/${model.name}`
+  );
 }
 
 function persistentStatus(

--- a/src/daemon/backend.ts
+++ b/src/daemon/backend.ts
@@ -172,6 +172,7 @@ export class DaemonBackend implements ZvecGrepDaemonBackend {
       input.root,
       this.options.serviceOptions,
       input.rebuild !== true,
+      false,
     );
     let modelLoadRequest: EmbeddingModelLoadRequest;
     try {
@@ -770,6 +771,7 @@ export class DaemonBackend implements ZvecGrepDaemonBackend {
     const before = await this.inspectRoot(
       runtime.canonicalRoot,
       includeInitialStatus,
+      false,
     );
     if (includeInitialStatus) {
       this.statusCache.set(runtime.canonicalRoot, before);
@@ -826,6 +828,7 @@ export class DaemonBackend implements ZvecGrepDaemonBackend {
             maxFileSizeBytes: input.maxFileSizeBytes,
             follow: input.follow,
             embeddingConcurrency: input.embeddingConcurrency,
+            noPrefetch: input.noPrefetch,
             changedPaths: input.changedPaths,
             signal,
             onProgress: report,
@@ -1336,11 +1339,13 @@ export class DaemonBackend implements ZvecGrepDaemonBackend {
   private async inspectRoot(
     root: string,
     includeStatus: boolean,
+    discoverParents = true,
   ): Promise<ZvecGrepInfoResult> {
     return await (this.options.inspectRoot ?? inspectRoot)(
       root,
       this.options.serviceOptions,
       includeStatus,
+      discoverParents,
     );
   }
 }
@@ -1385,6 +1390,7 @@ function assertDropOnlyInput(input: ZvecGrepIndexInput): void {
     [input.maxFileSizeBytes !== undefined, "maxFileSizeBytes"],
     [input.follow !== undefined, "follow"],
     [input.embeddingConcurrency !== undefined, "embeddingConcurrency"],
+    [input.noPrefetch !== undefined, "noPrefetch"],
     [input.wait !== undefined, "wait"],
   ];
   const names = conflicts

--- a/src/daemon/runtime-manager.ts
+++ b/src/daemon/runtime-manager.ts
@@ -6,6 +6,7 @@ import {
   type ZvecGrepInfoResult,
 } from "../engine/service/index.js";
 import type { CreateZvecGrepOptions } from "../engine/service/types.js";
+import { workspaceIndexLocation } from "../engine/service/root.js";
 import { DaemonError } from "./errors.js";
 import { DEFAULT_WATCHER_IDLE_TIMEOUT_MS } from "./config.js";
 import type {
@@ -115,24 +116,9 @@ export class RuntimeManager {
       requestedRoot,
       true,
     );
-    const activeRequestedRoot = this.runtimes.get(
-      this.aliases.get(canonicalRequestedRoot) ?? canonicalRequestedRoot,
-    );
-    if (activeRequestedRoot) {
-      return activeRequestedRoot;
-    }
-    const creatingRequestedRoot = this.creating.get(
-      this.aliases.get(canonicalRequestedRoot) ?? canonicalRequestedRoot,
-    );
-    if (creatingRequestedRoot) {
-      return creatingRequestedRoot;
-    }
-    const info = await inspectRoot(
-      canonicalRequestedRoot,
-      this.options.serviceOptions,
-      false,
-    );
-    const canonicalRoot = await resolveRequestedRoot(info.root, true);
+    // Search aliases may point at an ancestor. Index writes target the exact
+    // requested workspace, including an explicitly linked index home.
+    const canonicalRoot = workspaceIndexLocation(canonicalRequestedRoot).root;
     this.aliases.set(canonicalRequestedRoot, canonicalRoot);
     return this.getOrCreate(canonicalRoot);
   }
@@ -311,6 +297,7 @@ export async function inspectRoot(
   requestedRoot: string,
   serviceOptions: CreateZvecGrepOptions = {},
   includeStatus = true,
+  discoverParents = true,
 ): Promise<ZvecGrepInfoResult> {
   const canonicalRequestedRoot = await resolveRequestedRoot(
     requestedRoot,
@@ -321,7 +308,11 @@ export async function inspectRoot(
     root: canonicalRequestedRoot,
   });
   try {
-    return await service.info({ root: canonicalRequestedRoot, includeStatus });
+    return await service.info({
+      root: canonicalRequestedRoot,
+      includeStatus,
+      discoverParents,
+    });
   } finally {
     await service.close();
   }

--- a/src/engine/config.ts
+++ b/src/engine/config.ts
@@ -1,7 +1,7 @@
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { EngineError } from "./errors.js";
-import { getRemoteEmbeddingProviderCatalogEntry } from "./models/index.js";
+import { getRemoteEmbeddingProviderCatalogEntry } from "./remote-embedding-providers.js";
 import { readJsonFileSync, writeJsonFileSync } from "./utils/json.js";
 import { acquireReadWriteLock } from "./utils/lock.js";
 

--- a/src/engine/config.ts
+++ b/src/engine/config.ts
@@ -1,6 +1,7 @@
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { EngineError } from "./errors.js";
+import { getRemoteEmbeddingProviderCatalogEntry } from "./models/index.js";
 import { readJsonFileSync, writeJsonFileSync } from "./utils/json.js";
 import { acquireReadWriteLock } from "./utils/lock.js";
 
@@ -11,6 +12,7 @@ export type ZvecGrepGlobalDefaults = {
 
 export type ZvecGrepProviderConfig = {
   apiKey?: string;
+  auth?: "none";
 };
 
 export type EmbeddingDevice = "auto" | "cpu" | "metal" | "vulkan" | "cuda";
@@ -99,13 +101,14 @@ export function resolveEmbeddingRuntimeOptions(
       model?.device ??
       environmentDevice(environment))
     : undefined;
+  const configuredApiKey =
+    explicit.apiKey ?? workspace.apiKey ?? providerConfig?.apiKey;
   return {
     apiKey:
-      explicit.apiKey ??
-      workspace.apiKey ??
-      providerConfig?.apiKey ??
-      environmentApiKey(provider, environment) ??
-      "",
+      configuredApiKey ??
+      (providerConfig?.auth === "none"
+        ? ""
+        : (environmentApiKey(provider, environment) ?? "")),
     ...(endpoint !== undefined ? { endpoint } : {}),
     ...(device !== undefined ? { device } : {}),
   };
@@ -361,15 +364,40 @@ function parseProviders(
         `providers.${provider} must be an object with a valid provider name`,
       );
     }
-    assertKnownFields(providerValue, ["apiKey"], path, `providers.${provider}`);
+    assertKnownFields(
+      providerValue,
+      ["apiKey", "auth"],
+      path,
+      `providers.${provider}`,
+    );
 
     const apiKey = optionalNonEmptyString(
       providerValue.apiKey,
       path,
       `providers.${provider}.apiKey`,
     );
+    const auth = providerValue.auth;
+    if (auth !== undefined && auth !== "none") {
+      throw invalidConfig(path, `providers.${provider}.auth must be none`);
+    }
+    if (apiKey !== undefined && auth === "none") {
+      throw invalidConfig(
+        path,
+        `providers.${provider} cannot set both apiKey and auth none`,
+      );
+    }
+    if (
+      auth === "none" &&
+      getRemoteEmbeddingProviderCatalogEntry(provider)?.apiKey === "required"
+    ) {
+      throw invalidConfig(
+        path,
+        `providers.${provider}.auth none is not supported because the provider requires an API key`,
+      );
+    }
     const config: ZvecGrepProviderConfig = {
       ...(apiKey ? { apiKey } : {}),
+      ...(auth === "none" ? { auth } : {}),
     };
     if (Object.keys(config).length > 0) {
       providers[provider] = config;
@@ -389,10 +417,12 @@ function mergeProviderConfigs(
 
   const merged = { ...current };
   for (const [provider, config] of Object.entries(update ?? {})) {
-    merged[provider] = {
-      ...merged[provider],
-      ...config,
-    };
+    merged[provider] =
+      config.auth === "none"
+        ? { auth: "none" }
+        : config.apiKey !== undefined
+          ? { apiKey: config.apiKey }
+          : { ...merged[provider], ...config };
   }
   return merged;
 }

--- a/src/engine/models/backends/openai-compatible.ts
+++ b/src/engine/models/backends/openai-compatible.ts
@@ -11,6 +11,7 @@ import {
 import type { OpenAiCompatibleEmbeddingCatalogEntry } from "../catalog.js";
 
 const DEFAULT_REMOTE_EMBEDDING_TIMEOUT_MS = 60_000;
+const DGX_EMBEDDING_TIMEOUT_MS = 30 * 60_000;
 
 export type OpenAiCompatibleTextEmbeddingCatalogEntry = Readonly<
   Pick<
@@ -21,6 +22,7 @@ export type OpenAiCompatibleTextEmbeddingCatalogEntry = Readonly<
     | "dimension"
     | "metric"
     | "maxBatchSize"
+    | "maxBatchChars"
     | "maxInputTokens"
   > & {
     defaultEndpoint?: string;
@@ -53,6 +55,7 @@ export class OpenAiCompatibleTextEmbeddingModel extends BaseEmbeddingModel {
   private readonly displayName: string;
   private readonly errorCodePrefix: string;
   private readonly dependencies: OpenAiCompatibleDependencies;
+  private readonly timeoutMs: number;
 
   constructor(
     entry: OpenAiCompatibleTextEmbeddingCatalogEntry,
@@ -66,6 +69,10 @@ export class OpenAiCompatibleTextEmbeddingModel extends BaseEmbeddingModel {
     super();
 
     this.entry = entry;
+    this.timeoutMs =
+      entry.provider === "dgx"
+        ? DGX_EMBEDDING_TIMEOUT_MS
+        : DEFAULT_REMOTE_EMBEDDING_TIMEOUT_MS;
     const endpoint =
       options.endpoint === undefined
         ? (entry.defaultEndpoint?.trim() ?? "")
@@ -77,9 +84,13 @@ export class OpenAiCompatibleTextEmbeddingModel extends BaseEmbeddingModel {
       dimension: entry.dimension,
       metric: entry.metric,
       endpoint,
+      ...(entry.provider === "dgx" ? { defaultConcurrency: 1 } : {}),
       inputKinds: ["text"],
       limits: {
         maxBatchSize: entry.maxBatchSize,
+        ...(entry.maxBatchChars === undefined
+          ? {}
+          : { maxBatchChars: entry.maxBatchChars }),
         maxInputTokens: entry.maxInputTokens,
       },
     };
@@ -135,7 +146,7 @@ export class OpenAiCompatibleTextEmbeddingModel extends BaseEmbeddingModel {
     }
 
     let response: Response;
-    const signal = remoteEmbeddingSignal(options.signal);
+    const signal = remoteEmbeddingSignal(options.signal, this.timeoutMs);
 
     try {
       response = await this.dependencies.fetch(this.endpoint, {
@@ -148,7 +159,7 @@ export class OpenAiCompatibleTextEmbeddingModel extends BaseEmbeddingModel {
       throwIfEmbeddingCancelled(options.signal);
       throw new EngineError(`${this.displayName} request failed`, {
         code: this.errorCode("REQUEST_FAILED"),
-        context: `model=${this.info.reference} endpoint=${this.endpoint} timeoutMs=${DEFAULT_REMOTE_EMBEDDING_TIMEOUT_MS}`,
+        context: `model=${this.info.reference} endpoint=${this.endpoint} timeoutMs=${this.timeoutMs}`,
         cause,
       });
     }
@@ -292,8 +303,9 @@ export function readProviderError(body: unknown): {
 
 export function remoteEmbeddingSignal(
   signal: AbortSignal | undefined,
+  timeoutMs = DEFAULT_REMOTE_EMBEDDING_TIMEOUT_MS,
 ): AbortSignal {
-  const timeout = AbortSignal.timeout(DEFAULT_REMOTE_EMBEDDING_TIMEOUT_MS);
+  const timeout = AbortSignal.timeout(timeoutMs);
   return signal ? AbortSignal.any([signal, timeout]) : timeout;
 }
 

--- a/src/engine/models/backends/openai-compatible.ts
+++ b/src/engine/models/backends/openai-compatible.ts
@@ -1,0 +1,306 @@
+import { EngineError, type EngineErrorCode } from "../../errors.js";
+import type { Content, TextContent } from "../../types.js";
+import { traceHeaders } from "../../../observability/trace-context.js";
+import {
+  BaseEmbeddingModel,
+  type CreateEmbeddingModelOptions,
+  type EmbeddingModelInfo,
+  type EmbeddingResult,
+  type NormalizedEmbeddingOptions,
+} from "../embeddings.js";
+
+const DEFAULT_REMOTE_EMBEDDING_TIMEOUT_MS = 60_000;
+
+export type OpenAiCompatibleTextEmbeddingCatalogEntry = Readonly<{
+  reference: string;
+  provider: string;
+  model: string;
+  dimension: number;
+  metric: "cosine" | "dot" | "euclidean";
+  defaultEndpoint?: string;
+  maxBatchSize: number;
+  maxInputTokens?: number;
+  requestDimensions?: boolean;
+  requestEncodingFormat?: boolean;
+}>;
+
+export type OpenAiCompatibleTextEmbeddingSpec = Readonly<{
+  displayName: string;
+  errorCodePrefix: string;
+  requireApiKey?: boolean;
+  missingApiKeyHint?: string;
+}>;
+
+export type OpenAiCompatibleDependencies = {
+  fetch: typeof globalThis.fetch;
+};
+
+const defaultDependencies: OpenAiCompatibleDependencies = {
+  fetch: (...args) => globalThis.fetch(...args),
+};
+
+export class OpenAiCompatibleTextEmbeddingModel extends BaseEmbeddingModel {
+  readonly info: EmbeddingModelInfo;
+
+  private readonly entry: OpenAiCompatibleTextEmbeddingCatalogEntry;
+  private readonly apiKey: string;
+  private readonly endpoint: string;
+  private readonly displayName: string;
+  private readonly errorCodePrefix: string;
+  private readonly dependencies: OpenAiCompatibleDependencies;
+
+  constructor(
+    entry: OpenAiCompatibleTextEmbeddingCatalogEntry,
+    options: CreateEmbeddingModelOptions,
+    spec: OpenAiCompatibleTextEmbeddingSpec = {
+      displayName: "OpenAI-compatible text embedding",
+      errorCodePrefix: "OPENAI_COMPATIBLE_TEXT_EMBEDDING",
+    },
+    dependencies: Partial<OpenAiCompatibleDependencies> = {},
+  ) {
+    super();
+
+    this.entry = entry;
+    const endpoint =
+      options.endpoint === undefined
+        ? (entry.defaultEndpoint?.trim() ?? "")
+        : options.endpoint.trim();
+    this.info = {
+      reference: entry.reference,
+      provider: entry.provider,
+      name: entry.model,
+      dimension: entry.dimension,
+      metric: entry.metric,
+      endpoint,
+      inputKinds: ["text"],
+      limits: {
+        maxBatchSize: entry.maxBatchSize,
+        maxInputTokens: entry.maxInputTokens,
+      },
+    };
+    this.displayName = spec.displayName;
+    this.errorCodePrefix = spec.errorCodePrefix;
+    this.dependencies = { ...defaultDependencies, ...dependencies };
+
+    this.apiKey = options.apiKey?.trim() ?? "";
+    if (spec.requireApiKey && this.apiKey.length === 0) {
+      throw new EngineError(`${this.displayName} model requires an API key`, {
+        code: this.errorCode("MISSING_API_KEY"),
+        context: [
+          `model=${this.info.reference}`,
+          ...(spec.missingApiKeyHint ? [`hint=${spec.missingApiKeyHint}`] : []),
+        ].join("\n"),
+      });
+    }
+
+    if (endpoint.length === 0) {
+      throw new EngineError(`${this.displayName} model requires an endpoint`, {
+        code: this.errorCode("MISSING_ENDPOINT"),
+        context: `model=${this.info.reference}`,
+      });
+    }
+
+    this.endpoint = endpoint;
+  }
+
+  protected async doEmbed(
+    contents: readonly Content[],
+    options: NormalizedEmbeddingOptions,
+  ): Promise<EmbeddingResult> {
+    const texts = (contents as readonly TextContent[]).map(
+      (content) => content.text,
+    );
+    const requestBody: Record<string, unknown> = {
+      model: this.entry.model,
+      input: texts,
+    };
+    if (this.entry.requestDimensions) {
+      requestBody.dimensions = this.info.dimension;
+    }
+    if (this.entry.requestEncodingFormat) {
+      requestBody.encoding_format = "float";
+    }
+
+    const headers: Record<string, string> = {
+      ...traceHeaders(),
+      "Content-Type": "application/json",
+    };
+    if (this.apiKey.length > 0) {
+      headers.Authorization = `Bearer ${this.apiKey}`;
+    }
+
+    let response: Response;
+    const signal = remoteEmbeddingSignal(options.signal);
+
+    try {
+      response = await this.dependencies.fetch(this.endpoint, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(requestBody),
+        signal,
+      });
+    } catch (cause) {
+      throwIfEmbeddingCancelled(options.signal);
+      throw new EngineError(`${this.displayName} request failed`, {
+        code: this.errorCode("REQUEST_FAILED"),
+        context: `model=${this.info.reference} endpoint=${this.endpoint} timeoutMs=${DEFAULT_REMOTE_EMBEDDING_TIMEOUT_MS}`,
+        cause,
+      });
+    }
+
+    let body: unknown;
+    try {
+      body = await response.json();
+    } catch (cause) {
+      throw new EngineError(`${this.displayName} response was not valid JSON`, {
+        code: this.errorCode("INVALID_JSON"),
+        context: `model=${this.info.reference} status=${response.status}`,
+        cause,
+      });
+    }
+
+    if (!response.ok) {
+      const error = readProviderError(body);
+      throw new EngineError(`${this.displayName} request returned an error`, {
+        code: this.errorCode("API_ERROR"),
+        context: providerErrorContext(this.entry.model, response, error),
+      });
+    }
+
+    if (!isRecord(body) || !Array.isArray(body.data)) {
+      throw new EngineError(
+        `${this.displayName} response did not include data`,
+        {
+          code: this.errorCode("MISSING_DATA"),
+          context: `model=${this.info.reference}`,
+        },
+      );
+    }
+
+    const vectors = new Array<number[]>(texts.length);
+    const seenIndexes = new Set<number>();
+
+    for (const item of body.data) {
+      if (
+        !isRecord(item) ||
+        typeof item.index !== "number" ||
+        !Number.isInteger(item.index)
+      ) {
+        throw new EngineError(
+          `${this.displayName} response included an invalid index`,
+          {
+            code: this.errorCode("INVALID_INDEX"),
+            context: `model=${this.info.reference} index=${isRecord(item) ? String(item.index) : "unknown"}`,
+          },
+        );
+      }
+
+      if (item.index < 0 || item.index >= texts.length) {
+        throw new EngineError(
+          `${this.displayName} response index was out of range`,
+          {
+            code: this.errorCode("INDEX_OUT_OF_RANGE"),
+            context: `model=${this.info.reference} index=${item.index} inputCount=${texts.length}`,
+          },
+        );
+      }
+
+      if (seenIndexes.has(item.index)) {
+        throw new EngineError(
+          `${this.displayName} response included a duplicate index`,
+          {
+            code: this.errorCode("DUPLICATE_INDEX"),
+            context: `model=${this.info.reference} index=${item.index}`,
+          },
+        );
+      }
+      seenIndexes.add(item.index);
+
+      if (!Array.isArray(item.embedding)) {
+        throw new EngineError(
+          `${this.displayName} response included an invalid embedding`,
+          {
+            code: this.errorCode("INVALID_VECTOR"),
+            context: `model=${this.info.reference} index=${item.index}`,
+          },
+        );
+      }
+
+      vectors[item.index] = item.embedding as number[];
+    }
+
+    return { vectors, truncated: [] };
+  }
+
+  private errorCode(suffix: string): EngineErrorCode {
+    return `ZVEC_GREP.ENGINE.MODELS.${this.errorCodePrefix}_${suffix}`;
+  }
+}
+
+export function providerErrorContext(
+  model: string,
+  response: Response,
+  error: { code: string; type: string; message: string },
+): string {
+  const retryAfter = retryAfterHeaderMs(response.headers.get("retry-after"));
+  const retryAfterDetail =
+    typeof retryAfter === "number" ? ` retryAfterMs=${retryAfter}` : "";
+
+  return `model=${model} status=${response.status}${retryAfterDetail} providerCode=${error.code} providerType=${error.type} providerMessage=${error.message}`;
+}
+
+function retryAfterHeaderMs(value: string | null): number | undefined {
+  if (!value) return undefined;
+
+  const seconds = Number(value);
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return Math.round(seconds * 1000);
+  }
+
+  const dateMs = Date.parse(value);
+  return Number.isFinite(dateMs) ? Math.max(0, dateMs - Date.now()) : undefined;
+}
+
+export function readProviderError(body: unknown): {
+  code: string;
+  type: string;
+  message: string;
+} {
+  if (!isRecord(body) || !isRecord(body.error)) {
+    if (isRecord(body)) {
+      return {
+        code: typeof body.code === "string" ? body.code : "unknown",
+        type: "unknown",
+        message: typeof body.message === "string" ? body.message : "unknown",
+      };
+    }
+    return { code: "unknown", type: "unknown", message: "unknown" };
+  }
+
+  return {
+    code: typeof body.error.code === "string" ? body.error.code : "unknown",
+    type: typeof body.error.type === "string" ? body.error.type : "unknown",
+    message:
+      typeof body.error.message === "string" ? body.error.message : "unknown",
+  };
+}
+
+export function remoteEmbeddingSignal(
+  signal: AbortSignal | undefined,
+): AbortSignal {
+  const timeout = AbortSignal.timeout(DEFAULT_REMOTE_EMBEDDING_TIMEOUT_MS);
+  return signal ? AbortSignal.any([signal, timeout]) : timeout;
+}
+
+export function throwIfEmbeddingCancelled(
+  signal: AbortSignal | undefined,
+): void {
+  if (!signal?.aborted) return;
+  throw signal.reason instanceof Error
+    ? signal.reason
+    : new Error("Embedding request was cancelled.");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/src/engine/models/backends/openai-compatible.ts
+++ b/src/engine/models/backends/openai-compatible.ts
@@ -8,21 +8,26 @@ import {
   type EmbeddingResult,
   type NormalizedEmbeddingOptions,
 } from "../embeddings.js";
+import type { OpenAiCompatibleEmbeddingCatalogEntry } from "../catalog.js";
 
 const DEFAULT_REMOTE_EMBEDDING_TIMEOUT_MS = 60_000;
 
-export type OpenAiCompatibleTextEmbeddingCatalogEntry = Readonly<{
-  reference: string;
-  provider: string;
-  model: string;
-  dimension: number;
-  metric: "cosine" | "dot" | "euclidean";
-  defaultEndpoint?: string;
-  maxBatchSize: number;
-  maxInputTokens?: number;
-  requestDimensions?: boolean;
-  requestEncodingFormat?: boolean;
-}>;
+export type OpenAiCompatibleTextEmbeddingCatalogEntry = Readonly<
+  Pick<
+    OpenAiCompatibleEmbeddingCatalogEntry,
+    | "reference"
+    | "provider"
+    | "model"
+    | "dimension"
+    | "metric"
+    | "maxBatchSize"
+    | "maxInputTokens"
+  > & {
+    defaultEndpoint?: string;
+    requestDimensions?: boolean;
+    requestEncodingFormat?: boolean;
+  }
+>;
 
 export type OpenAiCompatibleTextEmbeddingSpec = Readonly<{
   displayName: string;

--- a/src/engine/models/backends/qwen.ts
+++ b/src/engine/models/backends/qwen.ts
@@ -1,6 +1,6 @@
 import { globalConfigPath } from "../../config.js";
-import { EngineError, type EngineErrorCode } from "../../errors.js";
-import type { Content, ImageFormat, TextContent } from "../../types.js";
+import { EngineError } from "../../errors.js";
+import type { Content, ImageFormat } from "../../types.js";
 import {
   BaseEmbeddingModel,
   type CreateEmbeddingModelOptions,
@@ -13,6 +13,15 @@ import type {
   QwenTextEmbeddingCatalogEntry,
 } from "../catalog.js";
 import { traceHeaders } from "../../../observability/trace-context.js";
+import {
+  OpenAiCompatibleTextEmbeddingModel,
+  providerErrorContext,
+  readProviderError,
+  remoteEmbeddingSignal,
+  throwIfEmbeddingCancelled,
+  type OpenAiCompatibleDependencies,
+  type OpenAiCompatibleTextEmbeddingSpec,
+} from "./openai-compatible.js";
 
 // -----------------------------------------------------------------------------
 // Text embedding models (OpenAI-compatible API)
@@ -28,20 +37,19 @@ const defaultDependencies: QwenDependencies = {
   fetch: (...args) => globalThis.fetch(...args),
 };
 
-type QwenTextEmbeddingSpec = {
-  displayName: string;
-  errorCodePrefix: string;
-};
-
 const QWEN_TEXT_EMBEDDING_V4_SPEC = {
   displayName: "Qwen text-embedding-v4",
   errorCodePrefix: "QWEN_TEXT_EMBEDDING_V4",
-} as const satisfies QwenTextEmbeddingSpec;
+  requireApiKey: true,
+  missingApiKeyHint: `Pass --api-key, set ZVEC_GREP_API_KEY, or configure providers.qwen.apiKey in ${globalConfigPath()}.`,
+} as const satisfies OpenAiCompatibleTextEmbeddingSpec;
 
 const QWEN37_TEXT_EMBEDDING_SPEC = {
   displayName: "Qwen3.7 text embedding",
   errorCodePrefix: "QWEN37_TEXT_EMBEDDING",
-} as const satisfies QwenTextEmbeddingSpec;
+  requireApiKey: true,
+  missingApiKeyHint: `Pass --api-key, set ZVEC_GREP_API_KEY, or configure providers.qwen.apiKey in ${globalConfigPath()}.`,
+} as const satisfies OpenAiCompatibleTextEmbeddingSpec;
 
 type QwenTextEmbeddingV4CatalogEntry = Extract<
   QwenTextEmbeddingCatalogEntry,
@@ -53,197 +61,23 @@ type Qwen37TextEmbeddingCatalogEntry = Extract<
   { model: "qwen3.7-text-embedding" }
 >;
 
-abstract class QwenTextEmbeddingModel extends BaseEmbeddingModel {
-  readonly info: EmbeddingModelInfo;
-
-  private readonly entry: QwenTextEmbeddingCatalogEntry;
-  private readonly apiKey: string;
-  private readonly endpoint: string;
-  private readonly displayName: string;
-  private readonly errorCodePrefix: string;
-  private readonly dependencies: QwenDependencies;
-
-  constructor(
-    entry: QwenTextEmbeddingCatalogEntry,
-    spec: QwenTextEmbeddingSpec,
-    options: CreateEmbeddingModelOptions,
-    dependencies: Partial<QwenDependencies>,
-  ) {
-    super();
-
-    this.entry = entry;
-    const endpoint =
-      options.endpoint === undefined
-        ? entry.defaultEndpoint
-        : options.endpoint.trim();
-    this.info = {
-      reference: entry.reference,
-      provider: entry.provider,
-      name: entry.model,
-      dimension: entry.dimension,
-      metric: entry.metric,
-      endpoint,
-      inputKinds: ["text"],
-      limits: {
-        maxBatchSize: entry.maxBatchSize,
-        maxInputTokens: entry.maxInputTokens,
-      },
-    };
-    this.displayName = spec.displayName;
-    this.errorCodePrefix = spec.errorCodePrefix;
-    this.dependencies = { ...defaultDependencies, ...dependencies };
-
-    const apiKey = options.apiKey?.trim() ?? "";
-    if (apiKey.length === 0) {
-      throw new EngineError(`${this.displayName} model requires an API key`, {
-        code: this.errorCode("MISSING_API_KEY"),
-        context: `model=${this.info.reference}\nhint=Pass --api-key, set ZVEC_GREP_API_KEY, or configure providers.qwen.apiKey in ${globalConfigPath()}.`,
-      });
-    }
-
-    if (endpoint.length === 0) {
-      throw new EngineError(`${this.displayName} model requires an endpoint`, {
-        code: this.errorCode("MISSING_ENDPOINT"),
-        context: `model=${this.info.reference}`,
-      });
-    }
-
-    this.apiKey = apiKey;
-    this.endpoint = endpoint;
-  }
-
-  protected async doEmbed(
-    contents: readonly Content[],
-    options: NormalizedEmbeddingOptions,
-  ): Promise<EmbeddingResult> {
-    const texts = (contents as readonly TextContent[]).map(
-      (content) => content.text,
-    );
-
-    let response: Response;
-    const signal = remoteEmbeddingSignal(options.signal);
-
-    try {
-      response = await this.dependencies.fetch(this.endpoint, {
-        method: "POST",
-        headers: {
-          ...traceHeaders(),
-          Authorization: `Bearer ${this.apiKey}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          model: this.entry.model,
-          input: texts,
-          dimensions: this.info.dimension,
-          encoding_format: "float",
-        }),
-        signal,
-      });
-    } catch (cause) {
-      throwIfEmbeddingCancelled(options.signal);
-      throw new EngineError(`${this.displayName} request failed`, {
-        code: this.errorCode("REQUEST_FAILED"),
-        context: `model=${this.info.reference} endpoint=${this.endpoint} timeoutMs=${DEFAULT_REMOTE_EMBEDDING_TIMEOUT_MS}`,
-        cause,
-      });
-    }
-
-    let body: unknown;
-
-    try {
-      body = await response.json();
-    } catch (cause) {
-      throw new EngineError(`${this.displayName} response was not valid JSON`, {
-        code: this.errorCode("INVALID_JSON"),
-        context: `model=${this.info.reference} status=${response.status}`,
-        cause,
-      });
-    }
-
-    if (!response.ok) {
-      const error = readProviderError(body);
-
-      throw new EngineError(`${this.displayName} request returned an error`, {
-        code: this.errorCode("API_ERROR"),
-        context: providerErrorContext(this.entry.model, response, error),
-      });
-    }
-
-    if (!isRecord(body) || !Array.isArray(body.data)) {
-      throw new EngineError(
-        `${this.displayName} response did not include data`,
-        {
-          code: this.errorCode("MISSING_DATA"),
-          context: `model=${this.info.reference}`,
-        },
-      );
-    }
-
-    const vectors = new Array<number[]>(texts.length);
-
-    for (const item of body.data) {
-      if (
-        !isRecord(item) ||
-        typeof item.index !== "number" ||
-        !Number.isInteger(item.index)
-      ) {
-        throw new EngineError(
-          `${this.displayName} response included an invalid index`,
-          {
-            code: this.errorCode("INVALID_INDEX"),
-            context: `model=${this.info.reference} index=${isRecord(item) ? String(item.index) : "unknown"}`,
-          },
-        );
-      }
-
-      if (item.index < 0 || item.index >= texts.length) {
-        throw new EngineError(
-          `${this.displayName} response index was out of range`,
-          {
-            code: this.errorCode("INDEX_OUT_OF_RANGE"),
-            context: `model=${this.info.reference} index=${item.index} inputCount=${texts.length}`,
-          },
-        );
-      }
-
-      if (!Array.isArray(item.embedding)) {
-        throw new EngineError(
-          `${this.displayName} response included an invalid embedding`,
-          {
-            code: this.errorCode("INVALID_VECTOR"),
-            context: `model=${this.info.reference} index=${item.index}`,
-          },
-        );
-      }
-
-      vectors[item.index] = item.embedding as number[];
-    }
-
-    return { vectors, truncated: [] };
-  }
-
-  private errorCode(suffix: string): EngineErrorCode {
-    return `ZVEC_GREP.ENGINE.MODELS.${this.errorCodePrefix}_${suffix}`;
-  }
-}
-
-export class QwenTextEmbeddingV4Model extends QwenTextEmbeddingModel {
+export class QwenTextEmbeddingV4Model extends OpenAiCompatibleTextEmbeddingModel {
   constructor(
     entry: QwenTextEmbeddingV4CatalogEntry,
     options: CreateEmbeddingModelOptions,
-    dependencies: Partial<QwenDependencies> = {},
+    dependencies: Partial<OpenAiCompatibleDependencies> = {},
   ) {
-    super(entry, QWEN_TEXT_EMBEDDING_V4_SPEC, options, dependencies);
+    super(entry, options, QWEN_TEXT_EMBEDDING_V4_SPEC, dependencies);
   }
 }
 
-export class Qwen37TextEmbeddingModel extends QwenTextEmbeddingModel {
+export class Qwen37TextEmbeddingModel extends OpenAiCompatibleTextEmbeddingModel {
   constructor(
     entry: Qwen37TextEmbeddingCatalogEntry,
     options: CreateEmbeddingModelOptions,
-    dependencies: Partial<QwenDependencies> = {},
+    dependencies: Partial<OpenAiCompatibleDependencies> = {},
   ) {
-    super(entry, QWEN37_TEXT_EMBEDDING_SPEC, options, dependencies);
+    super(entry, options, QWEN37_TEXT_EMBEDDING_SPEC, dependencies);
   }
 }
 
@@ -447,65 +281,6 @@ export class Qwen3VlEmbeddingModel extends BaseEmbeddingModel {
 const BASE64_CHARS =
   "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
-function providerErrorContext(
-  model: string,
-  response: Response,
-  error: { code: string; type: string; message: string },
-): string {
-  const retryAfter = retryAfterHeaderMs(response.headers.get("retry-after"));
-  const retryAfterDetail =
-    typeof retryAfter === "number" ? ` retryAfterMs=${retryAfter}` : "";
-
-  return `model=${model} status=${response.status}${retryAfterDetail} providerCode=${error.code} providerType=${error.type} providerMessage=${error.message}`;
-}
-
-function retryAfterHeaderMs(value: string | null): number | undefined {
-  if (!value) {
-    return undefined;
-  }
-
-  const seconds = Number(value);
-  if (Number.isFinite(seconds) && seconds >= 0) {
-    return Math.round(seconds * 1000);
-  }
-
-  const dateMs = Date.parse(value);
-  if (Number.isFinite(dateMs)) {
-    return Math.max(0, dateMs - Date.now());
-  }
-
-  return undefined;
-}
-
-function readProviderError(body: unknown): {
-  code: string;
-  type: string;
-  message: string;
-} {
-  if (!isRecord(body) || !isRecord(body.error)) {
-    if (isRecord(body)) {
-      return {
-        code: typeof body.code === "string" ? body.code : "unknown",
-        type: "unknown",
-        message: typeof body.message === "string" ? body.message : "unknown",
-      };
-    }
-
-    return {
-      code: "unknown",
-      type: "unknown",
-      message: "unknown",
-    };
-  }
-
-  return {
-    code: typeof body.error.code === "string" ? body.error.code : "unknown",
-    type: typeof body.error.type === "string" ? body.error.type : "unknown",
-    message:
-      typeof body.error.message === "string" ? body.error.message : "unknown",
-  };
-}
-
 function readEmbeddingIndex(
   item: Record<string, unknown>,
   fallbackIndex: number,
@@ -581,18 +356,4 @@ function bytesToBase64(bytes: Uint8Array): string {
   }
 
   return output;
-}
-
-function remoteEmbeddingSignal(signal: AbortSignal | undefined): AbortSignal {
-  const timeout = AbortSignal.timeout(DEFAULT_REMOTE_EMBEDDING_TIMEOUT_MS);
-  return signal ? AbortSignal.any([signal, timeout]) : timeout;
-}
-
-function throwIfEmbeddingCancelled(signal: AbortSignal | undefined): void {
-  if (!signal?.aborted) {
-    return;
-  }
-  throw signal.reason instanceof Error
-    ? signal.reason
-    : new Error("Embedding request was cancelled.");
 }

--- a/src/engine/models/catalog.ts
+++ b/src/engine/models/catalog.ts
@@ -3,36 +3,6 @@ const DEFAULT_QWEN_TEXT_EMBEDDING_ENDPOINT =
 const DEFAULT_QWEN3_VL_EMBEDDING_ENDPOINT =
   "https://dashscope.aliyuncs.com/api/v1/services/embeddings/multimodal-embedding/multimodal-embedding";
 
-export const REMOTE_EMBEDDING_PROVIDER_CATALOG = {
-  qwen: {
-    provider: "qwen",
-    apiKey: "required",
-  },
-  dgx: {
-    provider: "dgx",
-    apiKey: "optional",
-  },
-} as const;
-
-export type RemoteEmbeddingProviderCatalogEntry =
-  (typeof REMOTE_EMBEDDING_PROVIDER_CATALOG)[keyof typeof REMOTE_EMBEDDING_PROVIDER_CATALOG];
-
-export function listRemoteEmbeddingProviders(): RemoteEmbeddingProviderCatalogEntry[] {
-  return Object.values(REMOTE_EMBEDDING_PROVIDER_CATALOG);
-}
-
-export function getRemoteEmbeddingProviderCatalogEntry(
-  provider: string,
-): RemoteEmbeddingProviderCatalogEntry | undefined {
-  return REMOTE_EMBEDDING_PROVIDER_CATALOG[
-    provider as keyof typeof REMOTE_EMBEDDING_PROVIDER_CATALOG
-  ];
-}
-
-export function isRemoteEmbeddingProvider(provider: string): boolean {
-  return provider !== "local";
-}
-
 export const EMBEDDING_MODEL_CATALOG = {
   "local/embeddinggemma-300m": {
     backend: "llama-cpp",

--- a/src/engine/models/catalog.ts
+++ b/src/engine/models/catalog.ts
@@ -29,6 +29,10 @@ export function getRemoteEmbeddingProviderCatalogEntry(
   ];
 }
 
+export function isRemoteEmbeddingProvider(provider: string): boolean {
+  return provider !== "local";
+}
+
 export const EMBEDDING_MODEL_CATALOG = {
   "local/embeddinggemma-300m": {
     backend: "llama-cpp",

--- a/src/engine/models/catalog.ts
+++ b/src/engine/models/catalog.ts
@@ -79,6 +79,8 @@ export const EMBEDDING_MODEL_CATALOG = {
     defaultEndpoint: DEFAULT_QWEN_TEXT_EMBEDDING_ENDPOINT,
     maxBatchSize: 10,
     maxInputTokens: 8192,
+    requestDimensions: true,
+    requestEncodingFormat: true,
   },
 
   "qwen/qwen3.7-text-embedding": {
@@ -92,6 +94,8 @@ export const EMBEDDING_MODEL_CATALOG = {
     defaultEndpoint: DEFAULT_QWEN_TEXT_EMBEDDING_ENDPOINT,
     maxBatchSize: 20,
     maxInputTokens: 128000,
+    requestDimensions: true,
+    requestEncodingFormat: true,
   },
 
   "qwen/qwen3-vl-embedding": {

--- a/src/engine/models/catalog.ts
+++ b/src/engine/models/catalog.ts
@@ -639,3 +639,15 @@ export function getEmbeddingModelCatalogEntry(
 ): EmbeddingCatalogEntry | undefined {
   return EMBEDDING_MODEL_CATALOG[reference as EmbeddingModelCatalogId];
 }
+
+export function findEmbeddingModelCatalogEntry(
+  provider: string,
+  model: string,
+): EmbeddingCatalogEntry | undefined {
+  return (
+    getEmbeddingModelCatalogEntry(`${provider}/${model}`) ??
+    listEmbeddingModels().find(
+      (entry) => entry.provider === provider && entry.model === model,
+    )
+  );
+}

--- a/src/engine/models/catalog.ts
+++ b/src/engine/models/catalog.ts
@@ -3,6 +3,32 @@ const DEFAULT_QWEN_TEXT_EMBEDDING_ENDPOINT =
 const DEFAULT_QWEN3_VL_EMBEDDING_ENDPOINT =
   "https://dashscope.aliyuncs.com/api/v1/services/embeddings/multimodal-embedding/multimodal-embedding";
 
+export const REMOTE_EMBEDDING_PROVIDER_CATALOG = {
+  qwen: {
+    provider: "qwen",
+    apiKey: "required",
+  },
+  dgx: {
+    provider: "dgx",
+    apiKey: "optional",
+  },
+} as const;
+
+export type RemoteEmbeddingProviderCatalogEntry =
+  (typeof REMOTE_EMBEDDING_PROVIDER_CATALOG)[keyof typeof REMOTE_EMBEDDING_PROVIDER_CATALOG];
+
+export function listRemoteEmbeddingProviders(): RemoteEmbeddingProviderCatalogEntry[] {
+  return Object.values(REMOTE_EMBEDDING_PROVIDER_CATALOG);
+}
+
+export function getRemoteEmbeddingProviderCatalogEntry(
+  provider: string,
+): RemoteEmbeddingProviderCatalogEntry | undefined {
+  return REMOTE_EMBEDDING_PROVIDER_CATALOG[
+    provider as keyof typeof REMOTE_EMBEDDING_PROVIDER_CATALOG
+  ];
+}
+
 export const EMBEDDING_MODEL_CATALOG = {
   "local/embeddinggemma-300m": {
     backend: "llama-cpp",

--- a/src/engine/models/catalog.ts
+++ b/src/engine/models/catalog.ts
@@ -138,6 +138,18 @@ export const EMBEDDING_MODEL_CATALOG = {
     maxImageBytes: 10 * 1024 * 1024,
   },
 
+  "dgx/qwen3-embedding-0.6b": {
+    backend: "openai-compatible",
+    kind: "text",
+    reference: "dgx/qwen3-embedding-0.6b",
+    provider: "dgx",
+    model: "qwen3-embedding:0.6b",
+    dimension: 1024,
+    metric: "cosine",
+    maxBatchSize: 256,
+    maxInputTokens: 32768,
+  },
+
   "local/bge-small-en-v1.5": {
     backend: "transformers-js",
     reference: "local/bge-small-en-v1.5",
@@ -616,6 +628,21 @@ export type QwenEmbeddingCatalogEntry = Extract<
   EmbeddingCatalogEntry,
   { backend: "qwen" }
 >;
+
+export type OpenAiCompatibleEmbeddingCatalogEntry = Readonly<{
+  backend: "openai-compatible";
+  kind: "text";
+  reference: string;
+  provider: string;
+  model: string;
+  dimension: number;
+  metric: "cosine" | "dot" | "euclidean";
+  defaultEndpoint?: string;
+  maxBatchSize: number;
+  maxInputTokens?: number;
+  requestDimensions?: boolean;
+  requestEncodingFormat?: boolean;
+}>;
 
 export type QwenTextEmbeddingCatalogEntry = Extract<
   QwenEmbeddingCatalogEntry,

--- a/src/engine/models/catalog.ts
+++ b/src/engine/models/catalog.ts
@@ -120,7 +120,8 @@ export const EMBEDDING_MODEL_CATALOG = {
     model: "qwen3-embedding:0.6b",
     dimension: 1024,
     metric: "cosine",
-    maxBatchSize: 256,
+    maxBatchSize: 32,
+    maxBatchChars: 64_000,
     maxInputTokens: 32768,
   },
 
@@ -613,6 +614,7 @@ export type OpenAiCompatibleEmbeddingCatalogEntry = Readonly<{
   metric: "cosine" | "dot" | "euclidean";
   defaultEndpoint?: string;
   maxBatchSize: number;
+  maxBatchChars?: number;
   maxInputTokens?: number;
   requestDimensions?: boolean;
   requestEncodingFormat?: boolean;

--- a/src/engine/models/embeddings.ts
+++ b/src/engine/models/embeddings.ts
@@ -55,6 +55,8 @@ export type EmbeddingModelInfo = Readonly<{
   inputKinds: readonly ContentKind[];
   limits: Readonly<{
     maxBatchSize: number;
+    /** Total text characters per indexing request, including metadata. */
+    maxBatchChars?: number;
     maxInputTokens?: number;
     maxImageBytes?: number;
   }>;

--- a/src/engine/models/factory.ts
+++ b/src/engine/models/factory.ts
@@ -9,6 +9,7 @@ import type {
 } from "./embeddings.js";
 import { LlamaCppEmbeddingModel } from "./backends/llama-cpp.js";
 import { Model2VecEmbeddingModel } from "./backends/model2vec.js";
+import { OpenAiCompatibleTextEmbeddingModel } from "./backends/openai-compatible.js";
 import {
   Qwen37TextEmbeddingModel,
   Qwen3VlEmbeddingModel,
@@ -37,6 +38,8 @@ export function createEmbeddingModel(
       return new TransformersJsEmbeddingModel(catalogEntry, options);
     case "qwen":
       return createQwenEmbeddingModel(catalogEntry, options);
+    case "openai-compatible":
+      return new OpenAiCompatibleTextEmbeddingModel(catalogEntry, options);
     default:
       return unsupportedCatalogEntry(catalogEntry);
   }

--- a/src/engine/models/index.ts
+++ b/src/engine/models/index.ts
@@ -10,11 +10,13 @@ export {
 export { createEmbeddingModel } from "./factory.js";
 export {
   getEmbeddingModelCatalogEntry,
+  listEmbeddingModels,
+} from "./catalog.js";
+export {
   getRemoteEmbeddingProviderCatalogEntry,
   isRemoteEmbeddingProvider,
-  listEmbeddingModels,
   listRemoteEmbeddingProviders,
-} from "./catalog.js";
+} from "../remote-embedding-providers.js";
 export {
   resolveEmbeddingReference,
   type ResolveEmbeddingReferenceOptions,

--- a/src/engine/models/index.ts
+++ b/src/engine/models/index.ts
@@ -10,7 +10,9 @@ export {
 export { createEmbeddingModel } from "./factory.js";
 export {
   getEmbeddingModelCatalogEntry,
+  getRemoteEmbeddingProviderCatalogEntry,
   listEmbeddingModels,
+  listRemoteEmbeddingProviders,
 } from "./catalog.js";
 export {
   resolveEmbeddingReference,

--- a/src/engine/models/index.ts
+++ b/src/engine/models/index.ts
@@ -9,6 +9,7 @@ export {
 } from "./embeddings.js";
 export { createEmbeddingModel } from "./factory.js";
 export {
+  findEmbeddingModelCatalogEntry,
   getEmbeddingModelCatalogEntry,
   listEmbeddingModels,
 } from "./catalog.js";

--- a/src/engine/models/index.ts
+++ b/src/engine/models/index.ts
@@ -11,6 +11,7 @@ export { createEmbeddingModel } from "./factory.js";
 export {
   getEmbeddingModelCatalogEntry,
   getRemoteEmbeddingProviderCatalogEntry,
+  isRemoteEmbeddingProvider,
   listEmbeddingModels,
   listRemoteEmbeddingProviders,
 } from "./catalog.js";

--- a/src/engine/pipeline/indexing/index.ts
+++ b/src/engine/pipeline/indexing/index.ts
@@ -6,10 +6,11 @@ import {
   errorDetails,
   isEngineError,
 } from "../../errors.js";
-import type {
-  EmbeddingModel,
-  EmbeddingModelProgress,
-  EmbeddingResult,
+import {
+  isRemoteEmbeddingProvider,
+  type EmbeddingModel,
+  type EmbeddingModelProgress,
+  type EmbeddingResult,
 } from "../../models/index.js";
 import type { WorkspaceIndexStorage } from "../../storage/index.js";
 import type {
@@ -1452,7 +1453,7 @@ function resolveEmbeddingConcurrencyPolicy(
     };
   }
 
-  const remote = model.info.provider === "qwen";
+  const remote = isRemoteEmbeddingProvider(model.info.provider);
   const multimodal = model.info.inputKinds.includes("image");
   const configuredLocalDefault = model.info.defaultConcurrency;
   const localDefault =

--- a/src/engine/pipeline/indexing/index.ts
+++ b/src/engine/pipeline/indexing/index.ts
@@ -45,6 +45,7 @@ export type IndexContext = {
   storage: WorkspaceIndexStorage;
   embeddingModel: EmbeddingModel;
   embeddingConcurrency?: number;
+  noPrefetch?: boolean;
   onProgress?: (progress: IndexProgress) => void;
   signal?: AbortSignal;
 };
@@ -729,6 +730,9 @@ async function indexFiles(
   };
   const batchFiles: PreparedFile[] = [];
   let batchFragmentCount = 0;
+  let batchChars = 0;
+  const maxBatchChars =
+    ctx.embeddingModel.info.limits.maxBatchChars ?? Infinity;
   const embeddingScheduler = createEmbeddingScheduler(
     ctx.embeddingConcurrency,
     ctx.embeddingModel,
@@ -763,6 +767,7 @@ async function indexFiles(
 
     const filesToEmbed = batchFiles.splice(0);
     batchFragmentCount = 0;
+    batchChars = 0;
 
     await scheduleEmbeddingTask(() =>
       embedAndCommitBatch(
@@ -782,6 +787,14 @@ async function indexFiles(
   ): Promise<void> => {
     throwFirstEmbeddingError();
     throwIfIndexCancelled(ctx);
+    // Apply backpressure before launching, so the producer can prepare the
+    // next batch while existing tasks await embeddings. Only one prepared
+    // batch waits here; embedding request concurrency remains unchanged.
+    while (runningEmbeddings.size >= embeddingScheduler.taskConcurrency) {
+      await Promise.race(runningEmbeddings);
+      throwFirstEmbeddingError();
+      throwIfIndexCancelled(ctx);
+    }
     if (!modelPrepared && prepareModel) {
       // Finish shared initialization before any file or fragment batch is queued.
       try {
@@ -817,8 +830,10 @@ async function indexFiles(
       });
 
     runningEmbeddings.add(promise);
-
-    if (runningEmbeddings.size >= embeddingScheduler.taskConcurrency) {
+    if (
+      ctx.noPrefetch &&
+      runningEmbeddings.size >= embeddingScheduler.taskConcurrency
+    ) {
       await Promise.race(runningEmbeddings);
     }
     throwFirstEmbeddingError();
@@ -848,8 +863,11 @@ async function indexFiles(
         continue;
       }
 
+      const preparedChars = fragmentTextChars(prepared.fragments);
       if (
-        prepared.fragments.length > ctx.embeddingModel.info.limits.maxBatchSize
+        prepared.fragments.length >
+          ctx.embeddingModel.info.limits.maxBatchSize ||
+        preparedChars > maxBatchChars
       ) {
         await flushBatch();
         await scheduleEmbeddingTask(async () => {
@@ -870,16 +888,21 @@ async function indexFiles(
 
       if (
         batchFragmentCount > 0 &&
-        batchFragmentCount + prepared.fragments.length >
-          ctx.embeddingModel.info.limits.maxBatchSize
+        (batchFragmentCount + prepared.fragments.length >
+          ctx.embeddingModel.info.limits.maxBatchSize ||
+          batchChars + preparedChars > maxBatchChars)
       ) {
         await flushBatch();
       }
 
       batchFiles.push(prepared);
       batchFragmentCount += prepared.fragments.length;
+      batchChars += preparedChars;
 
-      if (batchFragmentCount === ctx.embeddingModel.info.limits.maxBatchSize) {
+      if (
+        batchFragmentCount === ctx.embeddingModel.info.limits.maxBatchSize ||
+        batchChars === maxBatchChars
+      ) {
         await flushBatch();
       }
     }
@@ -1193,6 +1216,15 @@ async function readSource(file: FileInfo): Promise<Source> {
   };
 }
 
+function fragmentTextChars(fragments: readonly PreparedFragment[]): number {
+  return fragments.reduce(
+    (total, { embeddingContent }) =>
+      total +
+      (embeddingContent.kind === "text" ? embeddingContent.text.length : 0),
+    0,
+  );
+}
+
 async function embedFragments(
   fragments: readonly PreparedFragment[],
   model: EmbeddingModel,
@@ -1202,16 +1234,23 @@ async function embedFragments(
 ): Promise<EmbeddingResult> {
   const batches: { start: number; fragments: PreparedFragment[] }[] = [];
 
-  for (
-    let start = 0;
-    start < fragments.length;
-    start += model.info.limits.maxBatchSize
-  ) {
-    const batch = fragments.slice(
-      start,
-      start + model.info.limits.maxBatchSize,
-    );
+  const maxBatchChars = model.info.limits.maxBatchChars ?? Infinity;
+  for (let start = 0; start < fragments.length;) {
+    let end = start;
+    let chars = 0;
+    while (
+      end < fragments.length &&
+      end - start < model.info.limits.maxBatchSize
+    ) {
+      const content = fragments[end].embeddingContent;
+      const nextChars = content.kind === "text" ? content.text.length : 0;
+      if (end > start && chars + nextChars > maxBatchChars) break;
+      chars += nextChars;
+      end++;
+    }
+    const batch = fragments.slice(start, end);
     batches.push({ start, fragments: batch });
+    start = end;
   }
 
   const vectors: number[][] = new Array(fragments.length);
@@ -1455,20 +1494,30 @@ function resolveEmbeddingConcurrencyPolicy(
 
   const remote = isRemoteEmbeddingProvider(model.info.provider);
   const multimodal = model.info.inputKinds.includes("image");
-  const configuredLocalDefault = model.info.defaultConcurrency;
-  const localDefault =
-    configuredLocalDefault !== undefined &&
-    Number.isInteger(configuredLocalDefault) &&
-    configuredLocalDefault > 0
-      ? configuredLocalDefault
+  const configuredDefault = model.info.defaultConcurrency;
+  const modelDefault =
+    configuredDefault !== undefined &&
+    Number.isInteger(configuredDefault) &&
+    configuredDefault > 0
+      ? configuredDefault
       : 1;
-  const initial = remote ? (multimodal ? 4 : 8) : localDefault;
-  const max = remote ? (multimodal ? 8 : 12) : localDefault;
-  const min = Math.min(initial, 4);
+  const initial =
+    remote && configuredDefault === undefined
+      ? multimodal
+        ? 4
+        : 8
+      : modelDefault;
+  const max =
+    remote && configuredDefault === undefined
+      ? multimodal
+        ? 8
+        : 12
+      : modelDefault;
 
   return {
     initial,
-    min,
+    // Self-hosted remote endpoints may only sustain one request at a time.
+    min: 1,
     max: Math.max(initial, max),
     adaptive: max > 1,
   };

--- a/src/engine/pipeline/indexing/input-budget.ts
+++ b/src/engine/pipeline/indexing/input-budget.ts
@@ -6,6 +6,7 @@ const TOKEN_DENSE_WINDOW_CHARS = 16 * 1024;
 const TOKEN_DENSE_WINDOW_STEP_CHARS = 8 * 1024;
 const TOKEN_DENSE_PERCENT = 30;
 const CHUNK_OVERLAP_PERCENT = 15;
+const RETRIEVAL_CHUNK_CHARS = 3600;
 
 export function indexChunkOptions(
   maxInputTokens: number | undefined,
@@ -18,7 +19,11 @@ export function indexChunkOptions(
   const charsPer100Tokens = isTokenDenseText(text, maxInputTokens)
     ? TOKEN_DENSE_CHARS_PER_100_TOKENS
     : DEFAULT_CHARS_PER_100_TOKENS;
-  const maxChunkChars = Math.floor((maxInputTokens * charsPer100Tokens) / 100);
+  // Model context length is a safety ceiling, not a retrieval passage size.
+  const maxChunkChars = Math.min(
+    RETRIEVAL_CHUNK_CHARS,
+    Math.floor((maxInputTokens * charsPer100Tokens) / 100),
+  );
   const chunkOverlapChars = Math.floor(
     (maxChunkChars * CHUNK_OVERLAP_PERCENT) / 100,
   );

--- a/src/engine/remote-embedding-providers.ts
+++ b/src/engine/remote-embedding-providers.ts
@@ -1,0 +1,29 @@
+export const REMOTE_EMBEDDING_PROVIDER_CATALOG = {
+  qwen: {
+    provider: "qwen",
+    apiKey: "required",
+  },
+  dgx: {
+    provider: "dgx",
+    apiKey: "optional",
+  },
+} as const;
+
+export type RemoteEmbeddingProviderCatalogEntry =
+  (typeof REMOTE_EMBEDDING_PROVIDER_CATALOG)[keyof typeof REMOTE_EMBEDDING_PROVIDER_CATALOG];
+
+export function listRemoteEmbeddingProviders(): RemoteEmbeddingProviderCatalogEntry[] {
+  return Object.values(REMOTE_EMBEDDING_PROVIDER_CATALOG);
+}
+
+export function getRemoteEmbeddingProviderCatalogEntry(
+  provider: string,
+): RemoteEmbeddingProviderCatalogEntry | undefined {
+  return REMOTE_EMBEDDING_PROVIDER_CATALOG[
+    provider as keyof typeof REMOTE_EMBEDDING_PROVIDER_CATALOG
+  ];
+}
+
+export function isRemoteEmbeddingProvider(provider: string): boolean {
+  return provider !== "local";
+}

--- a/src/engine/service/types.ts
+++ b/src/engine/service/types.ts
@@ -48,6 +48,7 @@ export type ZvecGrepIndexOptions = {
   maxFileSizeBytes?: number;
   follow?: boolean;
   embeddingConcurrency?: number;
+  noPrefetch?: boolean;
   onProgress?: (progress: IndexProgress) => void;
   changedPaths?: readonly string[];
   signal?: AbortSignal;
@@ -62,6 +63,8 @@ export type ZvecGrepWriterContext = (
 
 export type ZvecGrepInfoOptions = {
   root?: string;
+  /** Discover an ancestor workspace; disable when preparing an exact-root write. */
+  discoverParents?: boolean;
   includeStatus?: boolean;
 };
 

--- a/src/engine/service/workspace-index.ts
+++ b/src/engine/service/workspace-index.ts
@@ -81,6 +81,7 @@ export class WorkspaceIndex {
       embeddingModel,
       storage: this.storage,
       embeddingConcurrency: options.embeddingConcurrency,
+      noPrefetch: options.noPrefetch,
       onProgress: options.onProgress,
       signal: options.signal,
     };

--- a/src/engine/service/zvec-grep.ts
+++ b/src/engine/service/zvec-grep.ts
@@ -19,6 +19,7 @@ import {
 import {
   createEmbeddingModel,
   EmbeddingPurpose,
+  findEmbeddingModelCatalogEntry,
   isRemoteEmbeddingProvider,
   resolveEmbeddingReference,
   type CreateEmbeddingModelOptions,
@@ -1487,7 +1488,10 @@ function parseEmbeddingModelReference(
 }
 
 function embeddingModelReference(identity: EmbeddingModelIdentity): string {
-  return `${identity.provider}/${identity.name}`;
+  return (
+    findEmbeddingModelCatalogEntry(identity.provider, identity.name)
+      ?.reference ?? `${identity.provider}/${identity.name}`
+  );
 }
 
 function providerOptionsFingerprint(options: {

--- a/src/engine/service/zvec-grep.ts
+++ b/src/engine/service/zvec-grep.ts
@@ -19,6 +19,7 @@ import {
 import {
   createEmbeddingModel,
   EmbeddingPurpose,
+  isRemoteEmbeddingProvider,
   resolveEmbeddingReference,
   type CreateEmbeddingModelOptions,
   type EmbeddingModel,
@@ -1431,7 +1432,7 @@ function createServiceEmbeddingModel(
   serviceOptions: CreateZvecGrepOptions,
 ): EmbeddingModel {
   const model = createEmbeddingModel(reference, modelOptions);
-  if (model.info.provider !== "qwen") {
+  if (!isRemoteEmbeddingProvider(model.info.provider)) {
     return model;
   }
 

--- a/src/engine/service/zvec-grep.ts
+++ b/src/engine/service/zvec-grep.ts
@@ -216,6 +216,20 @@ class ZvecGrepService implements ZvecGrep {
           options.rebuild ? "index.rebuild" : "index",
           async () => {
             const existing = readWorkspaceManifest(location.home);
+            if (
+              !options.rebuild &&
+              isWorkspaceIndexed(existing) &&
+              existing.indexVersion !== CURRENT_INDEX_VERSION
+            ) {
+              throw new EngineError(
+                "Workspace index chunking policy has changed",
+                {
+                  code: "ZVEC_GREP.ENGINE.WORKSPACE_INDEX.VERSION_MISMATCH",
+                  context:
+                    'Run "zg --index --rebuild" to re-embed existing files with the current chunking policy.',
+                },
+              );
+            }
             const existingRuntime = existing?.embeddingRuntime ?? {};
             const embeddingModel = this.embeddingModelForIndex(
               existing,
@@ -306,6 +320,7 @@ class ZvecGrepService implements ZvecGrep {
                 const result = await workspaceIndex.index({
                   rebuild: false,
                   embeddingConcurrency: options.embeddingConcurrency,
+                  noPrefetch: options.noPrefetch,
                   onProgress: options.onProgress,
                   changedPaths: options.changedPaths,
                   signal: options.signal,
@@ -448,8 +463,15 @@ class ZvecGrepService implements ZvecGrep {
   async info(options: ZvecGrepInfoOptions = {}): Promise<ZvecGrepInfoResult> {
     this.ensureOpen();
     const startRoot = resolveZvecGrepRoot(options.root ?? this.root);
-    assertNearestWorkspaceHomeUnlocked(startRoot, "info");
-    const nearest = findNearestWorkspaceIndex(startRoot);
+    if (options.discoverParents === false) {
+      assertHomeUnlocked(workspaceHome(startRoot), "info");
+    } else {
+      assertNearestWorkspaceHomeUnlocked(startRoot, "info");
+    }
+    const nearest = findNearestWorkspaceIndex(
+      startRoot,
+      options.discoverParents,
+    );
 
     if (!nearest) {
       const location = workspaceIndexLocation(startRoot);
@@ -1115,8 +1137,13 @@ type WorkspaceIndexRecord = {
   info: WorkspaceManifest;
 };
 
-function findNearestWorkspaceIndex(start: string): WorkspaceIndexRecord | null {
-  const location = findNearestWorkspace(start);
+function findNearestWorkspaceIndex(
+  start: string,
+  discoverParents = true,
+): WorkspaceIndexRecord | null {
+  const location = discoverParents
+    ? findNearestWorkspace(start)
+    : workspaceIndexLocation(start);
   if (!location) return null;
   const info = readWorkspaceManifest(location.home);
   return info ? { location, info } : null;

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -194,7 +194,7 @@ export type EntityFragment = {
 // Workspace index types
 // -----------------------------------------------------------------------------
 
-export const CURRENT_INDEX_VERSION = 1;
+export const CURRENT_INDEX_VERSION = 2;
 
 export type WorkspaceIndexEmbeddingSchema = {
   provider: string;
@@ -247,6 +247,7 @@ export type IndexOptions = {
   name?: string;
   rebuild?: boolean;
   embeddingConcurrency?: number;
+  noPrefetch?: boolean;
   onProgress?: (progress: IndexProgress) => void;
   changedPaths?: readonly string[];
   signal?: AbortSignal;

--- a/src/mcp/schemas.ts
+++ b/src/mcp/schemas.ts
@@ -220,6 +220,12 @@ export const zvecGrepIndexInputSchema = z.object({
     .optional()
     .describe("Maximum indexed file size in bytes."),
   follow: z.boolean().optional().describe("Follow symbolic links."),
+  noPrefetch: z
+    .boolean()
+    .optional()
+    .describe(
+      "Disable preparing the next indexing batch while embeddings are pending.",
+    ),
   embeddingConcurrency: z
     .number()
     .int()

--- a/test/authorization.test.mjs
+++ b/test/authorization.test.mjs
@@ -13,6 +13,7 @@ import test from "node:test";
 import {
   RemoteEmbeddingAuthorizationManager,
   RemoteEmbeddingAuthorizationStore,
+  createRemoteEmbeddingOperationPermit,
   createRemoteEmbeddingTarget,
   planRemoteIndexAuthorization,
   planRemoteSearchAuthorization,
@@ -137,6 +138,53 @@ test("remote provider guard fails closed and re-checks Workspace revocation", as
   assert.equal(fetches, 2);
 });
 
+test("DGX provider uses the same fail-closed authorization guard", async (t) => {
+  const temporaryDirectory = await mkdtemp(join(tmpdir(), "zg-auth-dgx-"));
+  const root = join(temporaryDirectory, "repo");
+  await mkdir(root);
+  const endpoint = "http://spark.test:11434/v1/embeddings";
+  const target = await createRemoteEmbeddingTarget({
+    roots: [root],
+    provider: "dgx",
+    model: "qwen3-embedding:0.6b",
+    endpoint,
+  });
+  const originalFetch = globalThis.fetch;
+  let fetches = 0;
+  globalThis.fetch = async () => {
+    fetches += 1;
+    return new Response(
+      JSON.stringify({
+        data: [{ index: 0, embedding: new Array(1024).fill(0.01) }],
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+  };
+  const model = createEmbeddingModelForIdentity(
+    { provider: "dgx", name: "qwen3-embedding-0.6b" },
+    {
+      endpoint,
+      authorizationSigningKeyPath: join(temporaryDirectory, "signing.key"),
+    },
+  );
+  t.after(async () => {
+    globalThis.fetch = originalFetch;
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  });
+
+  await assert.rejects(
+    model.embed([{ kind: "text", text: "not authorized" }]),
+    /authorization is required/i,
+  );
+  assert.equal(fetches, 0);
+
+  const permit = createRemoteEmbeddingOperationPermit(target, "once");
+  await withRemoteEmbeddingOperationPermit(permit, () =>
+    model.embed([{ kind: "text", text: "authorized" }]),
+  );
+  assert.equal(fetches, 1);
+});
+
 test("authorization planner follows merged Query and Index behavior", async (t) => {
   const temporaryDirectory = await mkdtemp(join(tmpdir(), "zg-auth-plan-"));
   const root = join(temporaryDirectory, "repo");
@@ -239,6 +287,61 @@ test("authorization planner follows merged Query and Index behavior", async (t) 
   });
   assert.equal(updatePlan.operation, "index");
   assert.equal(updatePlan.reason, "index_update");
+});
+
+test("authorization planner treats DGX as a remote provider", async (t) => {
+  const temporaryDirectory = await mkdtemp(join(tmpdir(), "zg-auth-plan-dgx-"));
+  const root = join(temporaryDirectory, "repo");
+  await mkdir(root);
+  t.after(() => rm(temporaryDirectory, { recursive: true, force: true }));
+  const embedding = {
+    provider: "dgx",
+    model: "qwen3-embedding:0.6b",
+    dimension: 1024,
+    metric: "cosine",
+  };
+  const model = {
+    reference: "dgx/qwen3-embedding-0.6b",
+    ...embedding,
+    name: embedding.model,
+    endpoint: "http://spark.test:11434/v1/embeddings",
+    inputKinds: ["text"],
+    limits: { maxBatchSize: 256, maxInputTokens: 32768 },
+  };
+  const info = {
+    root,
+    indexed: true,
+    indexPolicy: "enabled",
+    home: join(root, ".zvec-grep"),
+    indexPath: join(root, ".zvec-grep", "index"),
+    source: "index",
+    status: status(0),
+    workspaceIndex: {
+      id: "workspace-index",
+      name: "workspace",
+      path: join(root, ".zvec-grep", "index"),
+      rootPaths: [{ absolutePath: root, recursive: true }],
+      embedding,
+      indexVersion: 1,
+      createdTime: 1,
+      updatedTime: 1,
+    },
+  };
+
+  const searchPlan = await planRemoteSearchAuthorization({
+    info,
+    model,
+    search: {
+      root,
+      queries: ["authorization"],
+      routes: [],
+      freshness: "eventual",
+      autoUpdate: true,
+    },
+  });
+  assert.equal(searchPlan.target.provider, "dgx");
+  assert.equal(searchPlan.target.model, "qwen3-embedding:0.6b");
+  assert.equal(searchPlan.operation, "query");
 });
 
 function status(filesModified) {

--- a/test/authorization.test.mjs
+++ b/test/authorization.test.mjs
@@ -161,7 +161,7 @@ test("DGX provider uses the same fail-closed authorization guard", async (t) => 
     );
   };
   const model = createEmbeddingModelForIdentity(
-    { provider: "dgx", name: "qwen3-embedding-0.6b" },
+    { provider: "dgx", name: "qwen3-embedding:0.6b" },
     {
       endpoint,
       authorizationSigningKeyPath: join(temporaryDirectory, "signing.key"),

--- a/test/config-cli.test.mjs
+++ b/test/config-cli.test.mjs
@@ -11,6 +11,19 @@ import { resolveAuthorizationSchema } from "../dist/cli/auth.js";
 const execFileAsync = promisify(execFile);
 const cliPath = resolve("dist/cli/index.js");
 
+test("no-prefetch is accepted only for indexing", () => {
+  for (const mode of ["direct", "server"]) {
+    assert.equal(
+      parseArgs(["--index", "--mode", mode, "--no-prefetch", "."]).options
+        .noPrefetch,
+      true,
+    );
+  }
+  for (const args of [["query"], ["--status"], ["--index", "--drop"]]) {
+    assert.throws(() => parseArgs([...args, "--no-prefetch"]), /--no-prefetch/);
+  }
+});
+
 test("catalog references resolve to served model identities", () => {
   assert.deepEqual(resolveAuthorizationSchema("dgx/qwen3-embedding-0.6b"), {
     provider: "dgx",

--- a/test/config-cli.test.mjs
+++ b/test/config-cli.test.mjs
@@ -36,6 +36,16 @@ test("config provider and default model settings parse", () => {
   assert.equal(provider.options.configAction, "provider-set");
   assert.equal(provider.options.apiKey, "secret");
 
+  const unauthenticatedProvider = parseArgs([
+    "--config",
+    "provider",
+    "set",
+    "dgx",
+    "--no-auth",
+  ]);
+  assert.equal(unauthenticatedProvider.options.configAction, "provider-set");
+  assert.equal(unauthenticatedProvider.options.providerNoAuth, true);
+
   const model = parseArgs([
     "--config",
     "model",
@@ -69,6 +79,11 @@ test("config model set persists independent local model settings", async (t) => 
       "--device",
       "metal",
     ],
+    { env, cwd: workspace },
+  );
+  await execFileAsync(
+    process.execPath,
+    [cliPath, "config", "provider", "set", "dgx", "--no-auth"],
     { env, cwd: workspace },
   );
   await execFileAsync(
@@ -137,6 +152,7 @@ test("config model set persists independent local model settings", async (t) => 
   });
   assert.deepEqual(config.providers, {
     qwen: { apiKey: "provider-key" },
+    dgx: { auth: "none" },
   });
   assert.equal(config.defaults.embedding, "qwen/text-embedding-v4");
   assert.equal(config.version, 1);
@@ -155,6 +171,30 @@ test("config model set rejects missing and incompatible settings", async () => {
       "local/embeddinggemma-300m",
     ]),
     /requires --endpoint, --device, or --default/,
+  );
+  await assert.rejects(
+    execFileAsync(process.execPath, [
+      cliPath,
+      "--config",
+      "provider",
+      "set",
+      "qwen",
+      "--no-auth",
+    ]),
+    /requires an API key and does not support --no-auth/,
+  );
+  await assert.rejects(
+    execFileAsync(process.execPath, [
+      cliPath,
+      "--config",
+      "provider",
+      "set",
+      "dgx",
+      "--api-key",
+      "secret",
+      "--no-auth",
+    ]),
+    /either --api-key or --no-auth, not both/,
   );
   await assert.rejects(
     execFileAsync(process.execPath, [
@@ -210,7 +250,7 @@ test("config model set rejects missing and incompatible settings", async () => {
       assert.match(error.stderr, /Unsupported remote embedding provider/);
       assert.match(
         error.stderr,
-        /Supported remote embedding providers:\s+qwen/,
+        /Supported remote embedding providers:\s+qwen\s+dgx/,
       );
       return true;
     },
@@ -241,5 +281,16 @@ test("config model set rejects missing and incompatible settings", async () => {
         "secret",
       ]),
     /does not accept --api-key/,
+  );
+  assert.throws(
+    () =>
+      parseArgs([
+        "config",
+        "model",
+        "set",
+        "local/embeddinggemma-300m",
+        "--no-auth",
+      ]),
+    /does not accept --no-auth/,
   );
 });

--- a/test/config-cli.test.mjs
+++ b/test/config-cli.test.mjs
@@ -6,9 +6,17 @@ import { join, resolve } from "node:path";
 import { promisify } from "node:util";
 import test from "node:test";
 import { parseArgs } from "../dist/cli/args.js";
+import { resolveAuthorizationSchema } from "../dist/cli/auth.js";
 
 const execFileAsync = promisify(execFile);
 const cliPath = resolve("dist/cli/index.js");
+
+test("catalog references resolve to served model identities", () => {
+  assert.deepEqual(resolveAuthorizationSchema("dgx/qwen3-embedding-0.6b"), {
+    provider: "dgx",
+    model: "qwen3-embedding:0.6b",
+  });
+});
 
 test("config model set parses local runtime settings", () => {
   const parsed = parseArgs([

--- a/test/config.test.mjs
+++ b/test/config.test.mjs
@@ -29,6 +29,9 @@ test("global config v1 is created securely and merged incrementally", async (t) 
         qwen: {
           apiKey: "first-key",
         },
+        dgx: {
+          auth: "none",
+        },
       },
       models: {
         "qwen/text-embedding-v4": {
@@ -64,6 +67,9 @@ test("global config v1 is created securely and merged incrementally", async (t) 
     providers: {
       qwen: {
         apiKey: "rotated-key",
+      },
+      dgx: {
+        auth: "none",
       },
     },
     models: {
@@ -168,6 +174,69 @@ test("embedding runtime resolver preserves every precedence layer", () => {
   );
 });
 
+test("explicit unauthenticated provider config suppresses only environment credentials", () => {
+  const config = {
+    version: 1,
+    providers: { dgx: { auth: "none" } },
+  };
+  const environment = { ZVEC_GREP_API_KEY: "unrelated-environment-key" };
+
+  assert.deepEqual(
+    resolveEmbeddingRuntimeOptions(
+      "dgx/qwen3-embedding-0.6b",
+      {},
+      {},
+      config,
+      environment,
+    ),
+    { apiKey: "" },
+  );
+  assert.deepEqual(
+    resolveEmbeddingRuntimeOptions(
+      "dgx/qwen3-embedding-0.6b",
+      { apiKey: "explicit-key" },
+      {},
+      config,
+      environment,
+    ),
+    { apiKey: "explicit-key" },
+  );
+  assert.deepEqual(
+    resolveEmbeddingRuntimeOptions(
+      "dgx/qwen3-embedding-0.6b",
+      {},
+      { apiKey: "workspace-key" },
+      config,
+      environment,
+    ),
+    { apiKey: "workspace-key" },
+  );
+});
+
+test("provider authentication updates replace mutually exclusive credentials", async (t) => {
+  const temporaryDirectory = await mkdtemp(
+    join(tmpdir(), "zvec-grep-config-auth-"),
+  );
+  const configPath = join(temporaryDirectory, ".zvec-grep", "config.json");
+  t.after(async () => {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  });
+
+  updateGlobalConfig({ providers: { dgx: { apiKey: "secret" } } }, configPath);
+  updateGlobalConfig({ providers: { dgx: { auth: "none" } } }, configPath);
+  assert.deepEqual(readGlobalConfig(configPath).providers?.dgx, {
+    auth: "none",
+  });
+
+  updateGlobalConfig(
+    { providers: { dgx: { apiKey: "replacement" } } },
+    configPath,
+  );
+  assert.deepEqual(readGlobalConfig(configPath).providers?.dgx, {
+    apiKey: "replacement",
+  });
+});
+
 test("embedding reference resolver prefers the environment over the global default", () => {
   assert.equal(
     resolveEmbeddingReference({
@@ -247,6 +316,33 @@ test("global config v1 rejects malformed schemas without echoing secrets", async
     () => readGlobalConfig(configPath),
     (error) => {
       assert.match(error.context, /defaults\.device is not supported/);
+      return true;
+    },
+  );
+
+  await writeFile(
+    configPath,
+    JSON.stringify({
+      version: 1,
+      providers: { dgx: { apiKey: "secret", auth: "none" } },
+    }),
+  );
+  assert.throws(
+    () => readGlobalConfig(configPath),
+    (error) => {
+      assert.match(error.context, /cannot set both apiKey and auth none/);
+      return true;
+    },
+  );
+
+  await writeFile(
+    configPath,
+    JSON.stringify({ version: 1, providers: { qwen: { auth: "none" } } }),
+  );
+  assert.throws(
+    () => readGlobalConfig(configPath),
+    (error) => {
+      assert.match(error.context, /provider requires an API key/);
       return true;
     },
   );

--- a/test/daemon-backend.test.mjs
+++ b/test/daemon-backend.test.mjs
@@ -17,6 +17,88 @@ const noopWatchManagerFactory = () => ({
   close: async () => {},
 });
 
+for (const searchFirst of [false, true]) {
+  test(`index targets a nested repository even with a parent index (search alias: ${searchFirst})`, async () => {
+    const temporaryDirectory = await mkdtemp(
+      join(tmpdir(), "zvec-grep-nested-index-"),
+    );
+    const root = join(temporaryDirectory, "repo");
+    const child = join(root, "campaign");
+    await mkdir(join(child, ".git"), { recursive: true });
+    await writeFile(
+      join(root, "parent.md"),
+      "# Parent\nParent workspace document.\n",
+    );
+    await writeFile(join(child, "answer.ts"), "export const answer = 42;\n");
+    const parentModel = new TestEmbeddingModel();
+    parentModel.info = {
+      ...parentModel.info,
+      reference: "test/parent",
+      name: "parent",
+    };
+    const service = await createZvecGrep({ root, embeddingModel: parentModel });
+    try {
+      await service.index({ globs: ["**/*.md"] });
+      const inherited = await service.info({ root: child });
+      assert.equal(inherited.root, await realpath(root));
+      const exact = await service.info({ root: child, discoverParents: false });
+      assert.equal(exact.root, child);
+      assert.equal(exact.indexed, false);
+      assert.equal(exact.workspaceIndex, undefined);
+    } finally {
+      await service.close();
+    }
+    const backend = new DaemonBackend({
+      version: "1.0.0",
+      watchManagerFactory: noopWatchManagerFactory,
+      modelPoolOptions: {
+        createModel: () => {
+          const model = new TestEmbeddingModel();
+          model.info = {
+            ...model.info,
+            provider: "local",
+            reference: "local/deterministic",
+          };
+          return model;
+        },
+      },
+    });
+    try {
+      if (searchFirst) {
+        const runtime = await backend.runtimeManager.activate(child);
+        assert.equal(runtime.canonicalRoot, await realpath(root));
+      }
+      const request = {
+        root: child,
+        embedding: "local/deterministic",
+        wait: true,
+      };
+      assert.equal(await backend.planIndexAuthorization(request), undefined);
+      const result = await backend.index(request);
+      assert.equal(result.state, "succeeded", JSON.stringify(result.error));
+      assert.equal(result.root, await realpath(child));
+      const childInfo = await inspectRoot(child);
+      assert.equal(childInfo.status.filesStored, 1);
+      assert.equal(childInfo.workspaceIndex.embedding.model, "deterministic");
+      assert.equal(
+        childInfo.workspaceIndex.rootPaths[0].absolutePath,
+        await realpath(child),
+      );
+      assert.equal(childInfo.workspaceIndex.rootPaths[0].globs, undefined);
+      assert.equal((await backend.index(request)).root, await realpath(child));
+      const parentInfo = await inspectRoot(root);
+      assert.equal(parentInfo.status.filesStored, 1);
+      assert.equal(parentInfo.workspaceIndex.embedding.model, "parent");
+      assert.deepEqual(parentInfo.workspaceIndex.rootPaths[0].globs, [
+        "**/*.md",
+      ]);
+    } finally {
+      await backend.close();
+      await rm(temporaryDirectory, { recursive: true, force: true });
+    }
+  });
+}
+
 test("index releases its model lease when service creation fails", async () => {
   const temporaryDirectory = await mkdtemp(
     join(tmpdir(), "zvec-grep-backend-"),

--- a/test/e2e/cli.test.mjs
+++ b/test/e2e/cli.test.mjs
@@ -963,6 +963,7 @@ test("CLI exposes stable help, version, and failure behavior", async (t) => {
   assert.match(indexHelp.stdout, /ZVEC_GREP_EMBEDDING/);
   const configHelp = await runCli(["--config", "--help"]);
   assert.match(configHelp.stdout, /Default API key for the provider/);
+  assert.match(configHelp.stdout, /Explicitly use an unauthenticated provider/);
   assert.match(configHelp.stdout, /Existing indexes continue to use/);
   const authHelp = await runCli(["--auth", "--help"]);
   assert.match(

--- a/test/embedding-runtime.test.mjs
+++ b/test/embedding-runtime.test.mjs
@@ -125,15 +125,100 @@ test("inherited provider keys are not copied into workspace metadata", async (t)
   assert.deepEqual(readRuntime(root), { endpoint });
 });
 
+test("DGX no-auth configuration indexes and queries through the OpenAI-compatible endpoint", async (t) => {
+  const temporaryDirectory = await mkdtemp(
+    join(tmpdir(), "zvec-grep-dgx-runtime-"),
+  );
+  const root = join(temporaryDirectory, "repo");
+  const requests = [];
+  const endpoint = await createFakeEmbeddingServer(t, 1024, {
+    onRequest({ request, body }) {
+      requests.push({
+        authorization: request.headers.authorization,
+        body,
+      });
+    },
+  });
+  const originalHome = process.env.HOME;
+  const originalApiKey = process.env.ZVEC_GREP_API_KEY;
+  process.env.HOME = temporaryDirectory;
+  process.env.ZVEC_GREP_API_KEY = "unrelated-environment-key";
+  t.after(async () => {
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    if (originalApiKey === undefined) delete process.env.ZVEC_GREP_API_KEY;
+    else process.env.ZVEC_GREP_API_KEY = originalApiKey;
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  });
+  await mkdir(root, { recursive: true });
+  await writeFile(join(root, "example.ts"), "export const spark = 'ready';\n");
+  updateGlobalConfig({
+    defaults: { embedding: "dgx/qwen3-embedding-0.6b" },
+    providers: { dgx: { auth: "none" } },
+    models: {
+      "dgx/qwen3-embedding-0.6b": { endpoint },
+    },
+  });
+
+  const service = await createZvecGrep({ root });
+  t.after(() => service.close());
+  await withPermit(
+    root,
+    endpoint,
+    () => service.index(),
+    "dgx",
+    "qwen3-embedding:0.6b",
+  );
+  const info = await service.info({ includeStatus: false });
+  assert.deepEqual(info.workspaceIndex.embedding, {
+    provider: "dgx",
+    model: "qwen3-embedding:0.6b",
+    dimension: 1024,
+    metric: "cosine",
+  });
+  assert.deepEqual(readRuntime(root), { endpoint });
+
+  const result = await withPermit(
+    root,
+    endpoint,
+    () =>
+      service.context({
+        root,
+        query: "spark readiness",
+        autoUpdate: false,
+      }),
+    "dgx",
+    "qwen3-embedding:0.6b",
+  );
+  assert.equal(result.source, "index");
+  assert.ok(requests.length >= 2);
+  assert.ok(requests.every((request) => request.authorization === undefined));
+  assert.ok(
+    requests.every((request) => request.body.model === "qwen3-embedding:0.6b"),
+  );
+  assert.ok(
+    requests.every(
+      (request) =>
+        !("dimensions" in request.body) && !("encoding_format" in request.body),
+    ),
+  );
+});
+
 function readRuntime(root) {
   return readWorkspaceManifest(join(root, ".zvec-grep")).embeddingRuntime;
 }
 
-async function withPermit(root, endpoint, operation) {
+async function withPermit(
+  root,
+  endpoint,
+  operation,
+  provider = "qwen",
+  model = "text-embedding-v4",
+) {
   const target = await createRemoteEmbeddingTarget({
     roots: [root],
-    provider: "qwen",
-    model: "text-embedding-v4",
+    provider,
+    model,
     endpoint,
   });
   return await withRemoteEmbeddingOperationPermit(

--- a/test/helpers/fake-embedding.mjs
+++ b/test/helpers/fake-embedding.mjs
@@ -37,11 +37,16 @@ export function deterministicVector(value, dimension = 1024) {
   );
 }
 
-export async function createFakeEmbeddingServer(t, dimension = 1024) {
+export async function createFakeEmbeddingServer(
+  t,
+  dimension = 1024,
+  options = {},
+) {
   const server = createServer(async (request, response) => {
     const chunks = [];
     for await (const chunk of request) chunks.push(chunk);
     const body = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+    options.onRequest?.({ request, body });
     const inputs = Array.isArray(body.input) ? body.input : [];
     response.writeHead(200, { "content-type": "application/json" });
     response.end(

--- a/test/integration/service.test.mjs
+++ b/test/integration/service.test.mjs
@@ -258,6 +258,141 @@ function multiBatchModel2Vec(modelCacheDir, failure) {
   return { model, calls };
 }
 
+for (const noPrefetch of [false, true]) {
+  test(`service bounds preparation with noPrefetch=${noPrefetch} and embedding concurrency one`, async (t) => {
+    const temporaryDirectory = await createTemporaryDirectory(
+      t,
+      "zvec-grep-prefetch-",
+    );
+    const root = join(temporaryDirectory, "repo");
+    await mkdir(root, { recursive: true });
+    await Promise.all(
+      Array.from({ length: 4 }, (_, index) =>
+        writeFile(join(root, `file-${index}.txt`), `unique content ${index}\n`),
+      ),
+    );
+    const model = new FakeEmbeddingModel();
+    model.info = {
+      ...model.info,
+      defaultConcurrency: 1,
+      limits: { maxBatchSize: 1 },
+    };
+    let releaseFirst;
+    const firstRequest = new Promise((resolve) => {
+      releaseFirst = resolve;
+    });
+    let calls = 0;
+    let active = 0;
+    let maxActive = 0;
+    let prefetched = false;
+    let firstFinished = false;
+    const reading = [];
+    const embed = model.doEmbed.bind(model);
+    model.doEmbed = async (contents) => {
+      calls++;
+      active++;
+      maxActive = Math.max(maxActive, active);
+      try {
+        if (calls === 1) {
+          await firstRequest;
+          firstFinished = true;
+        }
+        return await embed(contents);
+      } finally {
+        active--;
+      }
+    };
+    const service = await createZvecGrep({ root, embeddingModel: model });
+    t.after(() => service.close());
+    // Release even if prefetch regresses, so the test fails without hanging.
+    const timeout = setTimeout(releaseFirst, 2000);
+    let readingWhileBlocked;
+    let callsWhileBlocked;
+    try {
+      await service.index({
+        noPrefetch,
+        onProgress(progress) {
+          if (!progress.detail?.startsWith("reading ")) return;
+          reading.push(progress.detail);
+          if (reading.length === 2 && !firstFinished) {
+            prefetched = true;
+            // Let file preparation and scheduling proceed before checking the
+            // bound. A third read must wait for the first request to complete.
+            setTimeout(() => {
+              readingWhileBlocked = reading.length;
+              callsWhileBlocked = calls;
+              releaseFirst();
+            }, 50);
+          }
+        },
+      });
+    } finally {
+      clearTimeout(timeout);
+      releaseFirst();
+    }
+    assert.equal(prefetched, !noPrefetch);
+    if (!noPrefetch) {
+      assert.equal(readingWhileBlocked, 2);
+      assert.equal(callsWhileBlocked, 1);
+    }
+    assert.equal(maxActive, 1);
+    assert.equal(calls, 4);
+    assert.equal((await service.info()).status?.filesIndexed, 4);
+  });
+}
+
+for (const layout of ["multiple files", "single file", "many fragments"]) {
+  test(`service respects retrieval and request text budgets for ${layout}`, async (t) => {
+    const temporaryDirectory = await createTemporaryDirectory(
+      t,
+      "zvec-grep-text-budget-",
+    );
+    const root = join(temporaryDirectory, "repo");
+    await mkdir(root, { recursive: true });
+    const count = layout === "multiple files" ? 40 : 1;
+    const length =
+      layout === "multiple files"
+        ? 3200
+        : layout === "single file"
+          ? 90000
+          : 160000;
+    for (let index = 0; index < count; index++) {
+      await writeFile(
+        join(root, `file-${index}.md`),
+        `# Topic ${index}\n${"retrieval passage ".repeat(Math.ceil(length / 18)).slice(0, length)}`,
+      );
+    }
+    const model = new FakeEmbeddingModel();
+    model.info = {
+      ...model.info,
+      limits: { maxBatchSize: 32, maxBatchChars: 64000, maxInputTokens: 32768 },
+    };
+    const requests = [];
+    const embed = model.doEmbed.bind(model);
+    model.doEmbed = async (contents) => {
+      requests.push(contents.map((content) => content.text));
+      return embed(contents);
+    };
+    const service = await createZvecGrep({ root, embeddingModel: model });
+    t.after(() => service.close());
+    await service.index();
+    assert.ok(requests.length >= 2);
+    for (const request of requests) {
+      assert.ok(request.length <= 32);
+      assert.ok(request.reduce((sum, text) => sum + text.length, 0) <= 64000);
+      assert.ok(request.every((text) => text.length <= 3600));
+    }
+    assert.equal((await service.info()).status?.filesIndexed, count);
+    const before = requests.length;
+    await service.index();
+    assert.equal(
+      requests.length,
+      before,
+      "unchanged files are not re-embedded",
+    );
+  });
+}
+
 test("service exposes embedding model download progress while indexing", async (t) => {
   const temporaryDirectory = await createTemporaryDirectory(
     t,
@@ -624,6 +759,59 @@ test("service stops after bounded remote retries without a failed-file pass", as
   );
 });
 
+for (const configuredConcurrency of [undefined, 1]) {
+  test(`remote concurrency ${configuredConcurrency ?? "adaptive"} recovers from timeouts`, async (t) => {
+    const temporaryDirectory = await createTemporaryDirectory(
+      t,
+      "zvec-grep-timeout-backoff-",
+    );
+    const root = join(temporaryDirectory, "repo");
+    await mkdir(root, { recursive: true });
+    await writeFile(join(root, "example.ts"), "export const Example = 1;\n");
+    const model = new FakeEmbeddingModel();
+    model.info = {
+      ...model.info,
+      provider: "dgx",
+      defaultConcurrency: configuredConcurrency,
+    };
+    const embed = model.doEmbed.bind(model);
+    let calls = 0;
+    model.doEmbed = async (contents, options) => {
+      if (++calls <= 3) {
+        throw new EngineError(
+          "OpenAI-compatible text embedding request failed",
+          {
+            code: "ZVEC_GREP.ENGINE.MODELS.OPENAI_COMPATIBLE_TEXT_EMBEDDING_REQUEST_FAILED",
+            context: "timeoutMs=60000 retryAfterMs=0",
+            cause: new DOMException(
+              "The operation was aborted due to timeout",
+              "TimeoutError",
+            ),
+          },
+        );
+      }
+      options.onProgress?.({
+        stage: "warning",
+        model: model.info.reference,
+        message: "fixture recovered",
+      });
+      return embed(contents);
+    };
+    const service = await createZvecGrep({ root, embeddingModel: model });
+    t.after(() => service.close());
+    const progressEvents = [];
+    const result = await service.index({
+      onProgress: (progress) => progressEvents.push(progress),
+    });
+    assert.equal(result.filesFailed, 0);
+    assert.equal(calls, 4);
+    assert.ok(
+      progressEvents.some((progress) => progress.embedding?.concurrency === 1),
+      JSON.stringify(progressEvents),
+    );
+  });
+}
+
 test("service retries bounded remote HTTP and network failures before recovery", async (t) => {
   const fixtures = [
     {
@@ -938,6 +1126,16 @@ test("workspace rebuild recreates unsupported index metadata", async (t) => {
     (error) =>
       error.code === "ZVEC_GREP.ENGINE.WORKSPACE_INDEX.VERSION_MISMATCH" &&
       error.context.includes("zg --index --rebuild"),
+  );
+
+  await assert.rejects(
+    service.index(),
+    (error) =>
+      error.code === "ZVEC_GREP.ENGINE.WORKSPACE_INDEX.VERSION_MISMATCH",
+  );
+  assert.equal(
+    JSON.parse(await readFile(manifestPath, "utf8")).indexVersion,
+    999,
   );
 
   await service.index({ rebuild: true });

--- a/test/unit/core.test.mjs
+++ b/test/unit/core.test.mjs
@@ -26,6 +26,7 @@ import {
 import { makeEntityId } from "../../dist/engine/extraction/ids.js";
 import { detectFileType } from "../../dist/engine/file-type.js";
 import {
+  findEmbeddingModelCatalogEntry,
   getEmbeddingModelCatalogEntry,
   listEmbeddingModels,
 } from "../../dist/engine/models/catalog.js";
@@ -705,6 +706,10 @@ test("file, model, content, and entity helpers classify inputs", () => {
   assert.equal(
     getEmbeddingModelCatalogEntry("local/qwen3-embedding-0.6b")?.reference,
     "local/qwen3-embedding-0.6b",
+  );
+  assert.equal(
+    findEmbeddingModelCatalogEntry("dgx", "qwen3-embedding:0.6b")?.reference,
+    "dgx/qwen3-embedding-0.6b",
   );
   assert.equal(
     getEmbeddingModelCatalogEntry("local/bge-small-en-v1.5")?.backend,

--- a/test/unit/core.test.mjs
+++ b/test/unit/core.test.mjs
@@ -692,7 +692,7 @@ test("file, model, content, and entity helpers classify inputs", () => {
   });
   assert.equal(detectFileType("archive.zip"), null);
   assert.deepEqual(detectFileType("NOTICE"), { kind: "text", format: "text" });
-  assert.equal(listEmbeddingModels().length, 14);
+  assert.equal(listEmbeddingModels().length, 15);
   assert.equal(
     getEmbeddingModelCatalogEntry("local/embeddinggemma-300m")?.dimension,
     768,

--- a/test/unit/index-input-budget.test.mjs
+++ b/test/unit/index-input-budget.test.mjs
@@ -3,27 +3,27 @@ import test from "node:test";
 import { indexChunkOptions } from "../../dist/engine/pipeline/indexing/input-budget.js";
 import { vectorContentForFragment } from "../../dist/engine/extraction/vector-content.js";
 
-test("uses the default input estimate for ordinary text", () => {
+test("caps ordinary text at retrieval passage size", () => {
   assert.deepEqual(
     indexChunkOptions(128_000, "ordinary text ".repeat(20_000)),
     {
-      maxChunkChars: 236_800,
-      chunkOverlapChars: 35_520,
+      maxChunkChars: 3600,
+      chunkOverlapChars: 540,
     },
   );
 });
 
-test("uses the conservative input estimate for token-dense text", () => {
+test("caps token-dense text at retrieval passage size", () => {
   assert.deepEqual(indexChunkOptions(128_000, "<123-456>".repeat(30_000)), {
-    maxChunkChars: 128_000,
-    chunkOverlapChars: 19_200,
+    maxChunkChars: 3600,
+    chunkOverlapChars: 540,
   });
 });
 
 test("detects a localized token-dense region", () => {
   const text = `${"ordinary text ".repeat(12_000)}${"<123-456>".repeat(2_000)}`;
 
-  assert.equal(indexChunkOptions(100_000, text).maxChunkChars, 100_000);
+  assert.equal(indexChunkOptions(1024, text).maxChunkChars, 1024);
 });
 
 test("omits input limits when the model does not declare one", () => {
@@ -55,4 +55,15 @@ test("embedding content construction does not reject estimated character overflo
     vectorContentForFragment(fragment, embeddingContent, 32).text.length,
     256,
   );
+});
+
+test("respects smaller model input ceilings", () => {
+  assert.deepEqual(indexChunkOptions(1024, "ordinary text"), {
+    maxChunkChars: 1894,
+    chunkOverlapChars: 284,
+  });
+  assert.deepEqual(indexChunkOptions(1024, "<123-456>".repeat(3000)), {
+    maxChunkChars: 1024,
+    chunkOverlapChars: 153,
+  });
 });

--- a/test/unit/models/factory.test.mjs
+++ b/test/unit/models/factory.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { LlamaCppEmbeddingModel } from "../../../dist/engine/models/backends/llama-cpp.js";
 import { Model2VecEmbeddingModel } from "../../../dist/engine/models/backends/model2vec.js";
+import { OpenAiCompatibleTextEmbeddingModel } from "../../../dist/engine/models/backends/openai-compatible.js";
 import {
   Qwen37TextEmbeddingModel,
   Qwen3VlEmbeddingModel,
@@ -19,6 +20,7 @@ test("embedding factory resolves catalog entries and rejects unknown models", ()
     ["qwen/text-embedding-v4", QwenTextEmbeddingV4Model],
     ["qwen/qwen3.7-text-embedding", Qwen37TextEmbeddingModel],
     ["qwen/qwen3-vl-embedding", Qwen3VlEmbeddingModel],
+    ["dgx/qwen3-embedding-0.6b", OpenAiCompatibleTextEmbeddingModel],
     ["local/bge-small-en-v1.5", TransformersJsEmbeddingModel],
     ["local/all-minilm-l6-v2", TransformersJsEmbeddingModel],
     ["local/potion-retrieval-32m", Model2VecEmbeddingModel],
@@ -49,7 +51,9 @@ test("embedding factory resolves catalog entries and rejects unknown models", ()
     assert.equal(model.info.metric, entry.metric);
     assert.equal(
       model.info.endpoint,
-      entry.backend === "qwen" ? options.endpoint : undefined,
+      entry.backend === "qwen" || entry.backend === "openai-compatible"
+        ? options.endpoint
+        : undefined,
     );
   }
 

--- a/test/unit/models/openai-compatible.test.mjs
+++ b/test/unit/models/openai-compatible.test.mjs
@@ -1,0 +1,146 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { OpenAiCompatibleTextEmbeddingModel } from "../../../dist/engine/models/backends/openai-compatible.js";
+
+const entry = {
+  reference: "dgx/qwen3-embedding-0.6b",
+  provider: "dgx",
+  model: "qwen3-embedding:0.6b",
+  dimension: 3,
+  metric: "cosine",
+  maxBatchSize: 256,
+  maxInputTokens: 8192,
+};
+
+const vector = (value = 0.25) => Array(entry.dimension).fill(value);
+
+function jsonResponse(body, init = {}) {
+  return new Response(JSON.stringify(body), {
+    status: init.status ?? 200,
+    headers: { "content-type": "application/json", ...init.headers },
+  });
+}
+
+test("generic OpenAI-compatible model sends the minimal DGX request and restores response order", async () => {
+  let request;
+  const model = new OpenAiCompatibleTextEmbeddingModel(
+    entry,
+    { endpoint: " http://spark:11434/v1/embeddings " },
+    undefined,
+    {
+      async fetch(url, init) {
+        request = { url, init, body: JSON.parse(init.body) };
+        if ("dimensions" in request.body || "encoding_format" in request.body) {
+          return jsonResponse(
+            { error: { message: "unsupported optional field" } },
+            { status: 400 },
+          );
+        }
+        return jsonResponse({
+          data: [
+            { index: 1, embedding: vector(2) },
+            { index: 0, embedding: vector(1) },
+          ],
+        });
+      },
+    },
+  );
+
+  const result = await model.embed([
+    { kind: "text", text: "first" },
+    { kind: "text", text: "second" },
+  ]);
+
+  assert.equal(request.url, "http://spark:11434/v1/embeddings");
+  assert.deepEqual(request.body, {
+    model: "qwen3-embedding:0.6b",
+    input: ["first", "second"],
+  });
+  assert.equal(request.init.headers.Authorization, undefined);
+  assert.equal(request.init.headers["Content-Type"], "application/json");
+  assert.deepEqual(result.vectors, [vector(1), vector(2)]);
+});
+
+test("generic OpenAI-compatible model sends declared optional request fields and credentials", async () => {
+  let request;
+  const model = new OpenAiCompatibleTextEmbeddingModel(
+    {
+      ...entry,
+      requestDimensions: true,
+      requestEncodingFormat: true,
+    },
+    { endpoint: "https://example.test/embeddings", apiKey: "secret" },
+    undefined,
+    {
+      async fetch(_url, init) {
+        request = init;
+        return jsonResponse({ data: [{ index: 0, embedding: vector() }] });
+      },
+    },
+  );
+
+  await model.embed([{ kind: "text", text: "value" }]);
+
+  assert.equal(request.headers.Authorization, "Bearer secret");
+  assert.deepEqual(JSON.parse(request.body), {
+    model: "qwen3-embedding:0.6b",
+    input: ["value"],
+    dimensions: 3,
+    encoding_format: "float",
+  });
+});
+
+test("generic OpenAI-compatible model validates endpoint and indexed response shape", async () => {
+  assert.throws(
+    () => new OpenAiCompatibleTextEmbeddingModel(entry, {}),
+    /requires an endpoint/,
+  );
+
+  async function rejectsResponse(body, expected) {
+    const model = new OpenAiCompatibleTextEmbeddingModel(
+      entry,
+      { endpoint: "https://example.test/embeddings" },
+      undefined,
+      { fetch: async () => jsonResponse(body) },
+    );
+    await assert.rejects(
+      model.embed([
+        { kind: "text", text: "first" },
+        { kind: "text", text: "second" },
+      ]),
+      expected,
+    );
+  }
+
+  await rejectsResponse(
+    {
+      data: [
+        { index: 0, embedding: vector() },
+        { index: 0, embedding: vector() },
+      ],
+    },
+    /duplicate index/,
+  );
+  await rejectsResponse(
+    { data: [{ index: 0, embedding: vector() }] },
+    /non-array vector/,
+  );
+  await rejectsResponse(
+    {
+      data: [
+        { index: 0, embedding: [1, 2] },
+        { index: 1, embedding: vector() },
+      ],
+    },
+    /wrong dimension/,
+  );
+  await rejectsResponse(
+    {
+      data: [
+        { index: 0, embedding: [1, Number.NaN, 3] },
+        { index: 1, embedding: vector() },
+      ],
+    },
+    /non-finite vector value/,
+  );
+});

--- a/test/unit/models/openai-compatible.test.mjs
+++ b/test/unit/models/openai-compatible.test.mjs
@@ -8,7 +8,8 @@ const entry = {
   model: "qwen3-embedding:0.6b",
   dimension: 3,
   metric: "cosine",
-  maxBatchSize: 256,
+  maxBatchSize: 32,
+  maxBatchChars: 64000,
   maxInputTokens: 8192,
 };
 
@@ -52,6 +53,7 @@ test("generic OpenAI-compatible model sends the minimal DGX request and restores
   ]);
 
   assert.equal(request.url, "http://spark:11434/v1/embeddings");
+  assert.equal(model.info.limits.maxBatchChars, 64000);
   assert.deepEqual(request.body, {
     model: "qwen3-embedding:0.6b",
     input: ["first", "second"],
@@ -143,4 +145,30 @@ test("generic OpenAI-compatible model validates endpoint and indexed response sh
     },
     /non-finite vector value/,
   );
+});
+
+test("DGX allows slow inference while hosted models keep their timeout", async (t) => {
+  const timeouts = [];
+  t.mock.method(AbortSignal, "timeout", (ms) => {
+    timeouts.push(ms);
+    return new AbortController().signal;
+  });
+  for (const provider of ["dgx", "qwen"]) {
+    const model = new OpenAiCompatibleTextEmbeddingModel(
+      { ...entry, provider },
+      { endpoint: "http://example.test/embeddings" },
+      undefined,
+      {
+        async fetch() {
+          return jsonResponse({ data: [{ index: 0, embedding: vector() }] });
+        },
+      },
+    );
+    assert.equal(
+      model.info.defaultConcurrency,
+      provider === "dgx" ? 1 : undefined,
+    );
+    await model.embed([{ kind: "text", text: "value" }]);
+  }
+  assert.deepEqual(timeouts, [1_800_000, 60_000]);
 });


### PR DESCRIPTION
Self-hosted OpenAI-compatible embedding services can use their own endpoint and authentication settings without impersonating Qwen. DGX indexing also bounds the work sent to Ollama: the observed multi-megabyte requests left file progress unchanged for minutes; indexing now uses focused retrieval passages and smaller requests. The user completed the Phandalin indexing run after these changes and reported the fastest progress of the experiments.

Closes #120.

## Provider support

- Reuse the OpenAI-compatible text transport while preserving Qwen's required credentials and optional request fields.
- Register `dgx/qwen3-embedding-0.6b`, serving `qwen3-embedding:0.6b` with 1,024-dimensional vectors. Send only the required `model` and `input` fields to Ollama.
- Support configured Bearer credentials or explicit `auth: none`; retain remote-data authorization and endpoint/vector-space compatibility checks.
- Resolve persisted served-model identities back to catalog references on reload.

## Indexing behavior

- Cap retrieval passages at 3,600 characters with a 15% overlap target, respecting smaller model input limits and sharing the budget with heading/symbol metadata. This retrieval policy applies across providers.
- Cap DGX requests at 32 fragments and 64,000 total text characters, including metadata, for both multi-file batches and fragments of one large file. The character budget is not an exact token or wire-byte limit.
- Default DGX to one in-flight request with a 30-minute request/response deadline. Explicit concurrency can back off to one after transient failures; hosted providers retain their 60-second deadline.
- Prepare the next batch while current embedding tasks are pending, with bounded backpressure. Add `--no-prefetch` for direct and server indexing comparisons; `--embedding-concurrency` still controls request concurrency.
- Make explicit index roots target their own workspace, including nested repositories previously discovered as aliases of a parent index.

## Migration

Index version 2 requires existing indexes to be explicitly rebuilt so old large chunks are not mixed with new passages. Ordinary indexing rejects the old version without rewriting its manifest. After restarting a running daemon, use:

```bash
zg --index --allow-remote --rebuild .
```

Subsequent runs can resume incrementally. `--no-prefetch` and `--embedding-concurrency 2` remain available for experiments.

## Validation

- Build, typecheck, lint, formatting, and whitespace checks passed.
- `npm run test:run:unit`: 214 passed, one skipped, zero failures.
- Targeted extraction, input-budget, catalog, OpenAI-compatible backend, CLI option, service integration, and path-indexing tests passed. Tests cover character limits across files and within large files, serial requests with prefetch enabled/disabled, retries, unchanged-file reuse, and explicit version migration.
- The combined service/path/daemon run passed 60 of 70 tests. Ten daemon tests failed because their `test/deterministic` fake model is treated as remote without an endpoint. Representative search-authorization and watcher failures reproduce on unchanged HEAD `d2ecfd4`; they are not attributed to the new chunking policy.
- Manual validation: the user reported that the full Phandalin indexing job completed after applying the smaller passage and request budgets. No controlled wall-clock benchmark or retrieval-quality comparison was collected.
