### PR TITLE
fix(status): probe index storage before reporting ready

### DIFF
--- a/src/cli/format/status.ts
+++ b/src/cli/format/status.ts
@@ -16,6 +16,7 @@ import {
   indexCompletionFromStatus,
   indexStatusNeedsRefresh as statusNeedsRefresh,
 } from "../../engine/index-status.js";
+import { isWorkspaceIndexed } from "../../engine/service/workspace-index.js";
 import { redactErrorText } from "../../engine/errors.js";
 
 type StatusTheme = {
@@ -105,6 +106,7 @@ type ServerIndexInfo = {
         dimension: number;
         metric: string;
       } | null;
+      index_version?: number | null;
     };
     files?: {
       stored: number;
@@ -255,6 +257,7 @@ export function printWorkspaceInfo(
     failedReasons: status
       ? summarizeFailedFileReasons(status.failedFiles, "zg --index")
       : undefined,
+    error: info.error,
   });
   return state;
 }
@@ -542,6 +545,13 @@ function serverIndexState(info: ServerIndexInfo): WorkspaceIndexState {
     return "stale";
   }
   if (info.indexed) return "ready";
+  if (
+    info.persistent.workspace_index?.embedding &&
+    info.persistent.workspace_index?.index_version !== null &&
+    info.persistent.workspace_index?.index_version !== undefined
+  ) {
+    return "failed";
+  }
   return info.index_policy === "undecided" ? "undecided" : "unindexed";
 }
 
@@ -633,8 +643,12 @@ function workspaceState(
     return "undecided";
   }
 
+  if (info.error) {
+    return "failed";
+  }
+
   if (!info.indexed) {
-    return "unindexed";
+    return isWorkspaceIndexed(info.workspaceIndex) ? "failed" : "unindexed";
   }
 
   if (info.status?.filesFailed && info.status.filesFailed > 0) {

--- a/src/daemon/backend.ts
+++ b/src/daemon/backend.ts
@@ -639,22 +639,23 @@ export class DaemonBackend implements ZvecGrepDaemonBackend {
       indexPolicy: info.indexPolicy,
       source: info.source,
       persistent: persistentStatus(info),
-      runtime: runtimeSnapshot
-        ? {
-            watcherActive: runtimeSnapshot.watcherActive,
-            dirtyRevision: runtimeSnapshot.dirtyRevision,
-            indexedRevision: runtimeSnapshot.indexedRevision,
-            activeJobId: job?.id,
-            jobState: job?.state,
-            progress: job?.progress ? formatProgress(job) : undefined,
-            completion: indexCompletionForJob(
-              indexCompletionFromStatus(info.status),
-              job?.state,
-              job?.progress,
-            ),
-            error: job?.error,
-          }
-        : undefined,
+      runtime:
+        runtimeSnapshot || info.error
+          ? {
+              watcherActive: runtimeSnapshot?.watcherActive ?? false,
+              dirtyRevision: runtimeSnapshot?.dirtyRevision ?? 0,
+              indexedRevision: runtimeSnapshot?.indexedRevision ?? 0,
+              activeJobId: job?.id,
+              jobState: job?.state ?? (info.error ? "failed" : undefined),
+              progress: job?.progress ? formatProgress(job) : undefined,
+              completion: indexCompletionForJob(
+                indexCompletionFromStatus(info.status),
+                job?.state,
+                job?.progress,
+              ),
+              error: job?.error ?? info.error,
+            }
+          : undefined,
     };
   }
 

--- a/src/engine/service/types.ts
+++ b/src/engine/service/types.ts
@@ -75,6 +75,12 @@ export type ZvecGrepInfoResult = {
   workspaceIndex?: WorkspaceIndexInfo;
   status?: WorkspaceIndexStatus | null;
   suggestion?: string;
+  error?: {
+    code: string;
+    message: string;
+    context?: string;
+    cause?: string;
+  };
 };
 
 export type ZvecGrepContextRoute = SearchPlanRoute;

--- a/src/engine/service/zvec-grep.ts
+++ b/src/engine/service/zvec-grep.ts
@@ -15,6 +15,7 @@ import {
   detail,
   EngineError,
   errorDetails,
+  isEngineError,
 } from "../errors.js";
 import {
   createEmbeddingModel,
@@ -27,6 +28,7 @@ import {
 import type {
   WorkspaceIndexEmbeddingSchema,
   WorkspaceIndexInfo,
+  WorkspaceIndexStatus,
   Content,
   FileInfo,
   IndexResult,
@@ -45,6 +47,7 @@ import {
   writeWorkspaceManifest,
 } from "../manifest.js";
 import { validateRootPaths } from "../pipeline/indexing/root-paths.js";
+import { probeWorkspaceIndexStorage } from "../storage/index.js";
 import {
   findNearestWorkspace,
   hasWorkspaceIndex,
@@ -465,11 +468,43 @@ class ZvecGrepService implements ZvecGrep {
 
     return await withHomeReadLock(nearest.location.home, "info", async () => {
       const workspaceIndex = readWorkspaceManifest(nearest.location.home);
-      const indexed =
+      const isConfiguredIndexed =
         workspaceIndex !== null &&
         workspaceIndex.indexPolicy !== "disabled" &&
-        isWorkspaceIndexed(workspaceIndex) &&
-        hasWorkspaceIndex(nearest.location);
+        isWorkspaceIndexed(workspaceIndex);
+
+      let storageError: unknown = null;
+      if (isConfiguredIndexed) {
+        try {
+          probeWorkspaceIndexStorage(nearest.location.home);
+        } catch (error) {
+          storageError = error;
+        }
+      }
+
+      const indexed = isConfiguredIndexed && storageError === null;
+      let status: WorkspaceIndexStatus | null = null;
+      if (indexed && workspaceIndex && options.includeStatus !== false) {
+        status = await workspaceIndexStatus(workspaceIndex, nearest.location);
+      }
+
+      let errorInfo: ZvecGrepInfoResult["error"];
+      if (storageError) {
+        if (isEngineError(storageError)) {
+          errorInfo = {
+            code: storageError.code,
+            message: storageError.message,
+            context: storageError.context,
+            cause: storageError.cause ? String(storageError.cause) : undefined,
+          };
+        } else if (storageError instanceof Error) {
+          errorInfo = {
+            code: "ZVEC_GREP.ENGINE.STORAGE.ZVEC_OPEN_FAILED",
+            message: storageError.message,
+            cause: storageError.cause ? String(storageError.cause) : undefined,
+          };
+        }
+      }
 
       return {
         root: nearest.location.root,
@@ -481,11 +516,9 @@ class ZvecGrepService implements ZvecGrep {
         workspaceIndex: workspaceIndex
           ? workspaceIndexInfoFromManifest(workspaceIndex)
           : undefined,
-        status:
-          indexed && options.includeStatus !== false
-            ? await workspaceIndexStatus(workspaceIndex, nearest.location)
-            : null,
-        suggestion: workspaceInfoSuggestion(workspaceIndex),
+        status,
+        suggestion: workspaceInfoSuggestion(workspaceIndex, storageError),
+        error: errorInfo,
       };
     });
   }
@@ -1122,7 +1155,12 @@ function findNearestWorkspaceIndex(start: string): WorkspaceIndexRecord | null {
 
 function workspaceInfoSuggestion(
   workspaceIndex: WorkspaceIndexInfo | null,
+  storageError?: unknown,
 ): string | undefined {
+  if (storageError) {
+    return "re-run zg index (or zg index --rebuild) to rebuild the index";
+  }
+
   if (!workspaceIndex) {
     return "zg --index or zg --rg";
   }

--- a/src/engine/storage/index.ts
+++ b/src/engine/storage/index.ts
@@ -77,7 +77,10 @@ export interface WorkspaceIndexStorage {
   close(): void;
 }
 
-export { createWorkspaceIndexStorage } from "./zvec.js";
+export {
+  createWorkspaceIndexStorage,
+  probeWorkspaceIndexStorage,
+} from "./zvec.js";
 export {
   deleteWorkspaceIndexStorage,
   hasWorkspaceIndexStorage,

--- a/src/engine/storage/zvec.ts
+++ b/src/engine/storage/zvec.ts
@@ -79,6 +79,37 @@ const ZVEC_OPEN_RETRY_MAX_DELAY_MS = 1000;
 
 let zvecInitialized = false;
 
+export function probeWorkspaceIndexStorage(storagePath: string): void {
+  const paths = resolveWorkspaceIndexStoragePaths(storagePath);
+  initializeZvec();
+
+  if (!existsSync(paths.filesPath)) {
+    throw new EngineError("zvec file metadata storage does not exist", {
+      code: "ZVEC_GREP.ENGINE.STORAGE.ZVEC_FILE_META_MISSING",
+      context: `path=${paths.filesPath}`,
+    });
+  }
+
+  if (!existsSync(paths.indexPath)) {
+    throw new EngineError("zvec collection storage does not exist", {
+      code: "ZVEC_GREP.ENGINE.STORAGE.ZVEC_COLLECTION_MISSING",
+      context: `path=${paths.indexPath}`,
+    });
+  }
+
+  const files = openZvecCollection(paths.filesPath, true, "open", () =>
+    ZVecOpen(paths.filesPath, { readOnly: true }),
+  );
+  try {
+    const index = openZvecCollection(paths.indexPath, true, "open", () =>
+      ZVecOpen(paths.indexPath, { readOnly: true }),
+    );
+    index.closeSync();
+  } finally {
+    files.closeSync();
+  }
+}
+
 export function createWorkspaceIndexStorage(
   options: WorkspaceIndexStorageOptions,
 ): WorkspaceIndexStorage {

--- a/test/integration/service.test.mjs
+++ b/test/integration/service.test.mjs
@@ -8,7 +8,7 @@ import { resolveModelArtifacts } from "../../dist/engine/models/artifact-downloa
 import { Model2VecEmbeddingModel } from "../../dist/engine/models/backends/model2vec.js";
 import { CURRENT_INDEX_VERSION } from "../../dist/engine/types.js";
 import { createZvecGrep } from "../../dist/index.js";
-import { createTemporaryDirectory } from "../helpers/fixtures.mjs";
+import { createTemporaryDirectory, runCli } from "../helpers/fixtures.mjs";
 import { FakeEmbeddingModel } from "../helpers/fake-embedding.mjs";
 
 class SelectivelyFailingEmbeddingModel extends FakeEmbeddingModel {
@@ -952,6 +952,116 @@ test("workspace rebuild recreates unsupported index metadata", async (t) => {
     autoUpdate: false,
   });
   assert.ok(result.items.length > 0);
+});
+
+test("workspace status reports failed and unready when storage is missing or unopenable, and --check-ready fails", async (t) => {
+  const temporaryDirectory = await createTemporaryDirectory(
+    t,
+    "zvec-grep-storage-probe-",
+  );
+  const root = join(temporaryDirectory, "repo");
+  const home = join(temporaryDirectory, "home");
+  await mkdir(root, { recursive: true });
+  await writeFile(join(root, "file.ts"), "export const ProbeNeedle = 1;\n");
+
+  let service = await createZvecGrep({
+    root,
+    home,
+    embeddingModel: new FakeEmbeddingModel(),
+  });
+  t.after(async () => {
+    await service.close();
+  });
+  await service.index();
+  await service.close();
+
+  // Case 1: manifest present but files.zvec missing
+  const filesPath = join(root, ".zvec-grep", "files.zvec");
+  await rm(filesPath, { recursive: true, force: true });
+
+  service = await createZvecGrep({
+    root,
+    home,
+    embeddingModel: new FakeEmbeddingModel(),
+  });
+  const infoMissingFiles = await service.info();
+  assert.equal(infoMissingFiles.indexed, false);
+  assert.equal(
+    infoMissingFiles.error?.code,
+    "ZVEC_GREP.ENGINE.STORAGE.ZVEC_FILE_META_MISSING",
+  );
+  assert.equal(
+    infoMissingFiles.suggestion,
+    "re-run zg index (or zg index --rebuild) to rebuild the index",
+  );
+
+  const statusMissingFiles = await runCli(
+    ["--status", root, "--mode", "direct"],
+    { cwd: root },
+  );
+  assert.match(statusMissingFiles.stdout, /✗ Workspace index failed/);
+  assert.match(
+    statusMissingFiles.stdout,
+    /ZVEC_GREP\.ENGINE\.STORAGE\.ZVEC_FILE_META_MISSING/,
+  );
+  assert.match(
+    statusMissingFiles.stdout,
+    /re-run zg index \(or zg index --rebuild\) to rebuild the index/,
+  );
+
+  await assert.rejects(
+    runCli(["--status", root, "--mode", "direct", "--check-ready"], {
+      cwd: root,
+    }),
+    (error) => {
+      assert.match(
+        error.stderr,
+        /Workspace index is not ready \(state: failed\)/,
+      );
+      return true;
+    },
+  );
+
+  // Case 2: files.zvec present but unopenable (empty folder without LOCK / valid schema)
+  await mkdir(filesPath, { recursive: true });
+
+  const infoUnopenable = await service.info();
+  assert.equal(infoUnopenable.indexed, false);
+  assert.equal(
+    infoUnopenable.error?.code,
+    "ZVEC_GREP.ENGINE.STORAGE.ZVEC_OPEN_FAILED",
+  );
+  assert.equal(
+    infoUnopenable.suggestion,
+    "re-run zg index (or zg index --rebuild) to rebuild the index",
+  );
+
+  const statusUnopenable = await runCli(
+    ["--status", root, "--mode", "direct"],
+    { cwd: root },
+  );
+  assert.match(statusUnopenable.stdout, /✗ Workspace index failed/);
+  assert.match(
+    statusUnopenable.stdout,
+    /ZVEC_GREP\.ENGINE\.STORAGE\.ZVEC_OPEN_FAILED/,
+  );
+  assert.match(
+    statusUnopenable.stdout,
+    /re-run zg index \(or zg index --rebuild\) to rebuild the index/,
+  );
+
+  await assert.rejects(
+    runCli(["--status", root, "--mode", "direct", "--check-ready"], {
+      cwd: root,
+    }),
+    (error) => {
+      assert.match(
+        error.stderr,
+        /Workspace index is not ready \(state: failed\)/,
+      );
+      return true;
+    },
+  );
 });
 
 test("service records failed files, retries them, deletes stale records, and rebuilds", async (t) => {

--- a/test/unit/cli-format.test.mjs
+++ b/test/unit/cli-format.test.mjs
@@ -1858,3 +1858,106 @@ test("progress reporter covers TTY and non-TTY phases, counters, truncation, and
   assert.doesNotMatch(ttyText, /a long progress detail/);
   assert.match(ttyText, /\n\x1b\[\?25h$/);
 });
+
+test("workspace status formatters report failed state with error and rebuild suggestion on storage probe failure", async () => {
+  const directOutput = await captureConsole(() => {
+    const state = printWorkspaceInfo(
+      {
+        root: "/repo",
+        indexed: false,
+        indexPolicy: "enabled",
+        source: "unindexed",
+        home: "/repo/.zvec-grep",
+        indexPath: "/repo/.zvec-grep/index.zvec",
+        workspaceIndex: {
+          id: "repo",
+          name: "repo",
+          path: "/repo/.zvec-grep",
+          rootPaths: [{ absolutePath: "/repo", recursive: true }],
+          indexPolicy: "enabled",
+          embedding: {
+            provider: "local",
+            model: "test",
+            dimension: 16,
+            metric: "cosine",
+          },
+          indexVersion: 1,
+          createdTime: 1,
+          updatedTime: 1,
+        },
+        status: null,
+        suggestion:
+          "re-run zg index (or zg index --rebuild) to rebuild the index",
+        error: {
+          code: "ZVEC_GREP.ENGINE.STORAGE.ZVEC_FILE_META_MISSING",
+          message: "zvec file metadata storage does not exist",
+          context: "path=/repo/.zvec-grep/files.zvec",
+        },
+      },
+      { color: "never" },
+    );
+    assert.equal(state, "failed");
+  });
+
+  const directText = directOutput.logs.join("\n");
+  assert.match(directText, /✗ Workspace index failed/);
+  assert.match(
+    directText,
+    /ZVEC_GREP\.ENGINE\.STORAGE\.ZVEC_FILE_META_MISSING/,
+  );
+  assert.match(directText, /zvec file metadata storage does not exist/);
+  assert.match(
+    directText,
+    /Next\s+re-run zg index \(or zg index --rebuild\) to rebuild the index/,
+  );
+
+  const serverOutput = await captureConsole(() => {
+    const state = printServerIndexInfo(
+      {
+        root: "/repo",
+        indexed: false,
+        index_policy: "enabled",
+        source: "unindexed",
+        persistent: {
+          home: "/repo/.zvec-grep",
+          index_path: "/repo/.zvec-grep/index.zvec",
+          workspace_index: {
+            root_paths: [{ absolute_path: "/repo", recursive: true }],
+            embedding: {
+              provider: "local",
+              model: "test",
+              dimension: 16,
+              metric: "cosine",
+            },
+            index_version: 1,
+          },
+          suggestion:
+            "re-run zg index (or zg index --rebuild) to rebuild the index",
+        },
+        runtime: {
+          watcher_active: false,
+          dirty_revision: 0,
+          indexed_revision: 0,
+          job_state: "failed",
+          error: {
+            code: "ZVEC_GREP.ENGINE.STORAGE.ZVEC_FILE_META_MISSING",
+            message: "zvec file metadata storage does not exist",
+          },
+        },
+      },
+      { color: "never" },
+    );
+    assert.equal(state, "failed");
+  });
+
+  const serverText = serverOutput.logs.join("\n");
+  assert.match(serverText, /✗ Workspace index failed/);
+  assert.match(
+    serverText,
+    /ZVEC_GREP\.ENGINE\.STORAGE\.ZVEC_FILE_META_MISSING/,
+  );
+  assert.match(
+    serverText,
+    /Next\s+re-run zg index \(or zg index --rebuild\) to rebuild the index/,
+  );
+});

--- a/test/unit/zvec-storage.test.mjs
+++ b/test/unit/zvec-storage.test.mjs
@@ -8,7 +8,10 @@ import {
   ZVecCreateAndOpen,
   ZVecDataType,
 } from "@zvec/zvec";
-import { createWorkspaceIndexStorage } from "../../dist/engine/storage/index.js";
+import {
+  createWorkspaceIndexStorage,
+  probeWorkspaceIndexStorage,
+} from "../../dist/engine/storage/index.js";
 import { queryFileMetadataDocs } from "../../dist/engine/storage/zvec.js";
 
 function doc(id) {
@@ -152,3 +155,87 @@ function fileInfo(id, root, relativePath) {
     format: relativePath.endsWith(".md") ? "markdown" : "typescript",
   };
 }
+
+test("probeWorkspaceIndexStorage detects missing files.zvec storage", async (t) => {
+  const parent = await mkdtemp(
+    join(tmpdir(), "zvec-grep-probe-missing-files-"),
+  );
+  t.after(async () => {
+    await rm(parent, { recursive: true, force: true });
+  });
+
+  assert.throws(
+    () => probeWorkspaceIndexStorage(parent),
+    (error) =>
+      error.code === "ZVEC_GREP.ENGINE.STORAGE.ZVEC_FILE_META_MISSING" &&
+      error.context.includes("files.zvec"),
+  );
+});
+
+test("probeWorkspaceIndexStorage detects missing index.zvec collection", async (t) => {
+  const parent = await mkdtemp(
+    join(tmpdir(), "zvec-grep-probe-missing-index-"),
+  );
+  t.after(async () => {
+    await rm(parent, { recursive: true, force: true });
+  });
+
+  // Create valid files.zvec but leave index.zvec missing
+  const storage = createWorkspaceIndexStorage({
+    storagePath: parent,
+    readOnly: false,
+    embedding: {
+      provider: "local",
+      model: "test",
+      dimension: 2,
+      metric: "cosine",
+    },
+  });
+  storage.close();
+  await rm(join(parent, "index.zvec"), { recursive: true, force: true });
+
+  assert.throws(
+    () => probeWorkspaceIndexStorage(parent),
+    (error) =>
+      error.code === "ZVEC_GREP.ENGINE.STORAGE.ZVEC_COLLECTION_MISSING" &&
+      error.context.includes("index.zvec"),
+  );
+});
+
+test("probeWorkspaceIndexStorage detects unopenable storage collections", async (t) => {
+  const parent = await mkdtemp(join(tmpdir(), "zvec-grep-probe-unopenable-"));
+  t.after(async () => {
+    await rm(parent, { recursive: true, force: true });
+  });
+
+  // Create unopenable directory placeholders
+  const { mkdir } = await import("node:fs/promises");
+  await mkdir(join(parent, "files.zvec"), { recursive: true });
+  await mkdir(join(parent, "index.zvec"), { recursive: true });
+
+  assert.throws(
+    () => probeWorkspaceIndexStorage(parent),
+    (error) => error.code === "ZVEC_GREP.ENGINE.STORAGE.ZVEC_OPEN_FAILED",
+  );
+});
+
+test("probeWorkspaceIndexStorage succeeds on valid workspace index storage", async (t) => {
+  const parent = await mkdtemp(join(tmpdir(), "zvec-grep-probe-valid-"));
+  t.after(async () => {
+    await rm(parent, { recursive: true, force: true });
+  });
+
+  const storage = createWorkspaceIndexStorage({
+    storagePath: parent,
+    readOnly: false,
+    embedding: {
+      provider: "local",
+      model: "test",
+      dimension: 2,
+      metric: "cosine",
+    },
+  });
+  storage.close();
+
+  assert.doesNotThrow(() => probeWorkspaceIndexStorage(parent));
+});


### PR DESCRIPTION
## Summary
`zg status` treated `files.zvec` / `index.zvec` existence as readiness, so an upgrade that left storage missing or unopenable still looked healthy until the first query. Status now RO-opens both collections and fails loud with rebuild guidance when the probe fails.

Related to #139

## Test plan
- [x] `npm run build`
- [x] `npm run typecheck && npm run lint && npm run format:check`
- [x] `node --test --test-concurrency=1 test/unit/zvec-storage.test.mjs test/unit/cli-format.test.mjs test/integration/service.test.mjs` (55 pass)