### PR TITLE
docs: warn that guides track main CLI, not published 0.2.2

### DIFF
--- a/docs/02-cli.md
+++ b/docs/02-cli.md
@@ -5,6 +5,12 @@
 [Architecture](./05-architecture.md) · [Server](./06-server.md) ·
 [Embedding](./07-embedding.md) · [Roadmap](./08-roadmap.md)
 
+> [!WARNING]
+> This page describes the CLI on **`main`** (`zg <query>`, `zg --index`, …).
+> Published `0.2.2` still expects subcommands (`zg query`, `zg index`, …). See
+> [Documentation](./README.md) for the published-vs-`main` mapping, or use the
+> project README / `zg help` with the binary you installed.
+
 The `zg` command is a search interface first. Positional arguments are always
 queries; maintenance operations use long action options so ordinary words such
 as `index`, `install`, and `status` never collide with commands. Use the

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,23 @@ interfaces.
 > zvec-grep is a work in progress. Commands and configuration may change before
 > the first stable release.
 
+> [!WARNING]
+> These guides track **`main`**, where search is the default interface and
+> maintenance uses long options (`zg --index`, `zg --status`, …). The published
+> npm package (currently `0.2.2`) still uses subcommands (`zg index`,
+> `zg query`, `zg status`, …). For an installed binary, follow the project
+> [README](../README.md), https://zvec.org/en/docs/zvec-grep/, or `zg help` /
+> `zg <command> --help`. Do not copy `zg --index` examples from this tree onto
+> `0.2.2`.
+
+| Published (`0.2.2`) | `main` (these guides) |
+| --- | --- |
+| `zg index …` | `zg --index …` |
+| `zg query …` | `zg …` (positional search) |
+| `zg status …` | `zg --status …` |
+| `zg install …` | `zg --install …` |
+| `zg help` / `zg help query` | `zg --help` / `zg --help search` |
+
 ## Start here
 
 | I want to… | Read |
@@ -41,12 +58,18 @@ For the whole-system mental model and trust boundaries, read
 The [Roadmap](./08-roadmap.md) tracks the path from work in progress to a stable
 release.
 
-The CLI remains the source of truth for flags in the installed version:
+The installed CLI remains the source of truth for the package you have:
 
 ```bash
+# published 0.2.2
+zg help
+zg help query
+zg <command> --help
+
+# main / these guides
 zg --help
 zg --help search
-zg --help index
+zg --index --help
 ```
 
 For development setup and pull request conventions, see


### PR DESCRIPTION
## Summary
`docs/` on `main` describe the search-default / flag-action CLI from #105 (`zg --index`, positional search). The published npm package (`0.2.2`) still uses subcommands (`zg index`, `zg query`), which is what README / zvec.org already show after #131.

Following `docs/02-cli.md` on a current install yields `Unknown command: --index`. This adds an explicit published-vs-`main` warning and mapping in `docs/README.md`, plus a short callout on `docs/02-cli.md`, instead of rewriting the guides back to the old subcommand grammar (that would fight #105 and the in-tree tests).

Fixes #147

## Test plan
- [x] Confirmed published `@zvec/zvec-grep@0.2.2` `dist/cli/args.js` throws `Unknown command: ${first}` (subcommand parser; no `ACTION_FLAGS`)
- [x] Confirmed `main` `src/cli/args.ts` uses `ACTION_FLAGS` / `--index` (and e2e/unit tests invoke `--index`)
- [x] Manual review of the new WARNING + mapping table against README examples and issue repro