### PR TITLE
fix(watcher): preserve failed flush paths during reconciliation merge

### DIFF
--- a/src/daemon/change-set.ts
+++ b/src/daemon/change-set.ts
@@ -61,9 +61,6 @@ export class ChangeSet {
   }
 
   merge(other: ChangeSetSnapshot): void {
-    if (this.forceFullReconcile && this.size > 0) {
-      return;
-    }
     for (const path of other.touchedFiles) this.touchedFiles.add(path);
     for (const path of other.rescanDirectories)
       this.rescanDirectories.add(path);

--- a/test/change-set.test.mjs
+++ b/test/change-set.test.mjs
@@ -99,3 +99,28 @@ test("change set retains a path after an explicit full reconciliation request", 
     forceFullReconcile: true,
   });
 });
+
+test("change set merge preserves failed flush paths during reconciliation", () => {
+  const root = join(tmpdir(), "change-set-merge-recovery");
+  const changes = new ChangeSet();
+  changes.requireFullReconcile();
+  changes.add(join(root, "during-reconcile.ts"), "changed");
+
+  changes.merge({
+    touchedFiles: [join(root, "failed-a.ts"), join(root, "failed-b.ts")],
+    rescanDirectories: [join(root, "failed-dir")],
+    deletedPrefixes: [join(root, "removed.ts")],
+    forceFullReconcile: true,
+  });
+
+  assert.deepEqual(changes.snapshot(), {
+    touchedFiles: [
+      join(root, "during-reconcile.ts"),
+      join(root, "failed-a.ts"),
+      join(root, "failed-b.ts"),
+    ].sort(),
+    rescanDirectories: [join(root, "failed-dir")],
+    deletedPrefixes: [join(root, "removed.ts")],
+    forceFullReconcile: true,
+  });
+});


### PR DESCRIPTION
## Summary

- Remove the `ChangeSet.merge()` early-return so a recovery merge always unions path sets.
- Keep `forceFullReconcile` propagation via `||=`.
- Add a regression test for the flush-recovery merge shape used by `WatchManager.flush()`.

## Problem / scope (updated)

`WatchManager.flush()` recovers a failed `onChanges()` callback by merging the failed snapshot back with `forceFullReconcile: true`. If the live set already had `forceFullReconcile` and `size > 0`, `merge()` returned early and dropped the incoming path entries.

After discussion on #141: that drop does **not** by itself imply durable missed indexing or a premature `wait_for_fresh`, because the retry still carries `forceFullReconcile` and the backend submits with `changedPaths: undefined` (full reconcile). The remaining rationale is defensive correctness: a recovery `merge()` should restore the snapshot it was given rather than silently no-op.

Also note: the flush catch covers callback submission failure, not an awaited indexing-job failure.

## Test plan

- [x] `node --test test/change-set.test.mjs --test-name-pattern="failed flush"`
- [x] `npm run test:run:unit`
- [x] `npm run lint`

Fixes #141
